### PR TITLE
Test resolving all versions when running "hermit test"

### DIFF
--- a/app/commands.go
+++ b/app/commands.go
@@ -401,6 +401,13 @@ func (t *testCmd) Run(l *ui.UI, env *hermit.Env) error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
+		warnings, err := env.ValidateCompatibility(l, selector.Name())
+		for _, warning := range warnings {
+			l.Warnf("%s: %s", name, warning)
+		}
+		if err != nil {
+			return errors.WithStack(err)
+		}
 		if err = env.Test(l, pkg); err != nil {
 			return errors.WithStack(err)
 		}

--- a/manifest/config.go
+++ b/manifest/config.go
@@ -164,6 +164,26 @@ func (m *Manifest) layers(ref Reference, os string, arch string) (layers, error)
 	return nil, nil
 }
 
+// GetVersions returns all the versions defined in this manifest
+func (m *Manifest) GetVersions() []Version {
+	var result []Version
+	for _, vs := range m.Versions {
+		for _, v := range vs.Version {
+			result = append(result, ParseVersion(v))
+		}
+	}
+	return result
+}
+
+// GetChannels returns all the channels defined in this manifest.
+func (m *Manifest) GetChannels() []string {
+	result := make([]string, len(m.Channels))
+	for i, c := range m.Channels {
+		result[i] = c.Name
+	}
+	return result
+}
+
 type layers []*Layer
 
 // Return the last non-zero value for a field in the stack of layers.


### PR DESCRIPTION
Running `hermit test python3` on a broken package prints out:
```
warn: python3: darwin:arm64: file:///Users/juho/Development/hermit-packages/python3.hcl: python3-3.7: no source provided
warn: python3: darwin:amd64: file:///Users/juho/Development/hermit-packages/python3.hcl: python3-3.7: no binaries or apps provided
warn: python3: linux:arch: file:///Users/juho/Development/hermit-packages/python3.hcl: python3-3.7: no source provided
warn: python3: linux:amd64: file:///Users/juho/Development/hermit-packages/python3.hcl: python3-3.7: no source provided
fatal:hermit: python3-3.7 failed to resolve on all platforms
```