### PR TITLE
Add support for package defined local vars.

### DIFF
--- a/docs/content/packaging/schema/auto-version.md
+++ b/docs/content/packaging/schema/auto-version.md
@@ -1,6 +1,6 @@
 +++
 title = "version > auto-version"
-weight = 414
+weight = 415
 +++
 
 Automatically update versions.
@@ -8,9 +8,15 @@ Automatically update versions.
 Used by: [version](../version#blocks)
 
 
+## Blocks
+
+| Block  | Description |
+|--------|-------------|
+| [`html { … }`](../html) | Extract version information from a HTML URL using XPath. |
+
 ## Attributes
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
-| `github-release` | `string` | GitHub &lt;user&gt;/&lt;repo&gt; to retrieve and update versions from the releases API. |
+| `github-release` | `string?` | GitHub &lt;user&gt;/&lt;repo&gt; to retrieve and update versions from the releases API. |
 | `version-pattern` | `string?` | Regex with one capture group to extract the version number from the origin. |

--- a/docs/content/packaging/schema/channel.md
+++ b/docs/content/packaging/schema/channel.md
@@ -1,6 +1,6 @@
 +++
 title = "channel <name>"
-weight = 404
+weight = 405
 +++
 
 Definition of and configuration for an auto-update channel.
@@ -38,4 +38,5 @@ Used by: [&lt;manifest>](../manifest#blocks)
 | `strip` | `number?` | Number of path prefix elements to strip. |
 | `test` | `string?` | Command that will test the package is operational. |
 | `update` | `string` | Update frequency for this channel. |
+| `vars` | `{string: string}?` | Set local variables used during manifest evaluation. |
 | `version` | `string?` | Use the latest version matching this version glob as the source of this channel. Empty string matches all versions |

--- a/docs/content/packaging/schema/chmod.md
+++ b/docs/content/packaging/schema/chmod.md
@@ -1,6 +1,6 @@
 +++
 title = "on > chmod"
-weight = 407
+weight = 408
 +++
 
 Change a files mode.

--- a/docs/content/packaging/schema/copy.md
+++ b/docs/content/packaging/schema/copy.md
@@ -1,6 +1,6 @@
 +++
 title = "on > copy"
-weight = 408
+weight = 409
 +++
 
 A file to copy when the event is triggered.

--- a/docs/content/packaging/schema/darwin.md
+++ b/docs/content/packaging/schema/darwin.md
@@ -1,6 +1,6 @@
 +++
 title = "darwin"
-weight = 402
+weight = 403
 +++
 
 Darwin-specific configuration.
@@ -37,3 +37,4 @@ Used by: [channel](../channel#blocks) [linux](../linux#blocks) [&lt;manifest>](.
 | `source` | `string?` | URL for source package. Valid URLs are Git repositories (using .git[#&lt;tag&gt;] suffix), Local Files (using file:// prefix), and Remote Files (using http:// or https:// prefix) |
 | `strip` | `number?` | Number of path prefix elements to strip. |
 | `test` | `string?` | Command that will test the package is operational. |
+| `vars` | `{string: string}?` | Set local variables used during manifest evaluation. |

--- a/docs/content/packaging/schema/delete.md
+++ b/docs/content/packaging/schema/delete.md
@@ -1,6 +1,6 @@
 +++
 title = "on > delete"
-weight = 409
+weight = 410
 +++
 
 Delete files.

--- a/docs/content/packaging/schema/html.md
+++ b/docs/content/packaging/schema/html.md
@@ -1,0 +1,16 @@
++++
+title = "auto-version > html"
+weight = 402
++++
+
+Extract version information from a HTML URL using XPath.
+
+Used by: [auto-version](../auto-version#blocks)
+
+
+## Attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `url` | `string` | URL to retrieve HTML from. |
+| `xpath` | `string` | XPath for extracting versions from HTML (see https://github.com/antchfx/htmlquery) |

--- a/docs/content/packaging/schema/linux.md
+++ b/docs/content/packaging/schema/linux.md
@@ -1,6 +1,6 @@
 +++
 title = "linux"
-weight = 403
+weight = 404
 +++
 
 Linux-specific configuration.
@@ -37,3 +37,4 @@ Used by: [channel](../channel#blocks) [darwin](../darwin#blocks) [&lt;manifest>]
 | `source` | `string?` | URL for source package. Valid URLs are Git repositories (using .git[#&lt;tag&gt;] suffix), Local Files (using file:// prefix), and Remote Files (using http:// or https:// prefix) |
 | `strip` | `number?` | Number of path prefix elements to strip. |
 | `test` | `string?` | Command that will test the package is operational. |
+| `vars` | `{string: string}?` | Set local variables used during manifest evaluation. |

--- a/docs/content/packaging/schema/manifest.md
+++ b/docs/content/packaging/schema/manifest.md
@@ -40,3 +40,4 @@ Each Hermit package manifest is a nested structure containing OS/architecture-sp
 | `source` | `string?` | URL for source package. Valid URLs are Git repositories (using .git[#&lt;tag&gt;] suffix), Local Files (using file:// prefix), and Remote Files (using http:// or https:// prefix) |
 | `strip` | `number?` | Number of path prefix elements to strip. |
 | `test` | `string?` | Command that will test the package is operational. |
+| `vars` | `{string: string}?` | Set local variables used during manifest evaluation. |

--- a/docs/content/packaging/schema/message.md
+++ b/docs/content/packaging/schema/message.md
@@ -1,6 +1,6 @@
 +++
 title = "on > message"
-weight = 410
+weight = 411
 +++
 
 Display a message to the user.

--- a/docs/content/packaging/schema/on.md
+++ b/docs/content/packaging/schema/on.md
@@ -1,6 +1,6 @@
 +++
 title = "on <event>"
-weight = 406
+weight = 407
 +++
 
 Triggers to run on lifecycle events.

--- a/docs/content/packaging/schema/platform.md
+++ b/docs/content/packaging/schema/platform.md
@@ -1,6 +1,6 @@
 +++
 title = "platform <attr>"
-weight = 413
+weight = 414
 +++
 
 Platform-specific configuration. &lt;attr&gt; is a set regexes that must all match against one of CPU, OS, etc..
@@ -37,3 +37,4 @@ Used by: [channel](../channel#blocks) [darwin](../darwin#blocks) [linux](../linu
 | `source` | `string?` | URL for source package. Valid URLs are Git repositories (using .git[#&lt;tag&gt;] suffix), Local Files (using file:// prefix), and Remote Files (using http:// or https:// prefix) |
 | `strip` | `number?` | Number of path prefix elements to strip. |
 | `test` | `string?` | Command that will test the package is operational. |
+| `vars` | `{string: string}?` | Set local variables used during manifest evaluation. |

--- a/docs/content/packaging/schema/rename.md
+++ b/docs/content/packaging/schema/rename.md
@@ -1,6 +1,6 @@
 +++
 title = "on > rename"
-weight = 411
+weight = 412
 +++
 
 Rename a file.

--- a/docs/content/packaging/schema/run.md
+++ b/docs/content/packaging/schema/run.md
@@ -1,6 +1,6 @@
 +++
 title = "on > run"
-weight = 412
+weight = 413
 +++
 
 A command to run when the event is triggered.

--- a/docs/content/packaging/schema/version.md
+++ b/docs/content/packaging/schema/version.md
@@ -1,6 +1,6 @@
 +++
 title = "version <version>"
-weight = 405
+weight = 406
 +++
 
 Definition of and configuration for a specific version.
@@ -38,3 +38,4 @@ Used by: [&lt;manifest>](../manifest#blocks)
 | `source` | `string?` | URL for source package. Valid URLs are Git repositories (using .git[#&lt;tag&gt;] suffix), Local Files (using file:// prefix), and Remote Files (using http:// or https:// prefix) |
 | `strip` | `number?` | Number of path prefix elements to strip. |
 | `test` | `string?` | Command that will test the package is operational. |
+| `vars` | `{string: string}?` | Set local variables used during manifest evaluation. |

--- a/manifest/config.go
+++ b/manifest/config.go
@@ -38,6 +38,7 @@ type Layer struct {
 	Root        string            `hcl:"root,optional" help:"Override root for package."`
 	Test        *string           `hcl:"test,optional" help:"Command that will test the package is operational."`
 	Env         envars.Envars     `hcl:"env,optional" help:"Environment variables to export."`
+	Vars        map[string]string `hcl:"vars,optional" help:"Set local variables used during manifest evaluation."`
 	Source      string            `hcl:"source,optional" help:"URL for source package. Valid URLs are Git repositories (using .git[#<tag>] suffix), Local Files (using file:// prefix), and Remote Files (using http:// or https:// prefix)"`
 	Mirrors     []string          `hcl:"mirrors,optional" help:"Mirrors to use if the primary source is unavailable."`
 	SHA256      string            `hcl:"sha256,optional" help:"SHA256 of source package for verification."`

--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -403,10 +403,14 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 		}
 	}
 
+	vars := map[string]string{}
 	layerEnvars := make([]envars.Envars, 0, len(layers))
 	for _, layer := range layers {
 		if len(layer.Env) > 0 {
 			layerEnvars = append(layerEnvars, layer.Env)
+		}
+		for k, v := range layer.Vars {
+			vars[k] = v
 		}
 		if layer.Arch != "" {
 			p.Arch = layer.Arch
@@ -516,6 +520,10 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 				return fmt.Sprintf("%02d", time.Now().Day())
 
 			default:
+				value, ok := vars[key]
+				if ok {
+					return value
+				}
 				if ignoreMissing {
 					return "${" + key + "}"
 				}

--- a/manifest/resolver_test.go
+++ b/manifest/resolver_test.go
@@ -268,6 +268,29 @@ func TestResolver_Resolve(t *testing.T) {
 		manifestErrors: map[string][]string{
 			"memory:///test.hcl": {`5:4: invalid label "event": invalid event "invalid"`},
 		},
+	}, {
+		name: "Local var interpolation",
+		files: map[string]string{
+			`test.hcl`: `
+			description = ""
+			binaries = ["bin"]
+
+			source = "www.example.com/${path}"
+
+			version "1.0.0" {
+				vars = {
+					path: "foo/bar",
+				}
+			}
+			`,
+		},
+		reference: "test-1.0.0",
+		wantPkg: manifesttest.NewPkgBuilder(config.State + "/pkg/test-1.0.0").
+			WithName("test").
+			WithBinaries("bin").
+			WithVersion("1.0.0").
+			WithSource("www.example.com/foo/bar").
+			Result(),
 	},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This removes a lot of boilerplate from packages with less 1:1 mappings of version to URL.

eg. This

```hcl
description = "A tool to format C/C++/Java/JavaScript/JSON/Objective-C/Protobuf/C# code."
binaries = ["clang-format"]

version "10.0.0-20211020" {
  platform linux {
    source = "https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-f3a37dd2/clang-format-10_linux-amd64"
    on unpack { rename { from = "${root}/clang-format-10_linux-amd64" to = "${root}/clang-format" } }
  }

  platform darwin {
    source = "https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-f3a37dd2/clang-format-10_macosx-amd64"
    on unpack { rename { from = "${root}/clang-format-10_macosx-amd64" to = "${root}/clang-format" } }
  }
}

version "11.0.0-20211020" {
  platform linux {
    source = "https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-f3a37dd2/clang-format-11_linux-amd64"
    on unpack { rename { from = "${root}/clang-format-11_linux-amd64" to = "${root}/clang-format" } }
  }

  platform darwin {
    source = "https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-f3a37dd2/clang-format-11_macosx-amd64"
    on unpack { rename { from = "${root}/clang-format-11_macosx-amd64" to = "${root}/clang-format" } }
  }
}

version "12.0.0-20211020" {
  vars = { hash: "f3a37dd2", release: "12" }
  platform linux {
    source = "https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-f3a37dd2/clang-format-12_linux-amd64"
    on unpack { rename { from = "${root}/clang-format-12_linux-amd64" to = "${root}/clang-format" } }
  }

  platform darwin {
    source = "https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-f3a37dd2/clang-format-12_macosx-amd64"
    on unpack { rename { from = "${root}/clang-format-12_macosx-amd64" to = "${root}/clang-format" } }
  }
}
```

Can become this:

```hcl
description = "A tool to format C/C++/Java/JavaScript/JSON/Objective-C/Protobuf/C# code."
binaries = ["clang-format"]

platform linux {
  source = "https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-${hash}/clang-format-${release}_linux-amd64"
  on unpack { rename { from = "${root}/clang-format-${release}_linux-amd64" to = "${root}/clang-format" } }
}

platform darwin {
  source = "https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-${hash}/clang-format-${release}_macosx-amd64"
  on unpack { rename { from = "${root}/clang-format-${release}_macosx-amd64" to = "${root}/clang-format" } }
}

version "10.0.0-20211020" {
  vars = { hash: "f3a37dd2", release: "10" }
}

version "11.0.0-20211020" {
  vars = { hash: "f3a37dd2", release: "11" }
}

version "12.0.0-20211020" {
  vars = { hash: "f3a37dd2", release: "12" }
}
```