### PR TITLE
Factor cache construction out of the Env constructor.

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -214,7 +214,11 @@ func Main(config Config) {
 		downloadStrategies = append(downloadStrategies, cache.GitHubPrivateReleaseDownloadStrategy(ghClient))
 	}
 
-	sta, err = state.Open(hermit.UserStateDir, config.State, downloadStrategies, defaultHTTPClient, config.fastHTTPClient())
+	cache, err := cache.Open(hermit.UserStateDir, downloadStrategies, defaultHTTPClient, config.fastHTTPClient())
+	if err != nil {
+		log.Fatalf("failed to open cache: %s", err)
+	}
+	sta, err = state.Open(hermit.UserStateDir, config.State, cache)
 	if err != nil {
 		log.Fatalf("failed to open state: %s", err)
 	}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -40,18 +40,21 @@ func BasePath(checksum, uri string) string {
 
 // Open or create a Cache at the given directory, using the given http client.
 //
+// "stateDir" is the root of the Hermit state directory.
+//
 // "fastFailClient" is a HTTP client configured to fail quickly if a remote
 // server is unavailable, for use in optional checks.
 //
 // "strategies" are used to download URLS, attempted in order.
 // A default raw HTTP download strategy will always be the first strategy attempted.
-func Open(root string, strategies []DownloadStrategy, client *http.Client, fastFailClient *http.Client) (*Cache, error) {
-	err := os.MkdirAll(root, os.ModePerm)
+func Open(stateDir string, strategies []DownloadStrategy, client *http.Client, fastFailClient *http.Client) (*Cache, error) {
+	stateDir = filepath.Join(stateDir, "cache")
+	err := os.MkdirAll(stateDir, os.ModePerm)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	c := &Cache{
-		root:               root,
+		root:               stateDir,
 		httpClient:         client,
 		fastFailHTTPClient: fastFailClient,
 	}

--- a/hermittest/envfixture.go
+++ b/hermittest/envfixture.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cashapp/hermit/cache"
 	"github.com/cashapp/hermit/envars"
 	"github.com/cashapp/hermit/sources"
 	"github.com/cashapp/hermit/vfs"
@@ -53,10 +54,12 @@ func NewEnvTestFixture(t *testing.T, handler http.Handler) *EnvTestFixture {
 
 	server := httptest.NewServer(handler)
 	client := server.Client()
+	cache, err := cache.Open(stateDir, nil, client, client)
+	require.NoError(t, err)
 	sta, err := state.Open(stateDir, state.Config{
 		Sources: []string{},
 		Builtin: sources.NewBuiltInSource(vfs.InMemoryFS(nil)),
-	}, nil, client, client)
+	}, cache)
 	require.NoError(t, err)
 	env, err := hermit.OpenEnv(envDir, sta, envars.Envars{}, server.Client())
 	require.NoError(t, err)

--- a/state/state.go
+++ b/state/state.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -66,7 +65,9 @@ type State struct {
 }
 
 // Open the global Hermit state.
-func Open(stateDir string, config Config, downloadStrategies []cache.DownloadStrategy, client *http.Client, fastFailClient *http.Client) (*State, error) {
+//
+// See cache.Open for details on downloadStrategies.
+func Open(stateDir string, config Config, cache *cache.Cache) (*State, error) {
 	if config.Builtin == nil {
 		return nil, errors.Errorf("state.Config.Builtin not provided")
 	}
@@ -75,11 +76,6 @@ func Open(stateDir string, config Config, downloadStrategies []cache.DownloadStr
 	cacheDir := filepath.Join(stateDir, "cache")
 	sourcesDir := filepath.Join(stateDir, "sources")
 	binaryDir := filepath.Join(stateDir, "binaries")
-	cache, err := cache.Open(cacheDir, downloadStrategies, client, fastFailClient)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
 	dao := dao.Open(stateDir)
 	if config.Sources == nil {
 		config.Sources = DefaultSources

--- a/state/stateutils_test.go
+++ b/state/stateutils_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cashapp/hermit/cache"
 	"github.com/cashapp/hermit/sources"
 	"github.com/cashapp/hermit/state"
 	"github.com/cashapp/hermit/ui"
@@ -65,9 +66,11 @@ func (f *StateTestFixture) State() *state.State {
 	}
 	f.roots[root] = true
 	client := f.Server.Client()
+	cache, err := cache.Open(root, nil, client, client)
+	require.NoError(f.t, err)
 	sta, err := state.Open(root, state.Config{
 		Builtin: sources.NewBuiltInSource(vfs.InMemoryFS(nil)),
-	}, nil, client, client)
+	}, cache)
 	require.NoError(f.t, err)
 	return sta
 }


### PR DESCRIPTION
The majority of the arguments being passed into the env.Open() were for
the cache, which was a bit icky.