### PR TITLE
Fix a panic on invalid source

### DIFF
--- a/shell/shell.go
+++ b/shell/shell.go
@@ -97,6 +97,9 @@ func Detect() (Shell, error) {
 			return shell, nil
 		}
 		pid = process.PPid()
+		if pid == 0 {
+			break
+		}
 	}
 
 	// Next, try to pull the shell from the user's password entry.

--- a/sources/sources.go
+++ b/sources/sources.go
@@ -70,13 +70,15 @@ func (s *Sources) Sync(p *ui.UI, force bool) error {
 
 // ForURIs returns Source instances for given uri strings
 func ForURIs(b *ui.UI, dir, env string, uris []string) (*Sources, error) {
-	sources := make([]Source, len(uris))
-	for i, uri := range uris {
+	sources := make([]Source, 0, len(uris))
+	for _, uri := range uris {
 		s, err := getSource(b, uri, dir, env)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
-		sources[i] = s
+		if s != nil {
+			sources = append(sources, s)
+		}
 	}
 	return &Sources{
 		dir:     dir,


### PR DESCRIPTION
Also fixes an issue where running the `main` via IntelliJ ends up in an infinite loop in shell detection.