### PR TITLE
Remove edit and breadcrumb menu from docs

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -55,5 +55,6 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
   geekdocSearch = true
   geekdocNextPrev = true
   geekdocRepo = "https://github.com/cashapp/hermit"
-  geekdocEditPath = "edit/master/docs/content"
+  geekdocEditPath = ""
+  geekdocBreadcrumb = false
 


### PR DESCRIPTION
Remove edit and breadcrumb menu from docs - as discussed, this is the
preferred appearance.

<img width="888" alt="Screen Shot 2021-05-24 at 10 47 26 am" src="https://user-images.githubusercontent.com/1596871/119282659-db3bdf00-bc7d-11eb-8e0f-74da97d4d105.png">
<img width="888" alt="Screen Shot 2021-05-24 at 10 47 15 am" src="https://user-images.githubusercontent.com/1596871/119282666-e0992980-bc7d-11eb-8089-6b6d62469ba8.png">
