### PR TITLE
Synthesise @stable, @<MAJOR> and @<MAJOR>.<MINOR> channels.

### DIFF
--- a/docs/content/packaging/reference.md
+++ b/docs/content/packaging/reference.md
@@ -72,6 +72,14 @@ fine-grained control over which package definitions will be used.
 updates periodically. Hermit will check the URL's ETag and update the package
 if there is a newer version.
 
+Additionally, Hermit will create several synthetic channels which are checked for updates every 24h:
+
+1. A `@latest` channel pointing at the most recent non-pre-release version.
+2. A `@<MAJOR>` channel for every major version.
+3. A `@<MAJOR>.<MINOR>` channel for every major+minor version.
+
+This allows projects to pin to stable releases.
+
 ## Variable Interpolation
 
 Hermit manifests support basic variable interpolation to simplify

--- a/manifest/config_test.go
+++ b/manifest/config_test.go
@@ -136,7 +136,7 @@ func TestManifest(t *testing.T) {
 				version "1.14.4" {}
 			`,
 			pkg:  "go-1.14.5",
-			fail: "memory:///go.hcl: no version go-1.14.5 in known versions 1.14.4: unknown package",
+			fail: "memory:///go.hcl: no version go-1.14.5 in known versions 1.14.4, @1, @1.14, @latest: unknown package",
 		},
 		{name: "InvalidVariable",
 			manifest: `

--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -50,7 +50,7 @@ func (p Packages) Len() int { return len(p) }
 func (p Packages) Less(i, j int) bool {
 	n := strings.Compare(p[i].Reference.Name, p[j].Reference.Name)
 	if n == 0 {
-		return p[i].Reference.Version.Less(p[j].Reference.Version)
+		return p[i].Reference.Less(p[j].Reference)
 	}
 	return n < 0
 }
@@ -358,6 +358,7 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 		for _, ref := range allRefs {
 			knownVersions = append(knownVersions, ref.StringNoName())
 		}
+		sort.Strings(knownVersions)
 		return nil, errors.Wrapf(ErrUnknownPackage, "%s: no version %s in known versions %s", manifest.Path, selector, strings.Join(knownVersions, ", "))
 	}
 

