### PR TITLE
feat: add "${name}"

### DIFF
--- a/docs/content/packaging/reference.md
+++ b/docs/content/packaging/reference.md
@@ -114,6 +114,7 @@ The available variables are:
 
 | Variable     | Description |
 |--------------|-------------|
+| `name`       | The name of the current package. |
 | `version`    | The version selected by the user. Does not apply when installing a channel. |
 | `dest`       | The directory where the archive will be extracted.<br/> Defaults to `<hermit-state>/pkg/<pkg-selector>`. |
 | `root`       | Directory considered the package root. Defaults to `${dest}`.

--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -480,6 +480,9 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 	mapping := func(ignoreMissing bool) func(s string) string {
 		return func(key string) string {
 			switch key {
+			case "name":
+				return found.Name
+
 			case "version":
 				return found.Version.String()
 


### PR DESCRIPTION
Useful for packages that are identical except name, eg. clang-format,
clang-tidy, etc. We can symlink the packages.