### PR TITLE
docs: Add slack channel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img align="right" width="100" height="100" src="./docs/static/images/logo.svg" alt="Hermit">
 </a>
 
-# Hermit - uniform tooling for Linux and Mac [![CI](https://github.com/cashapp/hermit/actions/workflows/ci.yml/badge.svg)](https://github.com/cashapp/hermit/actions/workflows/ci.yml)
+# Hermit - uniform tooling for Linux and Mac [![CI](https://github.com/cashapp/hermit/actions/workflows/ci.yml/badge.svg)](https://github.com/cashapp/hermit/actions/workflows/ci.yml) [![Slack chat](https://img.shields.io/badge/slack-gophers-795679?logo=slack)](https://gophers.slack.com/messages/cashapp)
 
 Hermit installs tools for software projects in self-contained, isolated sets, so your team, your contributors, and your CI have the same consistent tooling.
 

--- a/docs/content/about/_index.md
+++ b/docs/content/about/_index.md
@@ -11,3 +11,7 @@ contributions by many others whose feedback is very much appreciated.
 The source code for Hermit is [here](https://github.com/cashapp/hermit). The
 default open source set of package manifests is
 [here](https://github.com/cashapp/hermit-packages).
+
+For discussions find us on the
+[#cashapp](https://app.slack.com/client/T029RQSE6/C028GSD4Y81) channel
+on Gophers Slack.


### PR DESCRIPTION
Add Slack channel link to #cashapp at Gophers Slack to README and docs.