### PR TITLE
Use a custom HCL schema for ~/.hermit.hcl.

### DIFF
--- a/app/commands.go
+++ b/app/commands.go
@@ -62,12 +62,13 @@ type unactivated struct {
 	Info       infoCmd       `cmd:"" help:"Show information on packages." group:"global"`
 	ShellHooks shellHooksCmd `cmd:"" help:"Manage Hermit auto-activation hooks of a shell." group:"global" aliases:"install-hooks"`
 
-	Noop     noopCmd     `cmd:"" help:"No-op, just exit." hidden:""`
-	Activate activateCmd `cmd:"" help:"Activate an environment." hidden:""`
-	Exec     execCmd     `cmd:"" help:"Directly execute a binary in a package." hidden:""`
-	Sync     syncCmd     `cmd:"" help:"Sync manifest sources." group:"global"`
-	Search   searchCmd   `cmd:"" help:"Search for packages to install." group:"global"`
-	DumpDB   dumpDBCmd   `cmd:"" help:"Dump state database." hidden:""`
+	Noop                 noopCmd              `cmd:"" help:"No-op, just exit." hidden:""`
+	Activate             activateCmd          `cmd:"" help:"Activate an environment." hidden:""`
+	Exec                 execCmd              `cmd:"" help:"Directly execute a binary in a package." hidden:""`
+	Sync                 syncCmd              `cmd:"" help:"Sync manifest sources." group:"global"`
+	Search               searchCmd            `cmd:"" help:"Search for packages to install." group:"global"`
+	DumpDB               dumpDBCmd            `cmd:"" help:"Dump state database." hidden:""`
+	DumpUserConfigSchema dumpUserConfigSchema `cmd:"" help:"Dump user configuration schema." hidden:""`
 
 	kong.Plugins
 }
@@ -984,4 +985,11 @@ func (s *autoVersionCmd) Run(l *ui.UI) error {
 type manifestCmd struct {
 	Validate    validateCmd    `cmd:"" help:"Check a package manifest source for errors." group:"global"`
 	AutoVersion autoVersionCmd `cmd:"" help:"Upgrade manifest versions automatically where possible." group:"global"`
+}
+
+type dumpUserConfigSchema struct{}
+
+func (dumpUserConfigSchema) Run() error {
+	fmt.Print(userConfigSchema)
+	return nil
 }

--- a/app/userconfig.go
+++ b/app/userconfig.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/alecthomas/hcl"
+	"github.com/alecthomas/kong"
+	"github.com/pkg/errors"
+)
+
+const userConfigPath = "~/.hermit.hcl"
+
+var userConfigSchema = func() string {
+	schema, err := hcl.Schema(&UserConfig{})
+	if err != nil {
+		return ""
+	}
+	data, err := hcl.MarshalAST(schema)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}()
+
+// UserConfig is stored in ~/.hermit.hcl
+type UserConfig struct {
+	ShortPrompt bool `hcl:"short-prompt,optional" help:"If true use a short prompt when an environment is activated."`
+	NoGit       bool `hcl:"no-git,optional" help:"If true Hermit will never add/remove files from Git automatically."`
+}
+
+// LoadUserConfig from disk.
+func LoadUserConfig() (UserConfig, error) {
+	config := UserConfig{}
+	data, err := ioutil.ReadFile(kong.ExpandPath(userConfigPath))
+	if os.IsNotExist(err) {
+		err = hcl.Unmarshal([]byte{}, &config)
+		return config, errors.WithStack(err)
+	} else if err != nil {
+		return config, errors.WithStack(err)
+	}
+	err = hcl.Unmarshal(data, &config)
+	if err != nil {
+		return config, errors.WithStack(err)
+	}
+	return config, nil
+}
+
+// UserConfigResolver is a Kong configuration resolver for the Hermit user configuration file.
+func UserConfigResolver(userConfig UserConfig) kong.Resolver {
+	return &userConfigResolver{userConfig}
+}
+
+type userConfigResolver struct{ config UserConfig }
+
+func (u *userConfigResolver) Validate(app *kong.Application) error { return nil }
+func (u *userConfigResolver) Resolve(context *kong.Context, parent *kong.Path, flag *kong.Flag) (interface{}, error) {
+	switch flag.Name {
+	case "no-git":
+		return u.config.NoGit, nil
+
+	case "short-prompt":
+		return u.config.ShortPrompt, nil
+
+	default:
+		return nil, nil
+	}
+}

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -9,3 +9,4 @@ build: schema
 .PHONY: schema
 schema:
 	(cd .. && ./bin/go run ./cmd/gendocs ./docs/content/packaging/schema/)
