### PR TITLE
Support multiple installed channels + Homebrew.

### DIFF
--- a/bin/gendocs
+++ b/bin/gendocs
@@ -1,0 +1,3 @@
+#!/bin/bash
+# go-main-stubs stub script
+exec "$(dirname $0)/go" run github.com/cashapp/hermit/cmd/gendocs "$@"

--- a/bin/geninstaller
+++ b/bin/geninstaller
@@ -1,0 +1,3 @@
+#!/bin/bash
+# go-main-stubs stub script
+exec "$(dirname $0)/go" run github.com/cashapp/hermit/cmd/geninstaller "$@"

--- a/bin/go-main-stubs
+++ b/bin/go-main-stubs
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+#
+# This script generates stub scripts for every Go "main" package in this
+# repository. These stubs execute the corresponding main package via "go run".
+#
+
+set -euo pipefail
+
+usage() {
+  echo "$(basename $0) [-c] -- create or clean Go main stub scripts"
+  exit 1
+}
+
+bindir="$(dirname $0)"
+root="$(dirname "${bindir}")"
+
+clean() {
+  grep -l "^# go-main-stubs stub script" "${bindir}"/* | grep -v bin/go-main-stubs | xargs rm || true
+}
+
+while getopts ":hc" arg; do
+  case $arg in
+    c)
+      echo "Cleaning old stubs"
+      clean
+      exit 0
+      ;;
+    h | *)
+      usage
+      exit 0
+      ;;
+  esac
+done
+
+clean
+
+echo "Creating Go main stubs in ${bindir}"
+
+echo -n .
+
+for main in $(cd "${root}" && go list -f '{{if eq "main" .Name}}{{.ImportPath}}{{end}}' ./...); do
+  stub_script="${bindir}/$(basename $main)"
+  cat << EOF > ${stub_script}
+#!/bin/bash
+# go-main-stubs stub script
+exec "\$(dirname \$0)/go" run $main "\$@"
+EOF
+  chmod +x "${stub_script}"
+  echo -n .
+done
+echo

--- a/cmd/geninstaller/install.sh.tmpl
+++ b/cmd/geninstaller/install.sh.tmpl
@@ -5,9 +5,9 @@
 # SC2018: Use '[:lower:]' to support accents and foreign alphabets.
 
 
-set -eo pipefail
+set -euo pipefail
 
-if [ -z "${HERMIT_STATE_DIR}" ]; then
+if [ -z "${HERMIT_STATE_DIR:-}" ]; then
   case "$(uname -s)" in
   Darwin)
     HERMIT_STATE_DIR_RAW="\${HOME}/Library/Caches/hermit"
@@ -33,63 +33,93 @@ HERMIT_CHANNEL="$(basename "${HERMIT_DIST_URL}")"
 HERMIT_EXE_RAW="${HERMIT_STATE_DIR_RAW}/pkg/hermit@${HERMIT_CHANNEL}/hermit"
 eval HERMIT_EXE="\${HERMIT_EXE:-${HERMIT_EXE_RAW}}"
 HERMIT_EXE_DIR="$(dirname "${HERMIT_EXE}")"
-HERMIT_BIN_INSTALL_DIR="${HERMIT_BIN_INSTALL_DIR:-${HOME}/bin}"
 
 ID_USER=$(id -u)
 ID_GROUP=$(id -g)
 
-for dir in "${HERMIT_EXE_DIR}" "${HERMIT_STATE_DIR}"; do
-  if [ ! -e "${dir}" ]; then
-    echo "Creating ${dir}"
-    mkdir -p "${dir}"
-    chown "$ID_USER:$ID_GROUP" "${dir}"
+function user_install() {
+  for dir in "${HERMIT_EXE_DIR}" "${HERMIT_STATE_DIR}"; do
+    if [ ! -e "${dir}" ]; then
+      echo "Creating ${dir}"
+      mkdir -p "${dir}"
+      chown "$ID_USER:$ID_GROUP" "${dir}"
+    fi
+
+    if [ ! -w "${dir}" ]; then
+      echo "${dir} is not writeable, making it so"
+      chown "$ID_USER:$ID_GROUP" "${dir}"
+      chmod u+w "${dir}"
+    fi
+  done
+
+  OS="$(uname -s | tr A-Z a-z)"
+  ARCH="$(uname -m | tr A-Z a-z)"
+  if [ "$ARCH" = "x86_64" ]; then
+    ARCH="amd64"
+  fi
+  URL="${HERMIT_DIST_URL}/hermit-${OS}-${ARCH}.gz"
+  TMP_FILE="${HERMIT_EXE}.download.${RANDOM}"
+  echo "Downloading ${URL} to ${HERMIT_EXE}"
+  chmod -f u+w "${HERMIT_EXE}" 2> /dev/null || true
+  curl -fsSL "${URL}" | gzip -dc > "${TMP_FILE}"
+  chown "$ID_USER:$ID_GROUP" "${TMP_FILE}"
+  chmod u+wx "${TMP_FILE}"
+  mv "${TMP_FILE}" "${HERMIT_EXE}"
+
+  echo "Hermit installed as ${HERMIT_EXE}"
+}
+
+# Install system-wide components
+function system_install() {
+  local HERMIT_INSTALL_NAME=hermit-${HERMIT_CHANNEL}
+  local CREATE_SYMLINK=1
+  # If HERMIT_BIN_INSTALL_DIR is not set, see if we can detect where Hermit was previously installed.
+  if [ -z "${HERMIT_BIN_INSTALL_DIR:-}" ]; then
+    for dir in {{.InstallPaths|words}}; do
+      # shellcheck disable=SC2016
+      if test -x "${dir}/hermit" && grep -Fq ': "${HERMIT' "${dir}/hermit"; then
+        if ! grep -q '{{.DistURL}}' "${dir}/hermit"; then
+          echo "Found Hermit in ${dir}/hermit but it is a different distribution, not overwriting."
+          CREATE_SYMLINK=
+        fi
+        rm "${HERMIT_BIN_INSTALL_DIR}/hermit"
+        HERMIT_BIN_INSTALL_DIR="${dir}"
+        break
+      fi
+    done
+    HERMIT_BIN_INSTALL_DIR="${HERMIT_BIN_INSTALL_DIR:-${HOME}/bin}"
+  fi
+  if [ ! -d "$HERMIT_BIN_INSTALL_DIR" ]; then
+    echo "NOTE: $HERMIT_BIN_INSTALL_DIR should be added to your \$PATH if it is not already"
+    mkdir -p "$HERMIT_BIN_INSTALL_DIR"
   fi
 
-  if [ ! -w "${dir}" ]; then
-    echo "${dir} is not writeable, making it so"
-    chown "$ID_USER:$ID_GROUP" "${dir}"
-    chmod u+w "${dir}"
+  if [ -e "$HERMIT_BIN_INSTALL_DIR/$HERMIT_INSTALL_NAME" ]; then
+    echo "Removing the previous $HERMIT_BIN_INSTALL_DIR/$HERMIT_INSTALL_NAME"
+    rm -f "$HERMIT_BIN_INSTALL_DIR/$HERMIT_INSTALL_NAME"
   fi
-done
-
-OS="$(uname -s | tr A-Z a-z)"
-ARCH="$(uname -m | tr A-Z a-z)"
-if [ "$ARCH" = "x86_64" ]; then
-  ARCH="amd64"
-fi
-URL="${HERMIT_DIST_URL}/hermit-${OS}-${ARCH}.gz"
-TMP_FILE="${HERMIT_EXE}.download.${RANDOM}"
-echo "Downloading ${URL} to ${HERMIT_EXE}"
-chmod -f u+w "${HERMIT_EXE}" 2> /dev/null || true
-curl -fsSL "${URL}" | gzip -dc > "${TMP_FILE}"
-chown "$ID_USER:$ID_GROUP" "${TMP_FILE}"
-chmod u+wx "${TMP_FILE}"
-mv "${TMP_FILE}" "${HERMIT_EXE}"
-
-echo "Hermit installed as ${HERMIT_EXE}"
-
-if [ ! -d "$HERMIT_BIN_INSTALL_DIR" ]; then
-  echo "NOTE: $HERMIT_BIN_INSTALL_DIR should be added to your \$PATH if it is not already"
-  mkdir -p "$HERMIT_BIN_INSTALL_DIR"
-fi
-
-if [ -e "$HERMIT_BIN_INSTALL_DIR/hermit" ]; then
-  echo "Removing the previous $HERMIT_BIN_INSTALL_DIR/hermit"
-  rm -f "$HERMIT_BIN_INSTALL_DIR/hermit"
-fi
-echo "Linking hermit to $HERMIT_BIN_INSTALL_DIR/hermit"
-cat > "$HERMIT_BIN_INSTALL_DIR/hermit" << EOF
+  cat > "$HERMIT_BIN_INSTALL_DIR/$HERMIT_INSTALL_NAME" << EOF
 #!/bin/bash
 : "\${HERMIT_EXE:=${HERMIT_EXE_RAW}}"
 test -x \${HERMIT_EXE} && exec "\${HERMIT_EXE}" "\$@"
 (curl -fsSL "${HERMIT_DIST_URL}/install.sh" | bash) && exec "\${HERMIT_EXE}" "\$@"
 EOF
-chmod +x "$HERMIT_BIN_INSTALL_DIR/hermit"
-
-cat <<-EOF
-
-Hermit is installed as $HERMIT_BIN_INSTALL_DIR/hermit!
+  chmod +x "$HERMIT_BIN_INSTALL_DIR/$HERMIT_INSTALL_NAME"
+  if [ -n "${CREATE_SYMLINK}" ]; then
+    echo "Hermit is installed as $HERMIT_BIN_INSTALL_DIR/hermit"
+    ln -fs "$HERMIT_INSTALL_NAME" "$HERMIT_BIN_INSTALL_DIR/hermit"
+  else
+    echo "Hermit is installed as $HERMIT_BIN_INSTALL_DIR/$HERMIT_INSTALL_NAME"
+  fi
+  cat <<-EOF
 
 See https://cashapp.github.io/hermit/usage/get-started/ for more information.
 
 EOF
+}
+
+# Used by system-wide package managers (eg. Homebrew)
+if [ -z "${HERMIT_SKIP_USER_INSTALL:-}" ]; then
+  user_install
+fi
+system_install

--- a/cmd/geninstaller/main.go
+++ b/cmd/geninstaller/main.go
@@ -4,6 +4,7 @@ import (
 	_ "embed" // Embedding.
 	"fmt"
 	"os"
+	"strings"
 	"text/template"
 
 	"github.com/alecthomas/hcl"
@@ -16,13 +17,15 @@ var (
 	installerTemplateSource string
 	installerTemplate       = template.Must(template.New("install.sh").Funcs(template.FuncMap{
 		"string": func(b []byte) string { return string(b) },
+		"words":  func(s []string) string { return strings.Join(s, " ") },
 	}).Parse(installerTemplateSource))
 )
 
 var cli struct {
-	Schema  bool   `help:"Display the global schema."`
-	Dest    string `required:"" placeholder:"FILE" help:"Where to write the installer script."`
-	DistURL string `required:"" placeholder:"URL" help:"Base distribution URL."`
+	Schema       bool     `help:"Display the global schema."`
+	Dest         string   `required:"" placeholder:"FILE" help:"Where to write the installer script."`
+	DistURL      string   `required:"" placeholder:"URL" help:"Base distribution URL."`
+	InstallPaths []string `placeholder:"PATH" help:"Possible system-wide installation paths." default:"$${HOME}/bin,/opt/homebrew/bin,/usr/local/bin"`
 }
 
 func main() {

--- a/github/api.go
+++ b/github/api.go
@@ -99,20 +99,20 @@ func (a *Client) Download(asset Asset) (resp *http.Response, err error) {
 func (a *Client) decode(url string, dest interface{}) error {
 	req, err := a.request(url, http.Header{})
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.Wrap(err, url)
 	}
 	resp, err := a.client.Do(req)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.Wrap(err, url)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return errors.Errorf("GitHub API request failed with %s", resp.Status)
+		return errors.Errorf("%s: GitHub API request failed with %s", url, resp.Status)
 	}
 	dec := json.NewDecoder(resp.Body)
 	err = dec.Decode(dest)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.Wrap(err, url)
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/alecthomas/colour v0.1.0
 	github.com/alecthomas/hcl v0.1.17
-	github.com/alecthomas/kong v0.2.18-0.20210713035501-d1a818b5a1a8
+	github.com/alecthomas/kong v0.2.20
 	github.com/alecthomas/participle v0.6.1-0.20200911005820-318127ca69ac
 	github.com/alecthomas/repr v0.0.0-20200325044227-4184120f674c
 	github.com/avvmoto/buf-readerat v0.0.0-20171115124131-a17c8cb89270

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/alecthomas/colour v0.1.0/go.mod h1:QO9JBoKquHd+jz9nshCh40fOfO+JzsoXy8
 github.com/alecthomas/hcl v0.1.17 h1:p2GTPQG9EcCCnSF60XsDVMyRWh0mkcuN2nobSiKsrkE=
 github.com/alecthomas/hcl v0.1.17/go.mod h1:VEYcgruQ39ELu6c0Bb+VRm3trQPt7dQUdAwF7QrG7AQ=
 github.com/alecthomas/kong v0.2.2/go.mod h1:kQOmtJgV+Lb4aj+I2LEn40cbtawdWJ9Y8QLq+lElKxE=
-github.com/alecthomas/kong v0.2.18-0.20210713035501-d1a818b5a1a8 h1:FQGpNQn+YtyEiECNxpdrWUqiCX6++xcVj+BxmKPw/D4=
-github.com/alecthomas/kong v0.2.18-0.20210713035501-d1a818b5a1a8/go.mod h1:ka3VZ8GZNPXv9Ov+j4YNLkI8mTuhXyr/0ktSlqIydQQ=
+github.com/alecthomas/kong v0.2.20 h1:j8icvBJGdkkvv4lZ8rWN9MF5Z9DWBEmQrjZ69Z8XFwM=
+github.com/alecthomas/kong v0.2.20/go.mod h1:ka3VZ8GZNPXv9Ov+j4YNLkI8mTuhXyr/0ktSlqIydQQ=
 github.com/alecthomas/participle v0.6.1-0.20200911005820-318127ca69ac h1:E1/zcnJ3CYONnRq6v5mR4NnyimIJHHIVu+EFdFLK3d4=
 github.com/alecthomas/participle v0.6.1-0.20200911005820-318127ca69ac/go.mod h1:HfdmEuwvr12HXQN44HPWXR0lHmVolVYe4dyL6lQ3duY=
 github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=


### PR DESCRIPTION
The first version installed will be installed as `~/bin/hermit` and
`~/bin/hermit-<channel>`. Subsequent channels will be installed just as
`~/bin/hermit-<channel>`.

Homebrew is supported by trying /opt/homebrew/bin and /usr/local/bin
before ~/bin.