### PR TITLE
Support multiple versions in a single block.

### DIFF
--- a/docs/content/packaging/schema/run.md
+++ b/docs/content/packaging/schema/run.md
@@ -12,8 +12,8 @@ Used by: [on](../on#blocks)
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
-| `args` | `[string]?` | The arguments to the binary |
-| `cmd` | `string` | The command to execute |
-| `dir` | `string?` | The directory where the command is run in. Defaults to the root directory. |
-| `env` | `[string]?` | The environment variables for the execution |
-| `stdin` | `string?` | Optional string to be used as the stdin for the command |
+| `args` | `[string]?` | The arguments to the binary. |
+| `cmd` | `string` | The command to execute, split by shellquote. |
+| `dir` | `string?` | The directory where the command is run. Defaults to the ${root} directory. |
+| `env` | `[string]?` | The environment variables for the execution. |
+| `stdin` | `string?` | Optional string to be used as the stdin for the command. |

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	aqwari.net/xml v0.0.0-20200724195937-ae380bb65a55
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/alecthomas/colour v0.1.0
-	github.com/alecthomas/hcl v0.1.13-0.20210317193125-0f220f5a1a5f
+	github.com/alecthomas/hcl v0.1.13
 	github.com/alecthomas/kong v0.2.16
 	github.com/alecthomas/kong-hcl v1.0.1
 	github.com/alecthomas/participle v0.6.1-0.20200911005820-318127ca69ac
@@ -22,7 +22,7 @@ require (
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/posener/complete v1.2.3 // indirect
+	github.com/posener/complete v1.2.3
 	github.com/qdm12/reprint v0.0.0-20200326205758-722754a53494
 	github.com/saracen/go7z v0.0.0-20191010121135-9c09b6bd7fda
 	github.com/saracen/go7z-fixtures v0.0.0-20190623165746-aa6b8fba1d2f // indirect
@@ -30,7 +30,7 @@ require (
 	github.com/sassoftware/go-rpmutils v0.1.2-0.20210127001923-e5cf0f808585
 	github.com/stretchr/testify v1.7.0
 	github.com/ulikunitz/xz v0.5.10 // indirect
-	github.com/willabides/kongplete v0.2.0 // indirect
+	github.com/willabides/kongplete v0.2.0
 	github.com/willdonnelly/passwd v0.0.0-20141013001024-7935dab3074c
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
 	go.etcd.io/bbolt v1.3.5

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/alecthomas/colour v0.1.0 h1:nOE9rJm6dsZ66RGWYSFrXw461ZIt9A6+nHgL7FRrDUk=
 github.com/alecthomas/colour v0.1.0/go.mod h1:QO9JBoKquHd+jz9nshCh40fOfO+JzsoXy8qTHF68zU0=
-github.com/alecthomas/hcl v0.1.13-0.20210317193125-0f220f5a1a5f h1:vMJwwIIeasi/mcpwrENXQJUfR0y1yGCmQr8ZbtkXFug=
-github.com/alecthomas/hcl v0.1.13-0.20210317193125-0f220f5a1a5f/go.mod h1:VEYcgruQ39ELu6c0Bb+VRm3trQPt7dQUdAwF7QrG7AQ=
+github.com/alecthomas/hcl v0.1.13 h1:gU7Ki8hftG1MsTAF9JkqzUfabakHFMnVjPgY6bLjQ+o=
+github.com/alecthomas/hcl v0.1.13/go.mod h1:VEYcgruQ39ELu6c0Bb+VRm3trQPt7dQUdAwF7QrG7AQ=
 github.com/alecthomas/kong v0.2.2/go.mod h1:kQOmtJgV+Lb4aj+I2LEn40cbtawdWJ9Y8QLq+lElKxE=
 github.com/alecthomas/kong v0.2.16 h1:F232CiYSn54Tnl1sJGTeHmx4vJDNLVP2b9yCVMOQwHQ=
 github.com/alecthomas/kong v0.2.16/go.mod h1:kQOmtJgV+Lb4aj+I2LEn40cbtawdWJ9Y8QLq+lElKxE=

--- a/manifest/config.go
+++ b/manifest/config.go
@@ -85,7 +85,7 @@ func (c *Layer) match(arch string) bool {
 
 // VersionBlock is a Layer block specifying an installable version of a package.
 type VersionBlock struct {
-	Version string `hcl:"version,label" help:"Version of package."`
+	Version []string `hcl:"version,label" help:"Version(s) of package."`
 	Layer
 }
 
@@ -105,7 +105,7 @@ func (c *ChannelBlock) layersWithReferences(os string, arch string, m *Manifest)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
-		result := m.HighestMatch(g)
+		result, _ := m.HighestMatch(g)
 		if result != nil {
 			return append(result.layers(os, arch), layer...), nil
 		}
@@ -131,10 +131,13 @@ func (m *Manifest) layers(ref Reference, os string, arch string) (layers, error)
 
 	for _, v := range m.Versions {
 		l := v.layers(os, arch)
-		versionLayers[v.Version] = l
-		if v.Version == ref.Version.String() {
-			return append(m.Layer.layers(os, arch), l...), nil
+		for _, version := range v.Version {
+			versionLayers[version] = l
+			if version == ref.Version.String() {
+				return append(m.Layer.layers(os, arch), l...), nil
+			}
 		}
+
 	}
 	for _, ch := range m.Channels {
 		if ch.Name == ref.Channel {


### PR DESCRIPTION
This will allow the following:

    version "1.13.5" {
      darwin {
        arch = "arm64"
        source = "https://golang.org/dl/go${version}.${os}-amd64.tar.gz"
      }
    }
    version "1.14.4" {
      darwin {
        arch = "arm64"
        source = "https://golang.org/dl/go${version}.${os}-amd64.tar.gz"
      }
    }
    ...

To be expressed as:

    version "1.13.5" "1.14.4" {
      darwin {
        arch = "arm64"
        source = "https://golang.org/dl/go${version}.${os}-amd64.tar.gz"
      }
    }