### PR TITLE
Include command output when test fails.

### DIFF
--- a/env.go
+++ b/env.go
@@ -434,13 +434,17 @@ func (e *Env) Test(l *ui.UI, pkg *manifest.Package) error {
 	if !found {
 		return errors.Errorf("couldn't find test executable %q in package %s", args[0], pkg)
 	}
-	cmd, _ := util.Command(task, args...)
+	cmd, out := util.Command(task, args...)
 	deps, err := e.ensureRuntimeDepsPresent(l, pkg)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 	cmd.Env = e.allEnvarsForPackages(true, deps, pkg)
-	return cmd.Run()
+	err = cmd.Run()
+	if err != nil {
+		return errors.Wrap(err, out.String())
+	}
+	return nil
 }
 
 // Unpack but do not install package.


### PR DESCRIPTION
Fixes #171

Looks like this:
```
🐚 ~/…/hermit/packages $ go run ../cmd/hermit test bash                                                                                                                                                           aat/test-shows-output 2921ms
fatal:hermit: /Users/aat/Library/Caches/hermit/pkg/bash-5.1/bash: --missing-flag: invalid option
Usage:	/Users/aat/Library/Caches/hermit/pkg/bash-5.1/bash [GNU long option] [option] ...
	/Users/aat/Library/Caches/hermit/pkg/bash-5.1/bash [GNU long option] [option] script-file ...
GNU long options:
	--debug
	--debugger
	--dump-po-strings
	--dump-strings
	--help
	--init-file
	--login
	--noediting
	--noprofile
	--norc
	--posix
	--pretty-print
	--rcfile
	--restricted
	--verbose
	--version
Shell options:
	-ilrsD or -c command or -O shopt_option		(invocation only)
	-abefhkmnptuvxBCHP or -o option
: exit status 2
```