### PR TITLE
Revert previous logic that returned a cloned copy of mutated packages.

### DIFF
--- a/app/commands.go
+++ b/app/commands.go
@@ -499,8 +499,7 @@ func updateHermit(l *ui.UI, env *hermit.Env, pkgRef string, force bool) error {
 		// set the update time to 0 to force an update check
 		pkg.UpdatedAt = time.Time{}
 	}
-	_, err = env.EnsureChannelIsUpToDate(l, pkg)
-	return errors.WithStack(err)
+	return errors.WithStack(env.EnsureChannelIsUpToDate(l, pkg))
 }
 
 type envCmd struct {
@@ -803,7 +802,7 @@ func (g *upgradeCmd) Run(l *ui.UI, env *hermit.Env) error {
 
 	// upgrade packages
 	for _, pkg := range packages {
-		c, _, err := env.Upgrade(l, pkg)
+		c, err := env.Upgrade(l, pkg)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/env_test.go
+++ b/env_test.go
@@ -110,7 +110,7 @@ func TestEnsureUpToDate(t *testing.T) {
 	require.Equal(t, 0, headCalls)
 
 	// Update before update check is due
-	_, err = fixture.Env.EnsureChannelIsUpToDate(fixture.P, pkg)
+	err = fixture.Env.EnsureChannelIsUpToDate(fixture.P, pkg)
 	require.NoError(t, err)
 	require.Equal(t, 1, getCalls)
 	require.Equal(t, 0, headCalls)
@@ -119,7 +119,7 @@ func TestEnsureUpToDate(t *testing.T) {
 
 	// Update after a check is needed but etag has not changed
 	pkg.UpdatedAt = time.Now().Add(-2 * time.Hour)
-	_, err = fixture.Env.EnsureChannelIsUpToDate(fixture.P, pkg)
+	err = fixture.Env.EnsureChannelIsUpToDate(fixture.P, pkg)
 	require.NoError(t, err)
 	require.Equal(t, 1, getCalls)
 	require.Equal(t, 1, headCalls)
@@ -130,7 +130,7 @@ func TestEnsureUpToDate(t *testing.T) {
 	pkg.UpdatedAt = time.Now().Add(-2 * time.Hour)
 	etag = "changed"
 	data = strings.Repeat("other", 1024)
-	_, err = fixture.Env.EnsureChannelIsUpToDate(fixture.P, pkg)
+	err = fixture.Env.EnsureChannelIsUpToDate(fixture.P, pkg)
 	require.NoError(t, err)
 	require.Equal(t, 2, getCalls)
 	require.Equal(t, 2, headCalls)


### PR DESCRIPTION
This wasn't following the current convention of mutating the package in
place. Better to stick to convention than half change.