### PR TITLE
css: Add padding between icon and breadcrumbs

### DIFF
--- a/docs/themes/geekdoc/layouts/partials/head/custom.html
+++ b/docs/themes/geekdoc/layouts/partials/head/custom.html
@@ -8,6 +8,10 @@
   font-weight: bold;
 }
 
+.breadcrumb {
+  padding: 0 4px;
+}
+
 pre {
    white-space: pre-wrap;
    line-break:  anywhere;


### PR DESCRIPTION
Minor fix to add some whitespace for what looks visually a bit off.
<img width="230" alt="Screen Shot 2021-05-25 at 11 02 14 am" src="https://user-images.githubusercontent.com/1596871/119424394-b7919b00-bd48-11eb-9200-e37b92246410.png">
<img width="230" alt="Screen Shot 2021-05-25 at 11 02 21 am" src="https://user-images.githubusercontent.com/1596871/119424396-b8c2c800-bd48-11eb-8b4d-68fff0c32086.png">

