### PR TITLE
Simplify run actions.

### DIFF
--- a/manifest/resolver_test.go
+++ b/manifest/resolver_test.go
@@ -84,7 +84,7 @@ func TestResolver_Resolve(t *testing.T) {
 				binaries = ["bin"]
 				on "unpack" {
 					copy { from = "foo/bar" to = "${root}/fizz" }
-  					run { cmd = "test" dir = "${root}"}
+					run { cmd = "test" dir = "${root}" }
 					copy { from = "foo/baz" to = "${root}/biz" }
 					message { text = "hello" }
 				}


### PR DESCRIPTION
Previously any run command with arguments would need to be two separate
attributes in the configuration, eg.

    on run { cmd = "chmod" args = ["-R", "+w", "${root}" ] }

Now `cmd` will be split via shellquote into command + arguments prior to
appending `args`:

    on run { cmd = "chmod -R +w ${root}" }

This is backwards compatible as `args` are appended anyway.