### PR TITLE
verify package sources with HTTP HEAD when validating packages

### DIFF
--- a/app/commands.go
+++ b/app/commands.go
@@ -239,12 +239,12 @@ type activateCmd struct {
 	Dir string `arg:"" help:"Directory of environment to activate (${default})" default:"${env}"`
 }
 
-func (a *activateCmd) Run(l *ui.UI, sta *state.State, globalState GlobalState) error {
+func (a *activateCmd) Run(l *ui.UI, sta *state.State, globalState GlobalState, config Config) error {
 	realdir, err := resolveActivationDir(a.Dir)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	env, err := hermit.OpenEnv(realdir, sta, globalState.Env)
+	env, err := hermit.OpenEnv(realdir, sta, globalState.Env, config.normalHTTPClient())
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -451,13 +451,13 @@ type execCmd struct {
 	Args   []string `arg:"" help:"Arguments to pass to executable (use -- to separate)." optional:""`
 }
 
-func (e *execCmd) Run(l *ui.UI, sta *state.State, env *hermit.Env, globalState GlobalState) error {
+func (e *execCmd) Run(l *ui.UI, sta *state.State, env *hermit.Env, globalState GlobalState, config Config) error {
 	envDir, err := hermit.EnvDirFromProxyLink(e.Binary)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 	if env == nil {
-		env, err = hermit.OpenEnv(envDir, sta, globalState.Env)
+		env, err = hermit.OpenEnv(envDir, sta, globalState.Env, config.normalHTTPClient())
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/hermittest/envfixture.go
+++ b/hermittest/envfixture.go
@@ -56,7 +56,7 @@ func NewEnvTestFixture(t *testing.T, handler http.Handler) *EnvTestFixture {
 		Builtin: sources.NewBuiltInSource(vfs.InMemoryFS(nil)),
 	}, server.Client(), server.Client())
 	require.NoError(t, err)
-	env, err := hermit.OpenEnv(envDir, sta, envars.Envars{})
+	env, err := hermit.OpenEnv(envDir, sta, envars.Envars{}, server.Client())
 	require.NoError(t, err)
 
 	return &EnvTestFixture{
@@ -103,7 +103,7 @@ func (f *EnvTestFixture) NewEnv() *hermit.Env {
 	log, _ := ui.NewForTesting()
 	err = hermit.Init(log, envDir, "", f.State.Root(), hermit.Config{})
 	require.NoError(f.t, err)
-	env, err := hermit.OpenEnv(envDir, f.State, envars.Envars{})
+	env, err := hermit.OpenEnv(envDir, f.State, envars.Envars{}, f.Server.Client())
 	require.NoError(f.t, err)
 	return env
 }


### PR DESCRIPTION
Gives an error like this when testing a package if there is a source for any platform that can not be resolved with `HEAD`:
```
fatal: error fetching https://downloads.haskell.org/~cabal/cabal-install-3.4.0.0/cabal-install-3.4.0.0-aarch64-darwin-sierra.tar.xz: 404 Not Found
```

Checked by testing packages from `A` to `E`, and the cabal error above is the only error returned.