### PR TITLE
docs: Fix breadcrumb spacing

### DIFF
--- a/docs/themes/geekdoc/layouts/partials/head/custom.html
+++ b/docs/themes/geekdoc/layouts/partials/head/custom.html
@@ -8,7 +8,7 @@
   font-weight: bold;
 }
 
-.breadcrumb {
+.breadcrumb li {
   padding: 0 4px;
 }
 


### PR DESCRIPTION
An initial PR fixed the spacing of the items in the breadcrumbs between
icon and rest. Here we also fix the spacing around the separator `/`.

Before
<img width="230" alt="Screen Shot 2021-05-26 at 1 59 42 pm" src="https://user-images.githubusercontent.com/1596871/119600600-b5077200-be2a-11eb-8f1f-1b288951409c.png">

After (double spaced on dev server 🤷‍♀️)
<img width="230" alt="Screen Shot 2021-05-26 at 1 59 59 pm" src="https://user-images.githubusercontent.com/1596871/119600602-b6d13580-be2a-11eb-8d6d-f2dd757557eb.png">
