### PR TITLE
Generalise platform matching.

### DIFF
--- a/cmd/gendocs/main.go
+++ b/cmd/gendocs/main.go
@@ -106,7 +106,7 @@ weight = %d
 
 %s
 
-`, title, weight, strings.Join(block.Comments, "\n"))
+`, title, weight, html.EscapeString(strings.Join(block.Comments, "\n")))
 	if len(backrefs) > 0 && (len(backrefs) > 1 || backrefs[0] != block.Name) {
 		seen := map[string]bool{block.Name: true}
 		fmt.Fprintf(w, "Used by:")

--- a/docs/content/packaging/schema/auto-version.md
+++ b/docs/content/packaging/schema/auto-version.md
@@ -1,6 +1,6 @@
 +++
 title = "version > auto-version"
-weight = 412
+weight = 413
 +++
 
 Automatically update versions.

--- a/docs/content/packaging/schema/channel.md
+++ b/docs/content/packaging/schema/channel.md
@@ -15,6 +15,7 @@ Used by: [&lt;manifest>](../manifest#blocks)
 | [`darwin { … }`](../darwin) | Darwin-specific configuration. |
 | [`linux { … }`](../linux) | Linux-specific configuration. |
 | [`on <event> { … }`](../on) | Triggers to run on lifecycle events. |
+| [`platform <attr> { … }`](../platform) | Platform-specific configuration. &lt;attr&gt; is a set of platform attributes (CPU, OS, etc.) to match. |
 
 ## Attributes
 

--- a/docs/content/packaging/schema/darwin.md
+++ b/docs/content/packaging/schema/darwin.md
@@ -5,7 +5,7 @@ weight = 402
 
 Darwin-specific configuration.
 
-Used by: [channel](../channel#blocks) [linux](../linux#blocks) [&lt;manifest>](../manifest#blocks) [version](../version#blocks)
+Used by: [channel](../channel#blocks) [linux](../linux#blocks) [&lt;manifest>](../manifest#blocks) [platform](../platform#blocks) [version](../version#blocks)
 
 
 ## Blocks
@@ -15,6 +15,7 @@ Used by: [channel](../channel#blocks) [linux](../linux#blocks) [&lt;manifest>](.
 | [`darwin { … }`](../darwin) | Darwin-specific configuration. |
 | [`linux { … }`](../linux) | Linux-specific configuration. |
 | [`on <event> { … }`](../on) | Triggers to run on lifecycle events. |
+| [`platform { … }`](../platform) | Platform-specific configuration. &lt;attr&gt; is a set of platform attributes (CPU, OS, etc.) to match. |
 
 ## Attributes
 

--- a/docs/content/packaging/schema/manifest.md
+++ b/docs/content/packaging/schema/manifest.md
@@ -14,6 +14,7 @@ Each Hermit package manifest is a nested structure containing OS/architecture-sp
 | [`darwin { … }`](../darwin) | Darwin-specific configuration. |
 | [`linux { … }`](../linux) | Linux-specific configuration. |
 | [`on <event> { … }`](../on) | Triggers to run on lifecycle events. |
+| [`platform <attr> { … }`](../platform) | Platform-specific configuration. &lt;attr&gt; is a set of platform attributes (CPU, OS, etc.) to match. |
 | [`version <version> { … }`](../version) | Definition of and configuration for a specific version. |
 
 ## Attributes

--- a/docs/content/packaging/schema/on.md
+++ b/docs/content/packaging/schema/on.md
@@ -5,7 +5,7 @@ weight = 406
 
 Triggers to run on lifecycle events.
 
-Used by: [channel](../channel#blocks) [darwin](../darwin#blocks) [linux](../linux#blocks) [&lt;manifest>](../manifest#blocks) [version](../version#blocks)
+Used by: [channel](../channel#blocks) [darwin](../darwin#blocks) [linux](../linux#blocks) [&lt;manifest>](../manifest#blocks) [platform](../platform#blocks) [version](../version#blocks)
 
 
 ## Blocks

--- a/docs/content/packaging/schema/platform.md
+++ b/docs/content/packaging/schema/platform.md
@@ -1,11 +1,11 @@
 +++
-title = "linux"
-weight = 403
+title = "platform <attr>"
+weight = 412
 +++
 
-Linux-specific configuration.
+Platform-specific configuration. &lt;attr&gt; is a set of platform attributes (CPU, OS, etc.) to match.
 
-Used by: [channel](../channel#blocks) [darwin](../darwin#blocks) [&lt;manifest>](../manifest#blocks) [platform](../platform#blocks) [version](../version#blocks)
+Used by: [channel](../channel#blocks) [darwin](../darwin#blocks) [linux](../linux#blocks) [&lt;manifest>](../manifest#blocks) [version](../version#blocks)
 
 
 ## Blocks

--- a/docs/content/packaging/schema/version.md
+++ b/docs/content/packaging/schema/version.md
@@ -16,6 +16,7 @@ Used by: [&lt;manifest>](../manifest#blocks)
 | [`darwin { … }`](../darwin) | Darwin-specific configuration. |
 | [`linux { … }`](../linux) | Linux-specific configuration. |
 | [`on <event> { … }`](../on) | Triggers to run on lifecycle events. |
+| [`platform <attr> { … }`](../platform) | Platform-specific configuration. &lt;attr&gt; is a set of platform attributes (CPU, OS, etc.) to match. |
 
 ## Attributes
 

--- a/manifest/config_test.go
+++ b/manifest/config_test.go
@@ -121,6 +121,33 @@ func TestManifest(t *testing.T) {
 				Source:    "https://arm-linux-golang.org/dl/go1.14.4.linux-arm.tar.gz",
 			},
 		},
+		{name: "PlatformOverlay",
+			manifest: `
+				description = "Go"
+				binaries = ["bin/go"]
+				source = "https://golang.org/dl/go${version}.${os}-${arch}.tar.gz"
+
+				platform linux amd64 {
+					source = "https://amd64-linux-golang.org/dl/go${version}.${os}-${arch}.tar.gz"
+				}
+
+				platform linux arm {
+					arch = "arm"
+					source = "https://arm-linux-golang.org/dl/go${version}.${os}-${arch}.tar.gz"
+				}
+
+				version "1.14.4" {}
+			`,
+			os:   "linux",
+			arch: "arm",
+			pkg:  "go-1.14.4",
+			expected: &Package{
+				Arch:      "arm",
+				Reference: ParseReference("go-1.14.4"),
+				Binaries:  []string{"bin/go"},
+				Source:    "https://arm-linux-golang.org/dl/go1.14.4.linux-arm.tar.gz",
+			},
+		},
 		{name: "VersionOverlay",
 			manifest: `
 				description = "Go"


### PR DESCRIPTION
Currently there are only "linux" and "darwin" blocks and to match a CPU
architecture the "arch" attribute must be specified. This is not
obvious.

This adds a "platform" block that accepts a set of platform attributes
to match against, such as CPU, OS, perhaps libc version in the future,
and so on.

eg.

    platform linux amd64 { ... }
    platform darwin { ... }