### PR TITLE
Run a manifest validation as a part of "hermit test" to detect problems in all architectures

### DIFF
--- a/app/commands.go
+++ b/app/commands.go
@@ -395,6 +395,12 @@ func (t *testCmd) Run(l *ui.UI, env *hermit.Env) error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
+		if errs := env.ValidatePackage(l, pkg.Reference.Name); len(errs) > 0 {
+			for _, err := range errs {
+				l.Errorf(err.Error())
+			}
+			return errors.Wrapf(err, "package %s manifest is not valid", pkg.Reference.Name)
+		}
 		if err = env.Test(l, pkg); err != nil {
 			return errors.WithStack(err)
 		}

--- a/env.go
+++ b/env.go
@@ -1043,6 +1043,20 @@ func writeFileToEnvBin(l *ui.Task, useGit bool, src, envDir string, vars map[str
 	return nil
 }
 
+// ValidatePackage checks that the package with the given name is semantically correct
+func (e *Env) ValidatePackage(l *ui.UI, name string) []error {
+	sources, err := e.sources(l)
+	if err != nil {
+		return []error{err}
+	}
+	loader := manifest.NewLoader(sources)
+	mnf, err := loader.Get(name)
+	if err != nil {
+		return []error{err}
+	}
+	return mnf.Validate()
+}
+
 func (e *Env) sources(l *ui.UI) (*sources.Sources, error) {
 	if e.lazySources != nil {
 		return e.lazySources, nil

--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -401,47 +401,7 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 		if len(layer.Env) > 0 {
 			layerEnvars = append(layerEnvars, layer.Env)
 		}
-		if layer.Arch != "" {
-			p.Arch = layer.Arch
-		}
-		if layer.SHA256 != "" {
-			p.SHA256 = layer.SHA256
-		}
-		if layer.Test != nil {
-			p.Test = *layer.Test
-		}
-		if layer.Source != "" {
-			p.Source = layer.Source
-		}
-		if len(layer.Mirrors) > 0 {
-			p.Mirrors = layer.Mirrors
-		}
-		if layer.Root != "" {
-			p.Root = layer.Root
-		}
-		if layer.Dest != "" {
-			p.Dest = layer.Dest
-		}
-		if len(layer.Apps) != 0 {
-			p.Apps = append(p.Apps, layer.Apps...)
-		}
-		if len(layer.Binaries) != 0 {
-			p.Binaries = append(p.Binaries, layer.Binaries...)
-		}
-		if len(layer.Requires) != 0 {
-			p.Requires = append(p.Requires, layer.Requires...)
-		}
-		if len(layer.Provides) != 0 {
-			p.Provides = append(p.Provides, layer.Provides...)
-		}
-		for k, v := range layer.Rename {
-			p.Rename[k] = v
-		}
-		if len(layer.Triggers) > 0 {
-			for _, trigger := range layer.Triggers {
-				p.Triggers[trigger.Event] = append(p.Triggers[trigger.Event], trigger.Ordered()...)
-			}
-		}
+		applyLayer(layer, p)
 		for k, v := range layer.Files {
 			files[k] = v
 		}
@@ -611,6 +571,50 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 		return nil, errors.WithStack(err)
 	}
 	return p, err
+}
+
+func applyLayer(layer *Layer, p *Package) {
+	if layer.Arch != "" {
+		p.Arch = layer.Arch
+	}
+	if layer.SHA256 != "" {
+		p.SHA256 = layer.SHA256
+	}
+	if layer.Test != nil {
+		p.Test = *layer.Test
+	}
+	if layer.Source != "" {
+		p.Source = layer.Source
+	}
+	if len(layer.Mirrors) > 0 {
+		p.Mirrors = layer.Mirrors
+	}
+	if layer.Root != "" {
+		p.Root = layer.Root
+	}
+	if layer.Dest != "" {
+		p.Dest = layer.Dest
+	}
+	if len(layer.Apps) != 0 {
+		p.Apps = append(p.Apps, layer.Apps...)
+	}
+	if len(layer.Binaries) != 0 {
+		p.Binaries = append(p.Binaries, layer.Binaries...)
+	}
+	if len(layer.Requires) != 0 {
+		p.Requires = append(p.Requires, layer.Requires...)
+	}
+	if len(layer.Provides) != 0 {
+		p.Provides = append(p.Provides, layer.Provides...)
+	}
+	for k, v := range layer.Rename {
+		p.Rename[k] = v
+	}
+	if len(layer.Triggers) > 0 {
+		for _, trigger := range layer.Triggers {
+			p.Triggers[trigger.Event] = append(p.Triggers[trigger.Event], trigger.Ordered()...)
+		}
+	}
 }
 
 func resolveFiles(manifest *AnnotatedManifest, pkg *Package, files map[string]string) error {


### PR DESCRIPTION
This only checks that `source` is defined for all "leaf" blocks. We can add further validations later.