### PR TITLE
fix link to submit PR to hermit-packages

### DIFF
--- a/docs/content/packaging/tutorial.md
+++ b/docs/content/packaging/tutorial.md
@@ -189,4 +189,4 @@ jq-1.6
 ## Distribute the Package
 
 At this point you can (and should!) contribute the package back to the
-community via a [PR](https://github.com/cashapp/hermit/pulls).
+community via a [PR](https://github.com/cashapp/hermit-packages/pulls).


### PR DESCRIPTION
I think that's where they are intended to go now ([example](https://github.com/cashapp/hermit-packages/pull/17))