### PR TITLE
Add command for auto-versioning from GitHub releases.

### DIFF
--- a/app/commands.go
+++ b/app/commands.go
@@ -57,7 +57,8 @@ type unactivated struct {
 
 	Init       initCmd       `cmd:"" help:"Initialise an environment (idempotent)." group:"env"`
 	Version    versionCmd    `cmd:"" help:"Show version." group:"global"`
-	Validate   validateCmd   `cmd:"" help:"Check a package manifest source for errors." group:"global"`
+	Validate   validateCmd   `hidden:"" cmd:"" help:"Check a package manifest source for errors." group:"global"`
+	Manifest   manifestCmd   `cmd:"" help:"Commands for manipulating manifests."`
 	Info       infoCmd       `cmd:"" help:"Show information on packages." group:"global"`
 	ShellHooks shellHooksCmd `cmd:"" help:"Manage Hermit auto-activation hooks of a shell." group:"global" aliases:"install-hooks"`
 
@@ -926,4 +927,27 @@ type dumpDBCmd struct{}
 
 func (dumpDBCmd) Run(state *state.State) error {
 	return state.DumpDB(os.Stdout)
+}
+
+type autoVersionCmd struct {
+	Manifest []string `arg:"" type:"existingfile" required:"" help:"Manifests to upgrade."`
+}
+
+func (s *autoVersionCmd) Run(l *ui.UI) error {
+	for _, path := range s.Manifest {
+		l.Debugf("Auto-versioning %s", path)
+		version, err := manifest.AutoVersion(path)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if version != "" {
+			l.Infof("Auto-versioned %s to %s", path, version)
+		}
+	}
+	return nil
+}
+
+type manifestCmd struct {
+	Validate    validateCmd    `cmd:"" help:"Check a package manifest source for errors." group:"global"`
+	AutoVersion autoVersionCmd `cmd:"" help:"Upgrade manifest versions automatically where possible." group:"global"`
 }

--- a/docs/content/packaging/schema/auto-version.md
+++ b/docs/content/packaging/schema/auto-version.md
@@ -1,0 +1,15 @@
++++
+title = "version > auto-version"
+weight = 412
++++
+
+Automatically update versions.
+
+Used by: [version](../version#blocks)
+
+
+## Attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `github-release` | `string` | GitHub <user>/<repo> to retrieve and update versions from the releases API. |

--- a/docs/content/packaging/schema/version.md
+++ b/docs/content/packaging/schema/version.md
@@ -12,6 +12,7 @@ Used by: [&lt;manifest>](../manifest#blocks)
 
 | Block  | Description |
 |--------|-------------|
+| [`auto-version { … }`](../auto-version) | Automatically update versions. |
 | [`darwin { … }`](../darwin) | Darwin-specific configuration. |
 | [`linux { … }`](../linux) | Linux-specific configuration. |
 | [`on <event> { … }`](../on) | Triggers to run on lifecycle events. |

--- a/manifest/autoversion.go
+++ b/manifest/autoversion.go
@@ -1,0 +1,110 @@
+package manifest
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/alecthomas/hcl"
+	"github.com/pkg/errors"
+)
+
+const githubAutoVersionerKey = "github-release"
+
+// AutoVersion rewrites the given manifest with new version information if applicable.
+//
+// Auto-versioning configuration is defined in a "version > auto-version" block. If a new
+// version is found in the defined location then the version block's versions are updated.
+func AutoVersion(path string) (version string, err error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	version, content, err = autoVersion(content, realVersioner{})
+	if err != nil {
+		return "", errors.Wrap(err, path)
+	}
+	if content == nil || version == "" {
+		return "", nil
+	}
+	w, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*")
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	defer w.Close() // nolint
+	defer os.Remove(w.Name())
+	_, err = w.Write(content)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	return version, errors.WithStack(os.Rename(w.Name(), path))
+}
+
+type versioner interface {
+	latestGitHubRelease(repo string) (string, error)
+}
+
+func autoVersion(manifest []byte, versioner versioner) (string, []byte, error) {
+	ast, err := hcl.ParseBytes(manifest)
+	if err != nil {
+		return "", nil, errors.WithStack(err)
+	}
+	var (
+		githubProject      string
+		autoVersionedBlock *hcl.Block
+	)
+	// Find auto-version info if any.
+	err = hcl.Visit(ast, func(node hcl.Node, next func() error) error {
+		if node, ok := node.(*hcl.Attribute); ok && node.Key == githubAutoVersionerKey {
+			githubProject = *node.Value.Str
+			// auto-version -> version
+			autoVersionedBlock = node.Parent.(*hcl.Entry).Parent.(*hcl.Block).Parent.(*hcl.Entry).Parent.(*hcl.Block)
+		}
+		return next()
+	})
+	if err != nil {
+		return "", nil, errors.WithStack(err)
+	}
+	if autoVersionedBlock == nil {
+		return "", nil, nil
+	}
+	latestVersion, err := versioner.latestGitHubRelease(githubProject)
+	if err != nil {
+		return "", nil, errors.WithStack(err)
+	}
+	if !strings.HasPrefix(latestVersion, "v") {
+		return "", nil, errors.Errorf("%s: latest release must be in the form v... but is %s", githubProject, latestVersion)
+	}
+	latestVersion = strings.TrimPrefix(latestVersion, "v")
+	// Check if version already exists.
+	for _, label := range autoVersionedBlock.Labels {
+		if label == latestVersion {
+			return "", nil, nil
+		}
+	}
+	autoVersionedBlock.Labels = append(autoVersionedBlock.Labels, latestVersion)
+	content, err := hcl.MarshalAST(ast)
+	return latestVersion, content, errors.WithStack(err)
+}
+
+type gitHubLatestReleaseResponse struct {
+	TagName string `json:"tag_name"`
+}
+
+type realVersioner struct{}
+
+func (realVersioner) latestGitHubRelease(repo string) (string, error) {
+	resp, err := http.Get("https://api.github.com/repos/" + repo + "/releases/latest") // nolint
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	defer resp.Body.Close()
+	ghResp := gitHubLatestReleaseResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&ghResp)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	return ghResp.TagName, nil
+}

--- a/manifest/autoversion_test.go
+++ b/manifest/autoversion_test.go
@@ -1,0 +1,64 @@
+package manifest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testVersioner struct{}
+
+func (testVersioner) latestGitHubRelease(repo string) (string, error) { return "v3.2.150", nil }
+
+func TestGitHubAutoVersion(t *testing.T) {
+	source := `
+description = "Jenkins X CLI"
+test = "jx version"
+binaries = ["jx"]
+
+linux {
+  source = "https://github.com/jenkins-x/jx/releases/download/v${version}/jx-linux-amd64.tar.gz"
+}
+darwin {
+  source = "https://github.com/jenkins-x/jx/releases/download/v${version}/jx-darwin-amd64.tar.gz"
+}
+
+version "3.2.137" "3.2.140" {
+  auto-version {
+    github-release = "jenkins-x/jx"
+  }
+}
+
+channel "stable" {
+  update = "24h"
+  version = "3.*"
+}
+`
+	latestVersion, actual, err := autoVersion([]byte(source), testVersioner{})
+	require.NoError(t, err)
+	require.Equal(t, "3.2.150", latestVersion)
+	expected := `description = "Jenkins X CLI"
+test = "jx version"
+binaries = ["jx"]
+
+linux {
+  source = "https://github.com/jenkins-x/jx/releases/download/v${version}/jx-linux-amd64.tar.gz"
+}
+
+darwin {
+  source = "https://github.com/jenkins-x/jx/releases/download/v${version}/jx-darwin-amd64.tar.gz"
+}
+
+version "3.2.137" "3.2.140" "3.2.150" {
+  auto-version {
+    github-release = "jenkins-x/jx"
+  }
+}
+
+channel "stable" {
+  update = "24h"
+  version = "3.*"
+}
+`
+	require.Equal(t, expected, string(actual))
+}

--- a/manifest/config.go
+++ b/manifest/config.go
@@ -85,7 +85,10 @@ func (c *Layer) match(arch string) bool {
 
 // VersionBlock is a Layer block specifying an installable version of a package.
 type VersionBlock struct {
-	Version []string `hcl:"version,label" help:"Version(s) of package."`
+	Version     []string `hcl:"version,label" help:"Version(s) of package."`
+	AutoVersion struct {
+		GitHubRelease string `hcl:"github-release" help:"GitHub <user>/<repo> to retrieve and update versions from the releases API."`
+	} `hcl:"auto-version,block" help:"Automatically update versions."`
 	Layer
 }
 


### PR DESCRIPTION
This requires explicit opt-in via a new configuration block
"auto-version".