### PR TITLE
Add "hermit manifest create <url>".

### DIFF
--- a/github/api.go
+++ b/github/api.go
@@ -1,0 +1,120 @@
+// Package github implements a client for GitHub that includes the minimum set
+// of functions required by Hermit.
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Repo information.
+type Repo struct {
+	Description string `json:"description"`
+}
+
+// Release is a minimal type for GitHub releases meta information retrieved via the GitHub API.
+//
+// See https://docs.github.com/en/rest/reference/repos#list-releases
+type Release struct {
+	TagName string  `json:"tag_name"`
+	Assets  []Asset `json:"assets"`
+}
+
+// Asset is a minimal type for assets in the GitHub releases meta information retrieved via the GitHub API.
+//
+// See https://docs.github.com/en/rest/reference/repos#list-releases
+type Asset struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+// Client for GitHub.
+type Client struct {
+	client *http.Client
+}
+
+// New creates a new GitHub API client.
+//
+// The passed http.Client should be configured
+func New(client *http.Client) *Client {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &Client{client: client}
+}
+
+// ProjectForURL returns the <repo>/<project> for the given URL if it is a GitHub project.
+func (a *Client) ProjectForURL(sourceURL string) string {
+	u, err := url.Parse(sourceURL)
+	if err != nil {
+		return ""
+	}
+	if u.Host != "github.com" {
+		return ""
+	}
+	parts := strings.Split(u.Path, "/")
+	if len(parts) < 3 {
+		return ""
+	}
+	return strings.Join(parts[1:3], "/")
+}
+
+// Repo information.
+func (a *Client) Repo(repo string) (*Repo, error) {
+	response := &Repo{}
+	url := "https://api.github.com/repos/" + repo
+	return response, a.decode(url, response)
+}
+
+// LatestRelease details for a GitHub repository.
+func (a *Client) LatestRelease(repo string) (*Release, error) {
+	url := "https://api.github.com/repos/" + repo + "/releases/latest"
+	release := &Release{}
+	return release, a.decode(url, release)
+}
+
+// Releases for a particular repo.
+func (a *Client) Releases(repo string) (releases []Release, err error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases", repo)
+	return releases, a.decode(url, &releases)
+}
+
+// PrepareDownload prepares a HTTP client and request for retrieving a file from GitHub.
+func (a *Client) PrepareDownload(asset Asset) (client *http.Client, req *http.Request, err error) {
+	req, err = a.request(asset.URL, http.Header{
+		"Accept": []string{"application/octet-stream"},
+	})
+	return a.client, req, err
+}
+
+func (a *Client) decode(url string, dest interface{}) error {
+	req, err := a.request(url, http.Header{})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer resp.Body.Close()
+	err = json.NewDecoder(resp.Body).Decode(dest)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func (a *Client) request(url string, headers http.Header) (*http.Request, error) {
+	req, err := http.NewRequest("GET", url, nil) // nolint: noctx
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	headers = headers.Clone()
+	req.Header = headers
+	return req, nil
+}

--- a/github/http.go
+++ b/github/http.go
@@ -1,0 +1,30 @@
+package github
+
+import (
+	"net/http"
+)
+
+// TokenAuthenticatedTransport returns a HTTP transport that will inject a
+// GitHub authentication token into any requests to github.com.
+//
+// Conceptually similar to
+// https://github.com/google/go-github/blob/d23570d44313ca73dbcaadec71fc43eca4d29f8b/github/github.go#L841-L875
+func TokenAuthenticatedTransport(transport http.RoundTripper, token string) http.RoundTripper {
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	return &githubAuthenticatedHTTPClient{rt: transport, token: token}
+}
+
+type githubAuthenticatedHTTPClient struct {
+	token string
+	rt    http.RoundTripper
+}
+
+func (g *githubAuthenticatedHTTPClient) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context()) // The stdlib docs recommend not mutating the request in place.
+	if (req.URL.Host == "github.com" || req.URL.Host == "api.github.com") && g.token != "" {
+		req.Header.Set("Authorization", "token "+g.token)
+	}
+	return g.rt.RoundTrip(req)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	aqwari.net/xml v0.0.0-20200724195937-ae380bb65a55
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/alecthomas/colour v0.1.0
-	github.com/alecthomas/hcl v0.1.13
+	github.com/alecthomas/hcl v0.1.15
 	github.com/alecthomas/kong v0.2.18-0.20210713035501-d1a818b5a1a8
 	github.com/alecthomas/participle v0.6.1-0.20200911005820-318127ca69ac
 	github.com/alecthomas/repr v0.0.0-20200325044227-4184120f674c

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/alecthomas/colour v0.1.0 h1:nOE9rJm6dsZ66RGWYSFrXw461ZIt9A6+nHgL7FRrDUk=
 github.com/alecthomas/colour v0.1.0/go.mod h1:QO9JBoKquHd+jz9nshCh40fOfO+JzsoXy8qTHF68zU0=
