### PR TITLE
Ask confirmation from the user when installing packages not supported…

### DIFF
--- a/manifest/config.go
+++ b/manifest/config.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"github.com/cashapp/hermit/platform"
 	"reflect"
 	"regexp"
 	"time"
@@ -150,7 +151,6 @@ func (m *Manifest) layers(ref Reference, os string, arch string) (layers, error)
 				return append(m.Layer.layers(os, arch), l...), nil
 			}
 		}
-
 	}
 	for _, ch := range m.Channels {
 		if ch.Name == ref.Channel {
@@ -162,6 +162,22 @@ func (m *Manifest) layers(ref Reference, os string, arch string) (layers, error)
 		}
 	}
 	return nil, nil
+}
+
+// unsupported returns the platforms not supported in the given Reference
+func (m *Manifest) unsupported(ref Reference, platforms []platform.Platform) []platform.Platform {
+	var result []platform.Platform
+platformsNext:
+	for _, p := range platforms {
+		lrs, _ := m.layers(ref, p.OS, p.Arch)
+		for _, l := range lrs {
+			if l.Source != "" {
+				continue platformsNext
+			}
+		}
+		result = append(result, p)
+	}
+	return result
 }
 
 // GetVersions returns all the versions defined in this manifest

--- a/manifest/manifesttest/pkgbuilder.go
+++ b/manifest/manifesttest/pkgbuilder.go
@@ -1,6 +1,7 @@
 package manifesttest
 
 import (
+	"github.com/cashapp/hermit/platform"
 	"io/fs"
 	"time"
 
@@ -128,5 +129,11 @@ func (b PkgBuilder) WithRequires(reqs ...string) PkgBuilder {
 // WithProvides sets the virtual packages this package provides
 func (b PkgBuilder) WithProvides(provs ...string) PkgBuilder {
 	b.result.Provides = provs
+	return b
+}
+
+// WithUnsupportedPlatforms sets the unsupported platforms for the package
+func (b PkgBuilder) WithUnsupportedPlatforms(platforms []platform.Platform) PkgBuilder {
+	b.result.UnsupportedPlatforms = platforms
 	return b
 }

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -1,0 +1,33 @@
+package platform
+
+// Amd64 architecture
+const Amd64 = "amd64"
+
+// Arm64 architecture
+const Arm64 = "arm64"
+
+// Linux OS
+const Linux = "linux"
+
+// Darwin OS
+const Darwin = "darwin"
+
+// Platform describes a system where a package can be installed
+type Platform struct {
+	// OS is the operating system of the platform
+	OS string
+	// Arch is the CPU architecture of the platform
+	Arch string
+}
+
+func (p Platform) String() string {
+	return p.OS + "-" + p.Arch
+}
+
+// Core platforms are core platforms officially supported by Hermit.
+// For a package to be considered fully compliant, these platforms need to be supported
+var Core = []Platform{
+	{Linux, Amd64},
+	{Darwin, Amd64},
+	{Darwin, Arm64},
+}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -19,6 +19,7 @@ package ui
 import (
 	"bytes"
 	"fmt"
+	"github.com/pkg/errors"
 	"hash/fnv"
 	"io"
 	"os"
@@ -321,4 +322,20 @@ func (w *UI) Printf(format string, args ...interface{}) {
 	w.lock.Lock()
 	fmt.Fprintf(w.stdout, format, args...)
 	w.lock.Unlock()
+}
+
+// Confirmation from the user with y/N options to proceed
+func (w *UI) Confirmation(message string, args ...interface{}) (bool, error) {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	fmt.Fprintf(w.stdout, "hermit: "+message+"\n", args...)
+	s := ""
+	if _, err := fmt.Scan(&s); err != nil {
+		return false, errors.WithStack(err)
+	}
+
+	s = strings.TrimSpace(s)
+	s = strings.ToLower(s)
+	return s == "y" || s == "yes", nil
 }


### PR DESCRIPTION
This confirmation lets the user know that after the installation the build might not work on all Hermit platforms.

```
🐚 $ hermit install make
hermit: make-4.2 is not supported on these Hermit platforms: [linux-amd64], are you sure you want to install it? [y/N]
N
🐚 $ hermit install make
hermit: make-4.2 is not supported on these Hermit platforms: [linux-amd64], are you sure you want to install it? [y/N]
yes
info:make-4.2:install: Installing make-4.2
🐚 $
```

(note: make really is supported on all platforms, this example uses a modified manifest for demonstration purposes only)