+	go run ../cmd/hermit dump-user-config-schema | sed 's,//,#,g' > ./content/usage/user-config-schema.hcl

--- a/docs/content/packaging/schema/channel.md
+++ b/docs/content/packaging/schema/channel.md
@@ -15,7 +15,7 @@ Used by: [&lt;manifest>](../manifest#blocks)
 | [`darwin { … }`](../darwin) | Darwin-specific configuration. |
 | [`linux { … }`](../linux) | Linux-specific configuration. |
 | [`on <event> { … }`](../on) | Triggers to run on lifecycle events. |
-| [`platform <attr> { … }`](../platform) | Platform-specific configuration. &lt;attr&gt; is a set of platform attributes (CPU, OS, etc.) to match. |
+| [`platform <attr> { … }`](../platform) | Platform-specific configuration. &lt;attr&gt; is a set regexes that must all match against one of CPU, OS, etc.. |
 
 ## Attributes
 

--- a/docs/content/packaging/schema/darwin.md
+++ b/docs/content/packaging/schema/darwin.md
@@ -15,7 +15,7 @@ Used by: [channel](../channel#blocks) [linux](../linux#blocks) [&lt;manifest>](.
 | [`darwin { … }`](../darwin) | Darwin-specific configuration. |
 | [`linux { … }`](../linux) | Linux-specific configuration. |
 | [`on <event> { … }`](../on) | Triggers to run on lifecycle events. |
-| [`platform { … }`](../platform) | Platform-specific configuration. &lt;attr&gt; is a set of platform attributes (CPU, OS, etc.) to match. |
+| [`platform { … }`](../platform) | Platform-specific configuration. &lt;attr&gt; is a set regexes that must all match against one of CPU, OS, etc.. |
 
 ## Attributes
 

--- a/docs/content/packaging/schema/linux.md
+++ b/docs/content/packaging/schema/linux.md
@@ -15,7 +15,7 @@ Used by: [channel](../channel#blocks) [darwin](../darwin#blocks) [&lt;manifest>]
 | [`darwin { … }`](../darwin) | Darwin-specific configuration. |
 | [`linux { … }`](../linux) | Linux-specific configuration. |
 | [`on <event> { … }`](../on) | Triggers to run on lifecycle events. |
-| [`platform { … }`](../platform) | Platform-specific configuration. &lt;attr&gt; is a set of platform attributes (CPU, OS, etc.) to match. |
+| [`platform { … }`](../platform) | Platform-specific configuration. &lt;attr&gt; is a set regexes that must all match against one of CPU, OS, etc.. |
 
 ## Attributes
 

--- a/docs/content/packaging/schema/manifest.md
+++ b/docs/content/packaging/schema/manifest.md
@@ -14,7 +14,7 @@ Each Hermit package manifest is a nested structure containing OS/architecture-sp
 | [`darwin { … }`](../darwin) | Darwin-specific configuration. |
 | [`linux { … }`](../linux) | Linux-specific configuration. |
 | [`on <event> { … }`](../on) | Triggers to run on lifecycle events. |
-| [`platform <attr> { … }`](../platform) | Platform-specific configuration. &lt;attr&gt; is a set of platform attributes (CPU, OS, etc.) to match. |
+| [`platform <attr> { … }`](../platform) | Platform-specific configuration. &lt;attr&gt; is a set regexes that must all match against one of CPU, OS, etc.. |
 | [`version <version> { … }`](../version) | Definition of and configuration for a specific version. |
 
 ## Attributes

--- a/docs/content/packaging/schema/platform.md
+++ b/docs/content/packaging/schema/platform.md
@@ -3,7 +3,7 @@ title = "platform <attr>"
 weight = 412
 +++
 
-Platform-specific configuration. &lt;attr&gt; is a set of platform attributes (CPU, OS, etc.) to match.
+Platform-specific configuration. &lt;attr&gt; is a set regexes that must all match against one of CPU, OS, etc..
 
 Used by: [channel](../channel#blocks) [darwin](../darwin#blocks) [linux](../linux#blocks) [&lt;manifest>](../manifest#blocks) [version](../version#blocks)
 
@@ -15,7 +15,7 @@ Used by: [channel](../channel#blocks) [darwin](../darwin#blocks) [linux](../linu
 | [`darwin { … }`](../darwin) | Darwin-specific configuration. |
 | [`linux { … }`](../linux) | Linux-specific configuration. |
 | [`on <event> { … }`](../on) | Triggers to run on lifecycle events. |
-| [`platform { … }`](../platform) | Platform-specific configuration. &lt;attr&gt; is a set of platform attributes (CPU, OS, etc.) to match. |
+| [`platform { … }`](../platform) | Platform-specific configuration. &lt;attr&gt; is a set regexes that must all match against one of CPU, OS, etc.. |
 
 ## Attributes
 

--- a/docs/content/packaging/schema/version.md
+++ b/docs/content/packaging/schema/version.md
@@ -16,7 +16,7 @@ Used by: [&lt;manifest>](../manifest#blocks)
 | [`darwin { … }`](../darwin) | Darwin-specific configuration. |
 | [`linux { … }`](../linux) | Linux-specific configuration. |
 | [`on <event> { … }`](../on) | Triggers to run on lifecycle events. |
-| [`platform <attr> { … }`](../platform) | Platform-specific configuration. &lt;attr&gt; is a set of platform attributes (CPU, OS, etc.) to match. |
+| [`platform <attr> { … }`](../platform) | Platform-specific configuration. &lt;attr&gt; is a set regexes that must all match against one of CPU, OS, etc.. |
 
 ## Attributes
 

--- a/docs/content/usage/ci.md
+++ b/docs/content/usage/ci.md
@@ -1,6 +1,6 @@
 +++
 title = "Continuous Integration"
-weight = 107
+weight = 108
 +++
 
 Generally, using Hermit in CI is similar to using it locally - activate

--- a/docs/content/usage/updates.md
+++ b/docs/content/usage/updates.md
@@ -1,6 +1,6 @@
 +++
 title = "Updating"
-weight = 108
+weight = 109
 +++
 
 Hermit is designed in such a way that it and its package manifests are

--- a/docs/content/usage/user-config-schema.hcl
+++ b/docs/content/usage/user-config-schema.hcl
@@ -1,0 +1,4 @@
+# If true use a short prompt when an environment is activated.
+short-prompt = boolean # (optional)
+# If true Hermit will never add/remove files from Git automatically.
+no-git = boolean # (optional)

--- a/docs/content/usage/user-config.md
+++ b/docs/content/usage/user-config.md
@@ -1,0 +1,9 @@
++++
+title = "User Configuration"
+weight = 107
++++
+
+User's can override certain global behaviours of Hermit by creating a
+`~/.hermit.hcl` file adhering to the following schema:
+
+{{< include file="usage/user-config-schema.hcl" language="hcl" >}}


### PR DESCRIPTION
This allows us to:

1. Generate a schema for the documentation.
2. Extend it with configuration that is not mapped directly to flags.
3. Programmatically update the configuration file.