-github.com/alecthomas/hcl v0.1.13 h1:gU7Ki8hftG1MsTAF9JkqzUfabakHFMnVjPgY6bLjQ+o=
-github.com/alecthomas/hcl v0.1.13/go.mod h1:VEYcgruQ39ELu6c0Bb+VRm3trQPt7dQUdAwF7QrG7AQ=
+github.com/alecthomas/hcl v0.1.15 h1:OmJy3NIscubHSE9LvX/e75dGTJ9Bg4sY3BLq/fsHmF8=
+github.com/alecthomas/hcl v0.1.15/go.mod h1:VEYcgruQ39ELu6c0Bb+VRm3trQPt7dQUdAwF7QrG7AQ=
 github.com/alecthomas/kong v0.2.2/go.mod h1:kQOmtJgV+Lb4aj+I2LEn40cbtawdWJ9Y8QLq+lElKxE=
 github.com/alecthomas/kong v0.2.18-0.20210713035501-d1a818b5a1a8 h1:FQGpNQn+YtyEiECNxpdrWUqiCX6++xcVj+BxmKPw/D4=
 github.com/alecthomas/kong v0.2.18-0.20210713035501-d1a818b5a1a8/go.mod h1:ka3VZ8GZNPXv9Ov+j4YNLkI8mTuhXyr/0ktSlqIydQQ=

--- a/hermittest/envfixture.go
+++ b/hermittest/envfixture.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/cashapp/hermit/envars"
+	"github.com/cashapp/hermit/github"
 	"github.com/cashapp/hermit/sources"
 	"github.com/cashapp/hermit/vfs"
 
@@ -51,10 +52,11 @@ func NewEnvTestFixture(t *testing.T, handler http.Handler) *EnvTestFixture {
 	require.NoError(t, err)
 
 	server := httptest.NewServer(handler)
+	client := server.Client()
 	sta, err := state.Open(stateDir, state.Config{
 		Sources: []string{},
 		Builtin: sources.NewBuiltInSource(vfs.InMemoryFS(nil)),
-	}, server.Client(), server.Client())
+	}, github.New(client), client, client)
 	require.NoError(t, err)
 	env, err := hermit.OpenEnv(envDir, sta, envars.Envars{}, server.Client())
 	require.NoError(t, err)

