### PR TITLE
Allow auto-version to extract version numbers via a regex.

### DIFF
--- a/docs/content/packaging/schema/auto-version.md
+++ b/docs/content/packaging/schema/auto-version.md
@@ -13,3 +13,4 @@ Used by: [version](../version#blocks)
 | Attribute | Type | Description |
 |-----------|------|-------------|
 | `github-release` | `string` | GitHub &lt;user&gt;/&lt;repo&gt; to retrieve and update versions from the releases API. |
+| `version-pattern` | `string?` | Regex with one capture group to extract the version number from the origin. |

--- a/manifest/config.go
+++ b/manifest/config.go
@@ -83,12 +83,16 @@ func (c *Layer) match(arch string) bool {
 	return c.Arch == "" || c.Arch == arch
 }
 
+// AutoVersionBlock represents auto-version configuration.
+type AutoVersionBlock struct {
+	GitHubRelease  string `hcl:"github-release" help:"GitHub <user>/<repo> to retrieve and update versions from the releases API."`
+	VersionPattern string `hcl:"version-pattern" help:"Regex with one capture group to extract the version number from the origin." default:"v?(.*)"`
+}
+
 // VersionBlock is a Layer block specifying an installable version of a package.
 type VersionBlock struct {
-	Version     []string `hcl:"version,label" help:"Version(s) of package."`
-	AutoVersion struct {
-		GitHubRelease string `hcl:"github-release" help:"GitHub <user>/<repo> to retrieve and update versions from the releases API."`
-	} `hcl:"auto-version,block" help:"Automatically update versions."`
+	Version     []string          `hcl:"version,label" help:"Version(s) of package."`
+	AutoVersion *AutoVersionBlock `hcl:"auto-version,block" help:"Automatically update versions."`
 	Layer
 }
 


### PR DESCRIPTION
This will allow for more flexibility when matching upstream versions.