### PR TITLE
Update to newer HCL library that doesn't serialise field descriptions.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	aqwari.net/xml v0.0.0-20200724195937-ae380bb65a55
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/alecthomas/colour v0.1.0
-	github.com/alecthomas/hcl v0.1.15
+	github.com/alecthomas/hcl v0.1.16
 	github.com/alecthomas/kong v0.2.18-0.20210713035501-d1a818b5a1a8
 	github.com/alecthomas/participle v0.6.1-0.20200911005820-318127ca69ac
 	github.com/alecthomas/repr v0.0.0-20200325044227-4184120f674c

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/alecthomas/colour v0.1.0 h1:nOE9rJm6dsZ66RGWYSFrXw461ZIt9A6+nHgL7FRrDUk=
 github.com/alecthomas/colour v0.1.0/go.mod h1:QO9JBoKquHd+jz9nshCh40fOfO+JzsoXy8qTHF68zU0=
-github.com/alecthomas/hcl v0.1.15 h1:OmJy3NIscubHSE9LvX/e75dGTJ9Bg4sY3BLq/fsHmF8=
-github.com/alecthomas/hcl v0.1.15/go.mod h1:VEYcgruQ39ELu6c0Bb+VRm3trQPt7dQUdAwF7QrG7AQ=
+github.com/alecthomas/hcl v0.1.16 h1:wxXlEveP+/Ajs1qffTAolGuHnrQAnllyKc3KX+Nr14g=
+github.com/alecthomas/hcl v0.1.16/go.mod h1:VEYcgruQ39ELu6c0Bb+VRm3trQPt7dQUdAwF7QrG7AQ=
 github.com/alecthomas/kong v0.2.2/go.mod h1:kQOmtJgV+Lb4aj+I2LEn40cbtawdWJ9Y8QLq+lElKxE=
 github.com/alecthomas/kong v0.2.18-0.20210713035501-d1a818b5a1a8 h1:FQGpNQn+YtyEiECNxpdrWUqiCX6++xcVj+BxmKPw/D4=
 github.com/alecthomas/kong v0.2.18-0.20210713035501-d1a818b5a1a8/go.mod h1:ka3VZ8GZNPXv9Ov+j4YNLkI8mTuhXyr/0ktSlqIydQQ=

--- a/manifest/config.go
+++ b/manifest/config.go
@@ -1,7 +1,6 @@
 package manifest
 
 import (
-	"github.com/cashapp/hermit/platform"
 	"reflect"
 	"regexp"
 	"time"
@@ -9,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/cashapp/hermit/envars"
+	"github.com/cashapp/hermit/platform"
 )
 
 //go:generate stringer -linecomment -type PackageState
@@ -85,7 +85,7 @@ func (c *Layer) match(arch string) bool {
 // AutoVersionBlock represents auto-version configuration.
 type AutoVersionBlock struct {
 	GitHubRelease  string `hcl:"github-release" help:"GitHub <user>/<repo> to retrieve and update versions from the releases API."`
-	VersionPattern string `hcl:"version-pattern" help:"Regex with one capture group to extract the version number from the origin." default:"v?(.*)"`
+	VersionPattern string `hcl:"version-pattern,optional" help:"Regex with one capture group to extract the version number from the origin." default:"v?(.*)"`
 }
 
 // PlatformBlock matches a set of attributes describing a platform (eg. CPU, OS, etc.)

--- a/manifest/infer.go
+++ b/manifest/infer.go
@@ -38,7 +38,8 @@ func InferFromArtefact(p *ui.UI, httpClient *http.Client, ghClient *github.Clien
 	}
 	// Pull description from GH API if possible.
 	description := ""
-	if repoName := ghClient.ProjectForURL(url); repoName != "" {
+	repoName := ghClient.ProjectForURL(url)
+	if repoName != "" {
 		repo, err := ghClient.Repo(repoName)
 		if err != nil {
 			return nil, errors.WithStack(err)
@@ -87,6 +88,10 @@ func InferFromArtefact(p *ui.UI, httpClient *http.Client, ghClient *github.Clien
 		},
 		Versions: []VersionBlock{{
 			Version: []string{version},
+			AutoVersion: &AutoVersionBlock{
+				GitHubRelease:  repoName,
+				VersionPattern: "v?(.*)", // This is the default, which prevents the attribute being serialised.
+			},
 		}},
 	}, nil
 }

--- a/manifest/infer_test.go
+++ b/manifest/infer_test.go
@@ -39,6 +39,10 @@ func TestInfer(t *testing.T) {
 		},
 		Versions: []VersionBlock{{
 			Version: []string{"0.1.1"},
+			AutoVersion: &AutoVersionBlock{
+				GitHubRelease:  "",
+				VersionPattern: "v?(.*)",
+			},
 		}},
 	}
 	require.Equal(t, expected, actual)


### PR DESCRIPTION
Which results in a change from this:

    // Relative glob from $root to individual terminal binaries.
    binaries = []

    // Platform-specific configuration. <attr> is a set regexes that must all match against one of CPU, OS, etc..
    platform "darwin" "amd64" {
      // URL for source package. Valid URLs are Git repositories (using .git suffix), Local Files (using file:// prefix), and Remote Files (using http:// or https:// prefix)
      source = "https://github.com/lima-vm/lima/releases/download/v${version}/lima-${version}-${os}-${xarch}.tar.gz"
    }

    // Platform-specific configuration. <attr> is a set regexes that must all match against one of CPU, OS, etc..
    platform "darwin" "arm64" {
      // URL for source package. Valid URLs are Git repositories (using .git suffix), Local Files (using file:// prefix), and Remote Files (using http:// or https:// prefix)
      source = "https://github.com/lima-vm/lima/releases/download/v${version}/lima-${version}-${os}-x86_64.tar.gz"
    }

    // Platform-specific configuration. <attr> is a set regexes that must all match against one of CPU, OS, etc..
    platform "linux" "amd64" {
      // URL for source package. Valid URLs are Git repositories (using .git suffix), Local Files (using file:// prefix), and Remote Files (using http:// or https:// prefix)
      source = "https://github.com/lima-vm/lima/releases/download/v${version}/lima-${version}-${os}-${xarch}.tar.gz"
    }

    // Human readable description of the package.
    description = "Linux virtual machines, on macOS (aka \"Linux-on-Mac\", \"macOS subsystem for Linux\", \"containerd for Mac\", unofficially)"

    // Definition of and configuration for a specific version.
    version "0.6.4" {
      // Automatically update versions.
      auto-version {
      }
    }

to this:

    binaries = []

    platform "darwin" "amd64" {
      source = "https://github.com/lima-vm/lima/releases/download/v${version}/lima-${version}-${os}-${xarch}.tar.gz"
    }

    platform "darwin" "arm64" {
      source = "https://github.com/lima-vm/lima/releases/download/v${version}/lima-${version}-${os}-x86_64.tar.gz"
    }

    platform "linux" "amd64" {
      source = "https://github.com/lima-vm/lima/releases/download/v${version}/lima-${version}-${os}-${xarch}.tar.gz"
    }

    description = "Linux virtual machines, on macOS (aka \"Linux-on-Mac\", \"macOS subsystem for Linux\", \"containerd for Mac\", unofficially)"

    version "0.6.4" {
      auto-version {
        github-release = "lima-vm/lima"
      }
    }