--- a/manifest/infer.go
+++ b/manifest/infer.go
@@ -1,0 +1,181 @@
+package manifest
+
+import (
+	"net/http"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/cashapp/hermit/github"
+	"github.com/cashapp/hermit/platform"
+	"github.com/cashapp/hermit/ui"
+)
+
+var (
+	inferVerRe         = regexp.MustCompile(`releases/download/(?:v)?([^/]+)/`)
+	inferOSRe          = regexp.MustCompile(`(darwin|linux)`)
+	inferArchRe        = regexp.MustCompile(`(amd64|arm64)`)
+	inferXArchRe       = regexp.MustCompile(`(x86_64|aarch64)`)
+	darwinamd64        = platform.Platform{OS: platform.Darwin, Arch: platform.Amd64}
+	darwinarm64        = platform.Platform{OS: platform.Darwin, Arch: platform.Arm64}
+	suffixAlternatives = []string{".zip", ".tar.gz", ".tar.bz2", ".tgz", ".tbz2", ".tar.xz", ".txz"}
+)
+
+// InferFromArtefact attempts to infer a Manifest from a package artefact.
+//
+// "url" should be the full URL to a package artefact.
+//
+//     https://github.com/protocolbuffers/protobuf-go/releases/download/v1.27.1/protoc-gen-go.v1.27.1.darwin.amd64.tar.gz
+//
+// "version" may be specified if it cannot be inferred from the URL.
+func InferFromArtefact(p *ui.UI, httpClient *http.Client, ghClient *github.Client, url, version string) (*Manifest, error) {
+	source, version, err := insertVariables(url, version, false)
+	if err != nil {
+		return nil, err
+	}
+	// Pull description from GH API if possible.
+	description := ""
+	if repoName := ghClient.ProjectForURL(url); repoName != "" {
+		repo, err := ghClient.Repo(repoName)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		description = repo.Description
+	}
+
+	// Check if sources for all valid platforms are available.
+	sourcesByPlatform := buildSourcesByPlatform(version, source)
+
+	p.Debugf("Validating sources")
+	substituteM1, err := validateSourcesByPlatform(p, httpClient, sourcesByPlatform)
+	if err != nil {
+		return nil, err
+	}
+
+	// Substitute back in variables now that we have concrete URLs for each platform.
+	for plat, platSource := range sourcesByPlatform {
+		skip := substituteM1 && plat == darwinarm64
+		platSource, _, err = insertVariables(platSource, version, skip)
+		if err != nil {
+			return nil, err
+		}
+		sourcesByPlatform[plat] = platSource
+	}
+
+	platforms := make([]*PlatformBlock, 0, len(sourcesByPlatform))
+	for plat, platSource := range sourcesByPlatform {
+		platforms = append(platforms, &PlatformBlock{
+			Attrs: []string{plat.OS, plat.Arch},
+			Layer: Layer{
+				Source: platSource,
+			},
+		})
+	}
+
+	sort.Slice(platforms, func(i, j int) bool {
+		return strings.Join(platforms[i].Attrs, "/") < strings.Join(platforms[j].Attrs, "/")
+	})
+
+	return &Manifest{
+		Description: description,
+		Layer: Layer{
+			Binaries: []string{},
+			Platform: platforms,
+		},
+		Versions: []VersionBlock{{
+			Version: []string{version},
+		}},
+	}, nil
+}
+
+func buildSourcesByPlatform(version string, source string) map[platform.Platform]string {
+	sourcesByPlatform := map[platform.Platform]string{}
+	for _, plat := range platform.Core {
+		vars := map[string]string{
+			"version": version,
+			"os":      plat.OS,
+			"arch":    plat.Arch,
+			"xarch":   platform.ArchToXArch(plat.Arch),
+		}
+		sourcesByPlatform[plat] = os.Expand(source, func(key string) string {
+			return vars[key]
+		})
+	}
+	return sourcesByPlatform
+}
+
+// Check that our initial sources exist and if not, try the same URLs with different extensions (.zip, .tgz, etc.)
+func validateSourcesByPlatform(p *ui.UI, httpClient *http.Client, sourcesByPlatform map[platform.Platform]string) (substituteM1 bool, err error) {
+nextPlatform:
+	for plat, url := range sourcesByPlatform {
+		p.Debugf("  %s - %s", plat, url)
+		if err := ValidatePackageSource(httpClient, url); err != nil {
+			// Try different extensions as packages sometimes use .zip for Windows, .tar.gz for Linux, etc.
+			candidate := url
+			// Strip the existing suffix.
+			for _, suffix := range suffixAlternatives {
+				candidate = strings.TrimSuffix(candidate, suffix)
+			}
+			// Try alternative suffixAlternatives.
+			for _, suffix := range suffixAlternatives {
+				url = candidate + suffix
+				if err := ValidatePackageSource(httpClient, url); err == nil {
+					sourcesByPlatform[plat] = url
+					continue nextPlatform
+				}
+			}
+
+			// Next just try to rely on Rosetta.
+			if plat == darwinarm64 {
+				substituteM1 = true
+				delete(sourcesByPlatform, darwinarm64)
+			} else {
+				return false, errors.WithStack(err)
+			}
+		}
+	}
+
+	// We can substitute amd64 for arm64 on Darwin due to Rosetta.
+	if substituteM1 {
+		sourcesByPlatform[darwinarm64] = sourcesByPlatform[darwinamd64]
+	}
+	return substituteM1, nil
+}
+
+func insertVariables(url, inVersion string, skipArch bool) (source, version string, err error) {
+	version = inVersion
+	// Pull out variables.
+	if version == "" {
+		groups := inferVerRe.FindStringSubmatch(url)
+		if len(groups) == 2 {
+			version = groups[1]
+		} else {
+			return "", "", errors.Errorf("%s: could not infer version", url)
+		}
+	}
+	pkgOS := inferOSRe.FindString(url)
+	if pkgOS == "" {
+		return "", "", errors.Errorf("%s: could not infer OS", url)
+	}
+	var arch, xarch string
+	if !skipArch {
+		arch = inferArchRe.FindString(url)
+		xarch = inferXArchRe.FindString(url)
+		if xarch == "" && arch == "" {
+			return "", "", errors.Errorf("%s: could not infer CPU architecture", url)
+		}
+	}
+
+	// Substitute in variables.
+	source = strings.ReplaceAll(url, version, "${version}")
+	source = strings.ReplaceAll(source, pkgOS, "${os}")
+	if arch != "" {
+		source = strings.ReplaceAll(source, arch, "${arch}")
+	} else if xarch != "" {
+		source = strings.ReplaceAll(source, xarch, "${xarch}")
+	}
+	return source, version, nil
+}

