### PR TITLE
Do not export PROMPT_COMMAND on bash

### DIFF
--- a/shell/bash.go
+++ b/shell/bash.go
@@ -10,9 +10,9 @@ import (
 
 const bashShellHooks = commonHooks + `
 if test -n "${PROMPT_COMMAND+_}"; then 
-  export PROMPT_COMMAND="change_hermit_env; $PROMPT_COMMAND"
+  PROMPT_COMMAND="change_hermit_env; $PROMPT_COMMAND"
 else
-  export PROMPT_COMMAND="change_hermit_env"
+  PROMPT_COMMAND="change_hermit_env"
 fi
 
 complete -o nospace -C "$HOME/bin/hermit" hermit


### PR DESCRIPTION
No point of exporting `PROMPT_COMMAND` as the function `change_hermit_env` won't be in the subshells anyway.