### PR TITLE
Mark unsupported packages in "hermit search" and fail to install them

### DIFF
--- a/env.go
+++ b/env.go
@@ -407,6 +407,9 @@ func (e *Env) Install(l *ui.UI, pkg *manifest.Package) (*shell.Changes, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	if err := pkg.EnsureSupported(); err != nil {
+		return nil, errors.Wrapf(err, "install failed")
+	}
 
 	allChanges := shell.NewChanges(envars.Parse(os.Environ()))
 
@@ -790,6 +793,9 @@ func (e *Env) upgradeVersion(l *ui.UI, pkg *manifest.Package) (*shell.Changes, e
 	resolved, err := resolver.Resolve(l, manifest.PrefixSelector(pkg.Reference.Major()))
 	if err != nil {
 		return nil, errors.WithStack(err)
+	}
+	if err := resolved.EnsureSupported(); err != nil {
+		return nil, errors.Wrapf(err, "upgrade failed")
 	}
 	if !resolved.Reference.Version.Match(pkg.Reference.Version) {
 		l.Task(pkg.Reference.Name).SubTask("upgrade").Infof("Upgrading %s to %s", pkg, resolved)


### PR DESCRIPTION
Removes this warning on packages that are not supported on the current architecture:
```
warn: invalid manifest reference python3-3.7 in python3.hcl: https://github.com/cashapp/hermit-packages.git/python3.hcl: python3-3.7: no binaries or apps provided
```

Now, instead when searching for packages:
```
$ hermit search python
python3 (@3, @3.9, @latest, 3.7 (architecture not supported), 3.9.5)
  Python is a programming language that lets you work quickly and integrate systems more effectively.
```

This notification is also shown when listing for packages on an environment with the unsupported dependency.

Finally, installing, upgrading to, or executing such packages results in an error.