### PR TITLE
Unpack hooks now run prior to the package being made immutable.

### DIFF
--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -39,12 +39,13 @@ func TestExtract(t *testing.T) {
 			defer os.RemoveAll(dest)
 
 			dest = filepath.Join(dest, "extracted")
-			err = Extract(
+			finalise, err := Extract(
 				p.Task("extract"),
 				filepath.Join("testdata", test.file),
 				&manifest.Package{Dest: dest, Source: test.file},
 			)
 			require.NoError(t, err)
+			require.NoError(t, finalise())
 			for _, expected := range test.expected {
 				info, err := os.Stat(filepath.Join(dest, expected))
 				require.NoError(t, err)

--- a/manifest/config_test.go
+++ b/manifest/config_test.go
@@ -242,9 +242,6 @@ func TestManifest(t *testing.T) {
 				if test.expected.Files == nil {
 					test.expected.Files = []*ResolvedFileRef{}
 				}
-				if test.expected.Rename == nil {
-					test.expected.Rename = map[string]string{}
-				}
 				if !test.expected.Reference.IsFullyQualified() {
 					test.expected.Reference = ParseReference(test.pkg)
 				}

--- a/manifest/manifesttest/pkgbuilder.go
+++ b/manifest/manifesttest/pkgbuilder.go
@@ -23,7 +23,6 @@ func NewPkgBuilder(root string) PkgBuilder {
 		&manifest.Package{
 			Reference: ref,
 			Binaries:  []string{"darwin_exe", "linux_exe"},
-			Rename:    map[string]string{},
 			Root:      root,
 			Dest:      root,
 			Triggers:  map[manifest.Event][]manifest.Action{},
@@ -77,12 +76,6 @@ func (b PkgBuilder) WithSource(src string) PkgBuilder {
 // WithWarnings sets the warnings in the package
 func (b PkgBuilder) WithWarnings(warnings ...string) PkgBuilder {
 	b.result.Warnings = warnings
-	return b
-}
-
-// WithRename sets the rename mappings for the package
-func (b PkgBuilder) WithRename(from, to string) PkgBuilder {
-	b.result.Rename[from] = to
 	return b
 }
 

--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -81,7 +81,6 @@ type Package struct {
 	Apps           []string
 	Requires       []string
 	Provides       []string
-	Rename         map[string]string `json:"-"`
 	Env            envars.Ops
 	Source         string
 	Mirrors        []string
@@ -372,7 +371,6 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 	p := &Package{
 		Description:    manifest.Description,
 		Reference:      found,
-		Rename:         map[string]string{},
 		Root:           "${dest}",
 		Dest:           root,
 		Triggers:       map[Event][]Action{},
@@ -441,9 +439,6 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 		}
 		if len(layer.Provides) != 0 {
 			p.Provides = append(p.Provides, layer.Provides...)
-		}
-		for k, v := range layer.Rename {
-			p.Rename[k] = v
 		}
 		if len(layer.Triggers) > 0 {
 			for _, trigger := range layer.Triggers {
@@ -560,13 +555,6 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 	}
 	for i, provides := range p.Provides {
 		p.Provides[i] = expand(provides, false)
-	}
-	if len(p.Rename) > 0 {
-		p.DeprecationWarningf(`rename = {"X": "Y"} must be replaced by on unpack { rename { from="${root}/X" to="${root}/Y" } }`)
-	}
-	for k, v := range p.Rename {
-		delete(p.Rename, k)
-		p.Rename[expand(k, true)] = expand(v, true)
 	}
 	p.Source = expand(p.Source, false)
 	for i, mirror := range p.Mirrors {

--- a/manifest/resolver_test.go
+++ b/manifest/resolver_test.go
@@ -113,29 +113,6 @@ func TestResolver_Resolve(t *testing.T) {
 			).
 			Result(),
 	}, {
-		name: "Returns warnings on deprecated features",
-		files: map[string]string{
-			"test.hcl": `
-                description = ""
-				binaries = ["bin"]
-				rename = {
-  					"a": "b",
-				}
-				version "1.0.0" {
-				  source = "www.example.com"
-				}
-            `,
-		},
-		reference: "test",
-		wantPkg: manifesttest.NewPkgBuilder(config.State+"/pkg/test-1.0.0").
-			WithName("test").
-			WithBinaries("bin").
-			WithVersion("1.0.0").
-			WithSource("www.example.com").
-			WithWarnings(`DEPRECATED: rename = {"X": "Y"} must be replaced by on unpack { rename { from="${root}/X" to="${root}/Y" } }`).
-			WithRename("a", "b").
-			Result(),
-	}, {
 		name: "Infer",
 		files: map[string]string{
 			"test.hcl": `

--- a/state/state.go
+++ b/state/state.go
@@ -290,7 +290,7 @@ func (s *State) CacheAndUnpack(b *ui.Task, p *manifest.Package) error {
 		path = s.cache.Path(p.SHA256, p.Source)
 	}
 
-	err = archive.Extract(b, path, p)
+	finalise, err := archive.Extract(b, path, p)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -305,7 +305,7 @@ func (s *State) CacheAndUnpack(b *ui.Task, p *manifest.Package) error {
 		_ = os.RemoveAll(p.Dest)
 		return errors.WithStack(err)
 	}
-	return nil
+	return errors.WithStack(finalise())
 }
 
 func (s *State) isCached(p *manifest.Package) bool {

--- a/state/stateutils_test.go
+++ b/state/stateutils_test.go
@@ -1,10 +1,12 @@
 package state_test
 
 import (
+	"io/fs"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -36,10 +38,15 @@ func NewStateTestFixture(t *testing.T) *StateTestFixture {
 }
 
 func (f *StateTestFixture) Clean() {
+	f.t.Helper()
 	if f.Server != nil {
 		f.Server.Close()
 	}
 	for r := range f.roots {
+		_ = filepath.Walk(r, func(path string, info fs.FileInfo, err error) error {
+			_ = os.Chmod(path, 0700) // nolint
+			return nil
+		})
 		err := os.RemoveAll(r)
 		require.NoError(f.t, err)
 	}


### PR DESCRIPTION
To facilitate this, archive.Extract() now returns a finalisation
function that makes the package directory immutable. The hooks run in
between extraction and finalisation.

Fixes #1 