### PR TITLE
Introduce a flag for configuring a short prompt.

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -121,7 +121,6 @@ func Main(config Config) {
 		kong.UsageOnError(),
 		kong.Description(help),
 		kong.BindTo(cli, (*cliCommon)(nil)),
-		kong.Bind(p),
 		kong.Vars{
 			"version": config.Version,
 			"env":     envPath,
@@ -143,7 +142,7 @@ func Main(config Config) {
 	}
 
 	if isActivated {
-		env, err = hermit.OpenEnv(p, envPath, sta, cli.getEnv())
+		env, err = hermit.OpenEnv(p, envPath, sta, cli.getGlobalState().Env)
 		if err != nil {
 			log.Fatalf("failed to open environment: %s", err)
 		}
@@ -166,7 +165,7 @@ func Main(config Config) {
 		err = pprof.WriteHeapProfile(f)
 		fatalIfError(p, err)
 	}
-	err = ctx.Run(env, p, sta, config, cli.getEnv())
+	err = ctx.Run(env, p, sta, config, cli.getGlobalState())
 	if err != nil && p.WillLog(ui.LevelDebug) {
 		p.Fatalf("%+v", err)
 	} else {

--- a/shell/bash.go
+++ b/shell/bash.go
@@ -23,11 +23,11 @@ var _ Shell = &Bash{}
 
 func (sh *Bash) Name() string { return "bash" } // nolint: golint
 
-func (sh *Bash) ActivationScript(w io.Writer, envName, root string) error { // nolint: golint
+func (sh *Bash) ActivationScript(w io.Writer, config ActivationConfig) error { // nolint: golint
 	err := posixActivationScriptTmpl.Execute(w, &posixActivationContext{
-		Root:    root,
-		EnvName: envName,
-		Shell:   "bash",
+		ActivationConfig: config,
+		EnvName:          filepath.Base(config.Root),
+		Shell:            "bash",
 	})
 	return errors.WithStack(err)
 }

--- a/shell/files/activate.tmpl.sh
+++ b/shell/files/activate.tmpl.sh
@@ -48,7 +48,7 @@ export ACTIVE_HERMIT=$HERMIT_ENV
 export HERMIT_DEACTIVATION="$(${HERMIT_ENV}/bin/hermit env --deactivate)"
 export HERMIT_BIN_CHANGE=$(date -r ${HERMIT_ENV}/bin +"%s")
 
-if test -n "${PS1+_}"; then export _HERMIT_OLD_PS1="${PS1}"; export PS1="{{ .EnvName }}🐚 ${PS1}"; fi
+if test -n "${PS1+_}"; then export _HERMIT_OLD_PS1="${PS1}"; export PS1="{{if not .ShortPrompt}}{{ .EnvName }}{{end}}🐚 ${PS1}"; fi
 
 update_hermit_env() {
   local CURRENT=$(date -r ${HERMIT_ENV}/bin +"%s")

--- a/shell/posix.go
+++ b/shell/posix.go
@@ -18,7 +18,7 @@ var (
 
 // Template context for activation script.
 type posixActivationContext struct {
-	Root    string
+	ActivationConfig
 	EnvName string
 	Shell   string
 }

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -16,6 +16,13 @@ import (
 	"github.com/willdonnelly/passwd"
 )
 
+// ActivationConfig for shells.
+type ActivationConfig struct {
+	Root        string
+	ShortPrompt bool
+	Env         envars.Envars
+}
+
 // Shell abstracts shell specific functionality
 type Shell interface {
 	Name() string
@@ -24,7 +31,7 @@ type Shell interface {
 	// ActivationHooksCode returns the shell fragment for activation/deactivation hooks
 	ActivationHooksCode() (script string, err error)
 	// ActivationScript for this shell.
-	ActivationScript(w io.Writer, envName, root string) error
+	ActivationScript(w io.Writer, config ActivationConfig) error
 	// ApplyEnvars writes the shell fragment required to apply the given envars.
 	//
 	// Envars with empty values should be deleted.
@@ -134,12 +141,11 @@ func (c Changes) Merge(o *Changes) *Changes {
 }
 
 // ActivateHermit prints out the hermit activation script for the given shell.
-func ActivateHermit(w io.Writer, shell Shell, envRoot string, env envars.Envars) error {
-	envName := filepath.Base(envRoot)
-	if err := shell.ApplyEnvars(w, env); err != nil {
+func ActivateHermit(w io.Writer, shell Shell, config ActivationConfig) error {
+	if err := shell.ApplyEnvars(w, config.Env); err != nil {
 		return errors.WithStack(err)
 	}
-	if err := shell.ActivationScript(w, envName, envRoot); err != nil {
+	if err := shell.ActivationScript(w, config); err != nil {
 		return errors.WithStack(err)
 	}
 	return nil

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -19,11 +19,11 @@ var _ Shell = &Zsh{}
 
 func (sh *Zsh) Name() string { return "zsh" } // nolint: golint
 
-func (sh *Zsh) ActivationScript(w io.Writer, envName, root string) error { // nolint: golint
+func (sh *Zsh) ActivationScript(w io.Writer, config ActivationConfig) error { // nolint: golint
 	err := posixActivationScriptTmpl.Execute(w, &posixActivationContext{
-		Root:    root,
-		EnvName: envName,
-		Shell:   "zsh",
+		EnvName:          filepath.Base(config.Root),
+		ActivationConfig: config,
+		Shell:            "zsh",
 	})
 	return errors.WithStack(err)
 }


### PR DESCRIPTION
eg.

    🐚 ~/Development/hermit-packages-opensource $

rather than

    hermit-packages-opensource🐚 ~/Development/hermit-packages-opensource $