--- a/manifest/resolver_test.go
+++ b/manifest/resolver_test.go
@@ -322,6 +322,30 @@ func TestSearchVersionsAndChannelsCoexist(t *testing.T) {
 	pkgs, err := l.Search(logger.Task("search"), "test")
 	require.NoError(t, err)
 	expected := Packages{
+		manifesttest.NewPkgBuilder(config.State + "/pkg/test@1").
+			WithName("test").
+			WithBinaries("bin").
+			WithChannel("1").
+			WithSource("www.example.com").
+			WithUpdateInterval(time.Hour * 24).
+			WithFS(ffs).
+			Result(),
+		manifesttest.NewPkgBuilder(config.State + "/pkg/test@1.0").
+			WithName("test").
+			WithBinaries("bin").
+			WithChannel("1.0").
+			WithSource("www.example.com").
+			WithUpdateInterval(time.Hour * 24).
+			WithFS(ffs).
+			Result(),
+		manifesttest.NewPkgBuilder(config.State + "/pkg/test@latest").
+			WithName("test").
+			WithBinaries("bin").
+			WithChannel("latest").
+			WithSource("www.example.com").
+			WithUpdateInterval(time.Hour * 24).
+			WithFS(ffs).
+			Result(),
 		manifesttest.NewPkgBuilder(config.State + "/pkg/test@stable").
 			WithName("test").
 			WithBinaries("bin").

--- a/manifest/version.go
+++ b/manifest/version.go
@@ -90,6 +90,14 @@ func (v Version) MarshalJSON() ([]byte, error) {
 	return []byte(`"` + v.String() + `"`), nil
 }
 
+// Clean pre-release and metadata.
+func (v Version) Clean() Version {
+	v.metadata = ""
+	v.prerelease = nil
+	v.orig = v.String()
+	return v
+}
+
 // Major version number components only (includes prerelease + metadata).
 func (v Version) Major() Version {
 	return v.addPrereleaseMetadata(v.version[0])


### PR DESCRIPTION
The current set of packages then looks like this:

    aws-iam-authenticator (@0, @0.4, 0.4.0)
      A tool to use AWS IAM credentials to authenticate to a Kubernetes cluster.
    awscli (@2.2, @2, @stable, @2.0, @2.1, 2.0.40, 2.1.26, 2.2.4)
      The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services.
    bash (@5, @5.1, @stable, 5.1.4)
      Bash is the GNU Project's shell—the Bourne Again SHell. This is an sh-compatible shell that incorporates useful features from the Korn shell (ksh) and the C
      shell (csh).
    bazel (@4, @4.0, @stable, 4.0.0)
      Bazel is an open-source build and test tool similar to Make, Maven, and Gradle.
    dynamosql (@0, @0.0, 0.0.1, 0.0.2)
      DynamoDB SQL CLI
    envoy (@1.11, @1.12, @1, @1.17, @1.16, @1.15, @1.14, @1.13, @stable, 1.11.1, 1.11.2, 1.12.0, 1.12.1, 1.12.2, 1.12.3, 1.12.6, 1.12.7, 1.13.0, 1.13.1, 1.13.2, 1.13.3, 1.13.4, 1.13.5, 1.13.6, 1.13.7, 1.14.1, 1.14.2, 1.14.3, 1.14.4, 1.14.5, 1.14.6, 1.15.0, 1.15.1, 1.15.3, 1.16.0, 1.16.1, 1.16.2, 1.17.0, 1.17.1)
      Envoy is an open source edge and service proxy, designed for cloud-native applications
    flutter (@2.0, @stable, @2, 2.0.1)
      Flutter is Google’s UI toolkit for building beautiful, natively compiled applications for mobile, web, and desktop from a single codebase.
    gcloud (@318, @318.0, @317, @stable, @317.0, 317.0.0, 318.0.0)
      The gcloud command-line interface is the primary CLI tool to create and manage Google Cloud resources.
    ghc (@8, @8.10, @stable, 8.10.4)
      GHC is a state-of-the-art, open source, compiler and interactive environment for the functional language Haskell.
    go (@stable, @1.13, @1, @1.16, @1.15, @1.14, 1.13.5, 1.14.4, 1.14.7, 1.15.2, 1.15.3, 1.15.6, 1.15.7, 1.15.11, 1.16, 1.16.3, 1.16.4)
      Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.
    golangci-lint (@stable, @1.36, @1.32, @1.37, @1.26, @1.24, @1, @1.23, 1.23.7, 1.24.0, 1.26.0, 1.32.2, 1.36.0, 1.37.0)
      golangci-lint is a fast Go linters runner. It runs linters in parallel, uses caching, supports yaml config, has integrations with all major IDE and has dozens of
      linters included.
    goose (@2.6, @2, @stable, 2.6.0)
      Goose is a database migration tool. Manage your database schema by creating incremental SQL changes or Go functions.
    goreleaser (@0.159, @0, 0.159.0)
      go release builder
    graalvm (@20.3, @stable, @20, 20.3.0)
      GraalVM is a high-performance runtime that provides significant improvements in application performance and efficiency which is ideal for microservices.
    gradle (@6.8, @stable, @7, @6, 6.7, 6.8.3, 7.0)
      Gradle helps teams build, automate and deliver better software, faster.
    helm (@3.4, @stable, @3, @3.5, 3.4.0, 3.5.3)
      Helm is a tool for managing Charts. Charts are packages of pre-configured Kubernetes resources.
    hermit (@stable, @canary)
      Hermit manages the installation of separate isolated per-project sets of tools for Linux and Mac.
    hugo (@0, @0.82, 0.82.0)
      Hugo is one of the most popular open-source static site generators. With its amazing speed and flexibility, Hugo makes building websites fun again.
    istioctl (@1.9, @1, @1.7, @stable, @1.8, 1.7.8, 1.8.5, 1.9.3)
      Istio configuration command line utility for service operators to debug and diagnose their Istio mesh.
    jq (@1, @stable, 1.6)
      jq is like sed for JSON data - you can use it to slice and filter and map and transform structured data with the same ease that sed, awk, grep and friends let
      you play with text.
    k3d (@3.2, @4, @stable, @3, @4.4, 3.2.0, 4.4.1)
      k3d creates containerized k3s clusters. This means, that you can spin up a multi-node k3s cluster on a single machine using docker.
    k9s (@0, @0.24, 0.24.0)
      K9s provides a terminal UI to interact with your Kubernetes clusters.
    kotlin (@stable, @1, @1.5, 1.5.0)
      Statically typed programming language for the JVM
    kubectl (@1.21, @1.19, @1, @stable, @1.20, 1.19.0, 1.20.0, 1.21.0)
      The Kubernetes command-line tool, kubectl, allows you to run commands against Kubernetes clusters. You can use kubectl to deploy applications, inspect and manage
      cluster resources, and view logs.
    maven (@stable, @3, @3.6, 3.6.3)
      Maven is a build automation tool used primarily for Java projects.
    mysql (@8.0, @8, @stable, 8.0.21)
      MySQL server and tools.
    mysql-client (@8, @8.0, @stable, 8.0.21)
      MySQL client.
    ninja (@1.10, @stable, @1, 1.10.2)
      Ninja is a small build system with a focus on speed.
    node (@12, @12.18, @14.16, @14, @stable, @16, @16.1, @15, @15.10, 12.18.3, 14.16.0, 15.10.0, 16.1.0)
      Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.
    openjdk (11.0.11_9-zulu11.48.21, @11, @zulu, @11.0, @stable, 11.0.8_10, 11.0.9_11, 11.0.10_9)
      Java is a class-based, object-oriented programming language.
    openjre (@stable, @11, @11.0, 11.0.10_9)
      Java is a class-based, object-oriented programming language.
    pandoc (@stable, @2, 2.13)
      Pandoc is a Haskell library for converting from one markup format to another, and a command-line tool that uses this library.
    protoc (@3.15, @3.14, @stable, @3.7, @3, 3.7.1, 3.14.0, 3.15.0, 3.15.8)
      protoc is a compiler for protocol buffers definitions files.
    protoc-gen-grpc-gateway-ts (@1.0, @stable, @1, @1.1, 1.0.0, 1.1.0)
      protoc-gen-grpc-gateway-ts
    rust (@1.51, @nightly, @1, @stable, 1.51.0)
      A language empowering everyone to build reliable and efficient software.
    shellcheck (@0.7, @0, 0.7.1)
      A static analysis tool for shell scripts
    shfmt (@stable, @3, @3.2, 3.2.4)
      A shell parser, formatter, and interpreter with bash support
    sqlc (1.5.1-kotlin.3, @1.5, @1.6, @1.7, @stable, @1, @1.8, 1.5.0, 1.6.0, 1.7.0, 1.8.0)
      sqlc generates fully type-safe idiomatic Go code from SQL.
    terraform (@0, @0.14, @0.15, 0.14.10, 0.15.0)
      Terraform is an open-source infrastructure as code software tool that provides a consistent CLI workflow to manage hundreds of cloud services.
    terragrunt (@0, @0.28, 0.28.20)
      Terragrunt is a thin wrapper that provides extra tools for keeping your configurations DRY, working with multiple Terraform modules, and managing remote state.
    zig (0.8.0-dev.2275+8467373bb, @0, @0.7, 0.7.1)
      Zig is a general-purpose programming language and toolchain for maintaining robust, optimal, and reusable software.
    zim (@0, @0.3, 0.3.0)
      Zim is a caching build system that is ideal for teams using monorepos containing many components and dependencies.