### PR TITLE
Fix binary execution in symlinked environment

### DIFF
--- a/env.go
+++ b/env.go
@@ -169,7 +169,10 @@ func EnvDirFromProxyLink(executable string) (string, error) {
 	if err != nil {
 		return "", errors.WithStack(err)
 	}
-	last := links[len(links)-1]
+	last, err := filepath.EvalSymlinks(links[len(links)-1])
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
 	if filepath.Base(last) != "hermit" {
 		return "", errors.Errorf("binary is not a Hermit symlink: %s", links[0])
 	}

--- a/it/full/spec/it_spec.sh
+++ b/it/full/spec/it_spec.sh
@@ -213,4 +213,16 @@ Describe "Hermit"
       The stderr should be blank
     End
   End
+
+  Describe "Environments with symbolic links in the path"
+    ln -s . ./symlinked
+    cd ./symlinked
+    . bin/activate-hermit
+    It "Allows calling binaries in the environment"
+      When call ./bin/testbin1
+      The status should be success
+      The stdout should not be blank
+      The stderr should be blank
+    End
+  End
 End


### PR DESCRIPTION
Fixes this error when executing Hermit binaries in a symlinked environment:
```
fatal:hermit: can not execute a Hermit managed binary from a non active environment
```

Fixes https://github.com/cashapp/hermit/issues/149