### PR TITLE
fix: cleaning a version removes everything but the base version

### DIFF
--- a/manifest/version_test.go
+++ b/manifest/version_test.go
@@ -39,17 +39,29 @@ func TestParseReferences(t *testing.T) {
 func TestParseVersions(t *testing.T) {
 	tests := []struct {
 		version    string
+		clean      string
+		majorMinor string
+		major      string
 		parts      string
 		prerelease string
 		metadata   string
 	}{
-		{"1.2.3", "1.2.3", "", ""},
-		{"1.5.1-kotlin.3", "1.5.1", "kotlin.3", ""},
-		{"11.0.10_9", "11.0.10.9", "", ""},
+		{version: "1.2.3", clean: "1.2.3", majorMinor: "1.2",
+			major: "1", parts: "1.2.3"},
+		{version: "1.5.1-kotlin.3", clean: "1.5.1", majorMinor: "1.5-kotlin.3",
+			major: "1-kotlin.3", parts: "1.5.1", prerelease: "kotlin.3"},
+		{version: "11.0.10_9", clean: "11.0.10_9", majorMinor: "11.0",
+			major: "11", parts: "11.0.10.9"},
+		{version: "1.2.3+meta", clean: "1.2.3", majorMinor: "1.2+meta",
+			major: "1+meta", parts: "1.2.3", metadata: "meta"},
 	}
 	for _, test := range tests {
 		t.Run(test.version, func(t *testing.T) {
 			v := ParseVersion(test.version)
+			require.Equal(t, test.version, v.String())
+			require.Equal(t, test.clean, v.Clean().String())
+			require.Equal(t, test.majorMinor, v.MajorMinor().String())
+			require.Equal(t, test.major, v.Major().String())
 			require.Equal(t, test.parts, strings.Join(v.Components(), "."))
 			require.Equal(t, test.prerelease, v.Prerelease())
 			require.Equal(t, test.metadata, v.Metadata())


### PR DESCRIPTION
Previously, the "orig" field used by `Version.String()` used the original string, including prerelease and metadata. This resulted in channel synthesis failing with eg.

    warn: invalid manifest reference openjdk@17+arm64 in openjdk.hcl: @17+arm64: no version found matching 17+arm64.*
    warn: invalid manifest reference openjdk@17.0+arm64 in openjdk.hcl: @17.0+arm64: no version found matching 17.0+arm64.*

This change correctly clears the non-base version information.