### PR TITLE
Prevent code spans from wrapping in tables.

### DIFF
--- a/docs/themes/geekdoc/static/custom.css
+++ b/docs/themes/geekdoc/static/custom.css
@@ -1,1 +1,4 @@
 /* You can add custom styles here. */
+table code {
+	white-space: nowrap;
+}


### PR DESCRIPTION
Rendering as this:
![image](https://user-images.githubusercontent.com/41767/139960765-f1b09c84-9882-4452-809d-289761e8de69.png)

Instead of this:
![image](https://user-images.githubusercontent.com/41767/139960814-625b6d78-be2a-4891-9b04-0ebf8f2f7082.png)
