### PR TITLE
Add a "prompt" option to leave the prompt alone

### DIFF
--- a/docs/content/usage/user-config-schema.hcl
+++ b/docs/content/usage/user-config-schema.hcl
@@ -1,3 +1,5 @@
+# Modify prompt to include hermit environment (env), just an icon (short) or nothing (none)
+prompt = string # (optional)
 # If true use a short prompt when an environment is activated.
 short-prompt = boolean # (optional)
 # If true Hermit will never add/remove files from Git automatically.

--- a/shell/files/activate.tmpl.sh
+++ b/shell/files/activate.tmpl.sh
@@ -33,7 +33,9 @@ _hermit_deactivate() {
   precmd_functions=(${precmd_functions:#update_hermit_env})
 {{- end}}
 
+{{- if ne .Prompt "none"}}
   if test -n "${_HERMIT_OLD_PS1+_}"; then export PS1="${_HERMIT_OLD_PS1}"; unset _HERMIT_OLD_PS1; fi
+{{- end}}
 
 }
 
@@ -48,7 +50,9 @@ export ACTIVE_HERMIT=$HERMIT_ENV
 export HERMIT_DEACTIVATION="$(${HERMIT_ENV}/bin/hermit env --deactivate)"
 export HERMIT_BIN_CHANGE=$(date -r ${HERMIT_ENV}/bin +"%s")
 
-if test -n "${PS1+_}"; then export _HERMIT_OLD_PS1="${PS1}"; export PS1="{{if not .ShortPrompt}}{{ .EnvName }}{{end}}🐚 ${PS1}"; fi
+{{- if ne .Prompt "none" }}
+if test -n "${PS1+_}"; then export _HERMIT_OLD_PS1="${PS1}"; export PS1="{{if eq .Prompt "env"}}{{ .EnvName }}{{end}}🐚 ${PS1}"; fi
+{{- end}}
 
 update_hermit_env() {
   local CURRENT=$(date -r ${HERMIT_ENV}/bin +"%s")

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -19,9 +19,9 @@ import (
 
 // ActivationConfig for shells.
 type ActivationConfig struct {
-	Root        string
-	ShortPrompt bool
-	Env         envars.Envars
+	Root   string
+	Prompt string
+	Env    envars.Envars
 }
 
 // Shell abstracts shell specific functionality


### PR DESCRIPTION
Add an option (both a flag and a .hermit.hcl field) to tell hermit not
to make changes to the prompt when activating an environment.

The "prompt" option is an enum with the values "env", "short", and
"none". "env" is the same as the current prompt - the environment name
and hermit icon in the prompt. "short" is the same as the short-prompt
option - just the hermit icon in the prompt. "none" prevents hermit from
changing the prompt at all.

This subsumes the short-prompt option. As a CLI flag, it has been made
hidden, but is still present for backward compatibility. If both
"prompt" and "short-prompt" are set, "short-prompt" will override
whatever has been set for "prompt".