--- a/manifest/infer_test.go
+++ b/manifest/infer_test.go
@@ -1,0 +1,45 @@
+package manifest
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cashapp/hermit/github"
+	"github.com/cashapp/hermit/ui"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInfer(t *testing.T) {
+	files := map[string]string{
+		"/releases/download/0.1.1/pkg-0.1.1-darwin-amd64.zip": "",
+		"/releases/download/0.1.1/pkg-0.1.1-linux-amd64.tgz":  "",
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		content, ok := files[r.URL.Path]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = io.WriteString(w, content)
+	}))
+	defer srv.Close()
+	p, _ := ui.NewForTesting()
+	actual, err := InferFromArtefact(p, http.DefaultClient, github.New(http.DefaultClient), srv.URL+"/releases/download/0.1.1/pkg-0.1.1-linux-amd64.tgz", "")
+	require.NoError(t, err)
+	expected := &Manifest{
+		Layer: Layer{
+			Binaries: []string{},
+			Platform: []*PlatformBlock{
+				{Attrs: []string{"darwin", "amd64"}, Layer: Layer{Source: srv.URL + "/releases/download/${version}/pkg-${version}-${os}-${arch}.zip"}},
+				{Attrs: []string{"darwin", "arm64"}, Layer: Layer{Source: srv.URL + "/releases/download/${version}/pkg-${version}-${os}-amd64.zip"}},
+				{Attrs: []string{"linux", "amd64"}, Layer: Layer{Source: srv.URL + "/releases/download/${version}/pkg-${version}-${os}-${arch}.tgz"}},
+			},
+		},
+		Versions: []VersionBlock{{
+			Version: []string{"0.1.1"},
+		}},
+	}
+	require.Equal(t, expected, actual)
+}

