### PR TITLE
Fail hermit install if the packages can not be installed due to failure to sync sources

### DIFF
--- a/app/exec_cmd.go
+++ b/app/exec_cmd.go
@@ -71,7 +71,7 @@ func (e *execCmd) Run(l *ui.UI, sta *state.State, env *hermit.Env, globalState G
 	if err := pkg.EnsureSupported(); err != nil {
 		return errors.Wrapf(err, "execution failed")
 	}
-	installed, err := env.ListInstalled(l)
+	installed, err := env.ListInstalledReferences()
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/env.go
+++ b/env.go
@@ -1145,9 +1145,9 @@ func (e *Env) Sources(l *ui.UI) ([]string, error) {
 }
 
 // ResolveWithDeps collect packages and their dependencies based on the given manifest.Selector into a map
-func (e *Env) ResolveWithDeps(l *ui.UI, installed manifest.Packages, selector manifest.Selector, out map[string]*manifest.Package) (err error) {
+func (e *Env) ResolveWithDeps(l *ui.UI, installed []manifest.Reference, selector manifest.Selector, out map[string]*manifest.Package) (err error) {
 	for _, existing := range installed {
-		if existing.Reference.String() == selector.Name() {
+		if existing.String() == selector.Name() {
 			return nil
 		}
 	}

--- a/env_test.go
+++ b/env_test.go
@@ -433,7 +433,7 @@ func TestDependencyResolution(t *testing.T) {
 	_, err = f.Env.Install(f.P, pkg)
 	require.NoError(t, err)
 
-	installed, err := f.Env.ListInstalled(f.P)
+	installed, err := f.Env.ListInstalledReferences()
 	require.NoError(t, err)
 
 	// Test that dependencies can be resolved based on the package name


### PR DESCRIPTION
Fixes https://github.com/cashapp/hermit/issues/143

Previously, when running `hermit install` and the sources could not be cloned, the return code was a success. This is because we were resolving installed packages, and ignoring the resolution errors at `ListInstalled`. This then marked the source as synchronised, and it was not attempted again. `ListInstalled` then returned 0 packages, and the execution was a success.

After this fix:
```
./bin/hermit install               

error:https://github.com/cashapp/hermit-packages.git: Cloning into '/Users/juho/Library/Caches/hermit/sources/6682e3c492bdd27fac0db80685cb1df7bd13fda32bb9765ca15e895df13eb3cc-113676931'...
fatal: unable to access 'https://github.com/cashapp/hermit-packages.git/': Could not resolve host: github.com

fatal:hermit: git sync failed: git clone --depth=1 https://github.com/cashapp/hermit-packages.git /Users/juho/Library/Caches/hermit/sources/6682e3c492bdd27fac0db80685cb1df7bd13fda32bb9765ca15e895df13eb3cc-113676931 failed: exit status 128
```

This also avoids resolving installed packages unnecessarily, when just the reference is needed.