### PR TITLE
Give a working step for shell-hooks

### DIFF
--- a/cmd/geninstaller/install.sh.tmpl
+++ b/cmd/geninstaller/install.sh.tmpl
@@ -86,6 +86,11 @@ To create a new Hermit environment run:
 
   $HERMIT_BIN_INSTALL_DIR/hermit init <dir>
 
+To setup shell hooks to automatically activate your environment when you enter
+it, run:
+
+  $HERMIT_BIN_INSTALL_DIR/hermit shell-hooks --<zsh | bash>
+
 To activate the environment run:
 
   . <dir>/bin/activate-hermit
@@ -97,10 +102,5 @@ Then run the following to list available commands:
 To deactivate the environment run:
 
   deactivate-hermit
-
-To setup shell hooks to automatically activate your environment when you enter
-it, run:
-
-  hermit shell-hooks --<zsh | bash>
 
 EOF


### PR DESCRIPTION
On first-use, `~/bin` is not in the user's path and the instructions for `shell-hooks` don't work out of the box.

Prefix the `shell-hooks` line to include `$HERMIT_BIN_INSTALL_DIR`.

Also, move the `shell-hooks` step up because narratively it makes more sense.