--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -2,7 +2,6 @@ package manifest
 
 import (
 	"fmt"
-	"github.com/cashapp/hermit/platform"
 	"io/fs"
 	"os"
 	"path"
@@ -12,6 +11,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/cashapp/hermit/platform"
 
 	"github.com/alecthomas/participle"
 	"github.com/gobwas/glob"
@@ -32,12 +33,6 @@ var ErrNoBinaries = errors.New("no binaries or apps provided")
 
 // ErrNoSource is returned when a resolved package does not contain source
 var ErrNoSource = errors.New("no source provided")
-
-var xarch = map[string]string{
-	platform.Amd64: "x86_64",
-	"386":          "i386",
-	platform.Arm64: "aarch64",
-}
 
 // Config required for loading manifests.
 type Config struct {
@@ -487,9 +482,8 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 				return config.Arch
 
 			case "xarch":
-				subst, ok := xarch[config.Arch]
-				if ok {
-					return subst
+				if xarch := platform.ArchToXArch(config.Arch); xarch != "" {
+					return xarch
 				}
 				return config.Arch
 

--- a/manifest/validate.go
+++ b/manifest/validate.go
@@ -1,0 +1,27 @@
+package manifest
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+// ValidatePackageSource checks that a package source is accessible.
+func ValidatePackageSource(httpClient *http.Client, url string) error {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodHead, url, nil)
+	if err != nil {
+		return errors.Wrap(err, url)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return errors.Errorf("could not retrieve source archive from %s: %s", url, resp.Status)
+	}
+
+	return nil
+}

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -24,10 +24,22 @@ func (p Platform) String() string {
 	return p.OS + "-" + p.Arch
 }
 
-// Core platforms are core platforms officially supported by Hermit.
+// Core platforms officially supported by Hermit.
+//
 // For a package to be considered fully compliant, these platforms need to be supported
 var Core = []Platform{
 	{Linux, Amd64},
 	{Darwin, Amd64},
 	{Darwin, Arm64},
+}
+
+var xarch = map[string]string{
+	Amd64: "x86_64",
+	"386": "i386",
+	Arm64: "aarch64",
+}
+
+// ArchToXArch maps "arch" to "xarch".
+func ArchToXArch(arch string) string {
+	return xarch[arch]
 }

--- a/state/state.go
+++ b/state/state.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cashapp/hermit/archive"
 	"github.com/cashapp/hermit/cache"
+	"github.com/cashapp/hermit/github"
 	"github.com/cashapp/hermit/internal/dao"
 	"github.com/cashapp/hermit/manifest"
 	"github.com/cashapp/hermit/sources"
@@ -65,7 +66,7 @@ type State struct {
 }
 
 // Open the global Hermit state.
-func Open(stateDir string, config Config, client *http.Client, fastFailClient *http.Client) (*State, error) {
+func Open(stateDir string, config Config, ghClient *github.Client, client *http.Client, fastFailClient *http.Client) (*State, error) {
 	if config.Builtin == nil {
 		return nil, errors.Errorf("state.Config.Builtin not provided")
 	}
@@ -73,7 +74,7 @@ func Open(stateDir string, config Config, client *http.Client, fastFailClient *h
 	pkgDir := filepath.Join(stateDir, "pkg")
 	cacheDir := filepath.Join(stateDir, "cache")
 	sourcesDir := filepath.Join(stateDir, "sources")
-	cache, err := cache.Open(cacheDir, client, fastFailClient)
+	cache, err := cache.Open(cacheDir, ghClient, client, fastFailClient)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/state/stateutils_test.go
+++ b/state/stateutils_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cashapp/hermit/github"
 	"github.com/cashapp/hermit/sources"
 	"github.com/cashapp/hermit/state"
 	"github.com/cashapp/hermit/ui"
@@ -64,9 +65,10 @@ func (f *StateTestFixture) State() *state.State {
 		f.Server = httptest.NewServer(f.handler)
 	}
 	f.roots[root] = true
+	client := f.Server.Client()
 	sta, err := state.Open(root, state.Config{
 		Builtin: sources.NewBuiltInSource(vfs.InMemoryFS(nil)),
-	}, f.Server.Client(), f.Server.Client())
+	}, github.New(client), client, client)
 	require.NoError(f.t, err)
 	return sta
 }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -19,13 +19,14 @@ package ui
 import (
 	"bytes"
 	"fmt"
-	"github.com/pkg/errors"
 	"hash/fnv"
 	"io"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
+
+	"github.com/pkg/errors"
 
 	"golang.org/x/crypto/ssh/terminal"
 )


### PR DESCRIPTION
This will attempt to infer a manifest from the given download artefact.
It is not super comprehensive but should at the very least check that
there are valid URLs. Only works on GitHub.

```console
$ hermit manifest create https://github.com/mattn/goreman/releases/download/v0.3.7/goreman_v0.3.7_darwin_amd64.zip
// Relative glob from $root to individual terminal binaries.
binaries = []

// Platform-specific configuration. <attr> is a set regexes that must all match against one of CPU, OS, etc..
platform "darwin" "amd64" {
  // URL for source package.
  source = "https://github.com/mattn/goreman/releases/download/v${version}/goreman_v${version}_${os}_${arch}.zip"
}

// Platform-specific configuration. <attr> is a set regexes that must all match against one of CPU, OS, etc..
platform "darwin" "arm64" {
  // URL for source package.
  source = "https://github.com/mattn/goreman/releases/download/v${version}/goreman_v${version}_${os}_amd64.zip"
}

// Platform-specific configuration. <attr> is a set regexes that must all match against one of CPU, OS, etc..
platform "linux" "amd64" {
  // URL for source package.
  source = "https://github.com/mattn/goreman/releases/download/v${version}/goreman_v${version}_${os}_${arch}.tar.gz"
}

// Human readable description of the package.
description = "foreman clone written in go language"

// Definition of and configuration for a specific version.
version "0.3.7" {
  // Automatically update versions.
  auto-version {
  }
}
```