### PR TITLE
Two bug fixes.

### DIFF
--- a/app/commands.go
+++ b/app/commands.go
@@ -460,7 +460,8 @@ func updateHermit(l *ui.UI, env *hermit.Env, pkgRef string) error {
 		// set the update time to 0 to force an update check
 		pkg.UpdatedAt = time.Time{}
 	}
-	return env.EnsureChannelIsUpToDate(l, pkg)
+	_, err = env.EnsureChannelIsUpToDate(l, pkg)
+	return errors.WithStack(err)
 }
 
 type envCmd struct {
@@ -763,7 +764,7 @@ func (g *upgradeCmd) Run(l *ui.UI, env *hermit.Env) error {
 
 	// upgrade packages
 	for _, pkg := range packages {
-		c, err := env.Upgrade(l, pkg)
+		c, _, err := env.Upgrade(l, pkg)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/env_test.go
+++ b/env_test.go
@@ -110,7 +110,7 @@ func TestEnsureUpToDate(t *testing.T) {
 	require.Equal(t, 0, headCalls)
 
 	// Update before update check is due
-	err = fixture.Env.EnsureChannelIsUpToDate(fixture.P, pkg)
+	_, err = fixture.Env.EnsureChannelIsUpToDate(fixture.P, pkg)
 	require.NoError(t, err)
 	require.Equal(t, 1, getCalls)
 	require.Equal(t, 0, headCalls)
@@ -119,7 +119,7 @@ func TestEnsureUpToDate(t *testing.T) {
 
 	// Update after a check is needed but etag has not changed
 	pkg.UpdatedAt = time.Now().Add(-2 * time.Hour)
-	err = fixture.Env.EnsureChannelIsUpToDate(fixture.P, pkg)
+	_, err = fixture.Env.EnsureChannelIsUpToDate(fixture.P, pkg)
 	require.NoError(t, err)
 	require.Equal(t, 1, getCalls)
 	require.Equal(t, 1, headCalls)
@@ -130,7 +130,7 @@ func TestEnsureUpToDate(t *testing.T) {
 	pkg.UpdatedAt = time.Now().Add(-2 * time.Hour)
 	etag = "changed"
 	data = strings.Repeat("other", 1024)
-	err = fixture.Env.EnsureChannelIsUpToDate(fixture.P, pkg)
+	_, err = fixture.Env.EnsureChannelIsUpToDate(fixture.P, pkg)
 	require.NoError(t, err)
 	require.Equal(t, 2, getCalls)
 	require.Equal(t, 2, headCalls)


### PR DESCRIPTION
1. When execing a package the package itself was included in the
   dependencies, would download and install, then re-download itself.
2. Second bug was that the last check time for channels in the DB was
   being overwritten with a zero time resulting in a re-check on every
   execution.