### PR TITLE
Add edit menu back on non-frontpage packages

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -55,6 +55,4 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
   geekdocSearch = true
   geekdocNextPrev = true
   geekdocRepo = "https://github.com/cashapp/hermit"
-  geekdocEditPath = ""
-  geekdocBreadcrumb = false
-
+  geekdocEditPath = "edit/master/docs/content"

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -4,6 +4,8 @@ description = "Hermit manages isolated, self-bootstrapping sets of tools in soft
 geekdocNav = false
 geekdocAlign = "center"
 geekdocAnchor = false
+geekdocBreadcrumb = false
+geekdocEditPath = false
 +++
 
 ### Hermit manages isolated, self-bootstrapping sets of tools in software projects.


### PR DESCRIPTION
We removed the breadcrumb/edit menu in a previous PR from all pages. This
was a misunderstanding, should have only been done for frontpage.