### PR TITLE
Git repo as package source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bin/hermit.hcl
 docs/resources/_gen
 docs/public
 .gobin/
+.hermit/

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -29,6 +29,7 @@ func TestExtract(t *testing.T) {
 		{"linux_exe.gz", []string{"linux_exe"}},
 		{"bzip2_1.0.6-9.2_deb10u1_amd64.deb", []string{"/bin/bzip2"}},
 		{"bzip2-1.0.6-13.el7.x86_64.rpm", []string{"/usr/bin/bzip2"}},
+		{"directory", []string{"foo"}},
 	}
 	for _, test := range tests {
 		t.Run(test.file, func(t *testing.T) {

--- a/archive/testdata/directory/foo
+++ b/archive/testdata/directory/foo
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "bar"

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -134,7 +134,7 @@ func (c *Cache) ETag(b *ui.Task, uri string, mirrors ...string) (etag string, er
 		if err != nil {
 			return "", errors.WithStack(err)
 		}
-		result, err := source.ETag(c)
+		result, err := source.ETag(b, c)
 		if err != nil {
 			b.Debugf("%s failed: %s", uri, err)
 			continue

--- a/cache/source.go
+++ b/cache/source.go
@@ -3,23 +3,31 @@ package cache
 import (
 	"context"
 	"github.com/cashapp/hermit/ui"
+	"github.com/cashapp/hermit/util"
 	"github.com/pkg/errors"
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 type packageSource interface {
 	OpenLocal(cache *Cache, checksum string) (*os.File, error)
 	Download(b *ui.Task, cache *Cache, checksum string) (path string, etag string, err error)
-	ETag(cache *Cache) (etag string, err error)
+	ETag(b *ui.Task, cache *Cache) (etag string, err error)
 }
 
 func getSource(uri string) (packageSource, error) {
+	if strings.HasSuffix(uri, ".git") {
+		return &gitSource{URL: uri}, nil
+	}
+
 	u, err := url.Parse(uri)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+
 	switch u.Scheme {
 	case "", "file":
 		return &fileSource{Path: u.Path}, nil
@@ -46,7 +54,7 @@ func (s *fileSource) Download(_ *ui.Task, _ *Cache, _ string) (path string, etag
 	return s.Path, "", nil
 }
 
-func (s *fileSource) ETag(_ *Cache) (etag string, err error) {
+func (s *fileSource) ETag(_ *ui.Task, _ *Cache) (etag string, err error) {
 	return "", nil
 }
 
@@ -64,7 +72,7 @@ func (s *httpSource) Download(b *ui.Task, cache *Cache, checksum string) (path s
 	return cache.downloadHTTP(b, checksum, s.URL, cachePath)
 }
 
-func (s *httpSource) ETag(c *Cache) (etag string, err error) {
+func (s *httpSource) ETag(_ *ui.Task, c *Cache) (etag string, err error) {
 	uri := s.URL
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodHead, uri, nil)
 	if err != nil {
@@ -81,4 +89,41 @@ func (s *httpSource) ETag(c *Cache) (etag string, err error) {
 	}
 	result := resp.Header.Get("ETag")
 	return result, nil
+}
+
+type gitSource struct {
+	URL string
+}
+
+func (s *gitSource) OpenLocal(c *Cache, checksum string) (*os.File, error) {
+	f, err := os.Open(c.Path(checksum, s.URL))
+	return f, errors.WithStack(err)
+}
+
+func (s *gitSource) Download(b *ui.Task, cache *Cache, checksum string) (string, string, error) {
+	base := BasePath(checksum, s.URL)
+	err := util.RunInDir(b, cache.root, "git", "clone", "--depth=1", s.URL, base)
+	if err != nil {
+		return "", "", errors.Wrap(err, s.URL)
+	}
+	etag, err := s.ETag(b, cache)
+	if err != nil {
+		return "", "", errors.Wrap(err, s.URL)
+	}
+
+	return filepath.Join(cache.root, base), etag, nil
+}
+
+func (s *gitSource) ETag(b *ui.Task, c *Cache) (etag string, err error) {
+	bts, err := util.Capture(b, "git", "ls-remote", s.URL, "HEAD")
+	if err != nil {
+		return "", errors.Wrap(err, s.URL)
+	}
+	str := string(bts)
+	parts := strings.Split(str, "\t")
+	if len(parts) != 2 {
+		return "", errors.Errorf("invalid HEAD: %s", str)
+	}
+
+	return parts[0], nil
 }

--- a/cache/source.go
+++ b/cache/source.go
@@ -1,0 +1,84 @@
+package cache
+
+import (
+	"context"
+	"github.com/cashapp/hermit/ui"
+	"github.com/pkg/errors"
+	"net/http"
+	"net/url"
+	"os"
+)
+
+type packageSource interface {
+	OpenLocal(cache *Cache, checksum string) (*os.File, error)
+	Download(b *ui.Task, cache *Cache, checksum string) (path string, etag string, err error)
+	ETag(cache *Cache) (etag string, err error)
+}
+
+func getSource(uri string) (packageSource, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	switch u.Scheme {
+	case "", "file":
+		return &fileSource{Path: u.Path}, nil
+
+	case "http", "https":
+		return &httpSource{uri}, errors.WithStack(err)
+	default:
+		return nil, errors.Errorf("unsupported URI %s", uri)
+	}
+}
+
+type fileSource struct {
+	Path string
+}
+
+func (s *fileSource) OpenLocal(_ *Cache, _ string) (*os.File, error) {
+	f, err := os.Open(s.Path)
+	return f, errors.WithStack(err)
+}
+
+func (s *fileSource) Download(_ *ui.Task, _ *Cache, _ string) (path string, etag string, err error) {
+	// TODO: Checksum it again?
+	// Local file, just open it.
+	return s.Path, "", nil
+}
+
+func (s *fileSource) ETag(_ *Cache) (etag string, err error) {
+	return "", nil
+}
+
+type httpSource struct {
+	URL string
+}
+
+func (s *httpSource) OpenLocal(c *Cache, checksum string) (*os.File, error) {
+	f, err := os.Open(c.Path(checksum, s.URL))
+	return f, errors.WithStack(err)
+}
+
+func (s *httpSource) Download(b *ui.Task, cache *Cache, checksum string) (path string, etag string, err error) {
+	cachePath := cache.Path(checksum, s.URL)
+	return cache.downloadHTTP(b, checksum, s.URL, cachePath)
+}
+
+func (s *httpSource) ETag(c *Cache) (etag string, err error) {
+	uri := s.URL
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodHead, uri, nil)
+	if err != nil {
+		return "", errors.Wrap(err, uri)
+	}
+	resp, err := c.fastFailHTTPClient.Do(req)
+	if err != nil {
+		return "", errors.Wrap(err, uri)
+	}
+	defer resp.Body.Close()
+	// Normal HTTP error, log and try the next mirror.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", errors.Errorf("%s failed: %d", uri, resp.StatusCode)
+	}
+	result := resp.Header.Get("ETag")
+	return result, nil
+}


### PR DESCRIPTION
This PR adds git repos as package sources. If the `source` ends with `.git` it is interpreted as a git repo, and it is fetched by cloning the default branch. This should allow us to serve scripts from a repo via hermit.

We could improve this in the future by allowing non-default branches or tags.
