### PR TITLE
fix: many many bugs fixed and refactorings done

### DIFF
--- a/app/activate_cmd.go
+++ b/app/activate_cmd.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/cashapp/hermit"
+	"github.com/cashapp/hermit/cache"
 	"github.com/cashapp/hermit/envars"
 	"github.com/cashapp/hermit/manifest"
 	"github.com/cashapp/hermit/shell"
@@ -22,12 +23,12 @@ type activateCmd struct {
 	ShortPrompt bool   `help:"Use a minimal prompt in active environments." hidden:""`
 }
 
-func (a *activateCmd) Run(l *ui.UI, sta *state.State, globalState GlobalState, config Config, defaultClient *http.Client) error {
+func (a *activateCmd) Run(l *ui.UI, cache *cache.Cache, sta *state.State, globalState GlobalState, config Config, defaultClient *http.Client) error {
 	realdir, err := resolveActivationDir(a.Dir)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	env, err := hermit.OpenEnv(realdir, sta, globalState.Env, defaultClient)
+	env, err := hermit.OpenEnv(realdir, sta, cache.GetSource, globalState.Env, defaultClient)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/app/commands.go
+++ b/app/commands.go
@@ -30,7 +30,7 @@ type unactivated struct {
 	Debug       bool             `help:"Enable debug logging." short:"d"`
 	Trace       bool             `help:"Enable trace logging." short:"t"`
 	Quiet       bool             `help:"Disable logging and progress UI, except fatal errors." env:"HERMIT_QUIET" short:"q"`
-	Level       ui.Level         `help:"Set minimum log level." env:"HERMIT_LOG" default:"info" enum:"trace,debug,info,warn,error,fatal"`
+	Level       ui.Level         `help:"Set minimum log level (${enum})." env:"HERMIT_LOG" default:"auto" enum:"auto,trace,debug,info,warn,error,fatal"`
 	GlobalState
 
 	Init       initCmd       `cmd:"" help:"Initialise an environment (idempotent)." group:"env"`
@@ -56,7 +56,7 @@ func (u *unactivated) getMemProfile() string       { return u.MemProfile }
 func (u *unactivated) getTrace() bool              { return u.Trace }
 func (u *unactivated) getDebug() bool              { return u.Debug }
 func (u *unactivated) getQuiet() bool              { return u.Quiet }
-func (u *unactivated) getLevel() ui.Level          { return u.Level }
+func (u *unactivated) getLevel() ui.Level          { return ui.AutoLevel(u.Level) }
 func (u *unactivated) getGlobalState() GlobalState { return u.GlobalState }
 
 type activated struct {

--- a/app/exec_cmd.go
+++ b/app/exec_cmd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/cashapp/hermit"
+	"github.com/cashapp/hermit/cache"
 	"github.com/cashapp/hermit/manifest"
 	"github.com/cashapp/hermit/state"
 	"github.com/cashapp/hermit/ui"
@@ -22,7 +23,7 @@ type execCmd struct {
 	Args   []string `arg:"" help:"Arguments to pass to executable (use -- to separate)." optional:""`
 }
 
-func (e *execCmd) Run(l *ui.UI, sta *state.State, env *hermit.Env, globalState GlobalState, config Config, defaultHTTPClient *http.Client) error {
+func (e *execCmd) Run(l *ui.UI, cache *cache.Cache, sta *state.State, env *hermit.Env, globalState GlobalState, config Config, defaultHTTPClient *http.Client) error {
 	envDir, err := hermit.EnvDirFromProxyLink(e.Binary)
 	if err != nil {
 		return errors.WithStack(err)
@@ -30,7 +31,7 @@ func (e *execCmd) Run(l *ui.UI, sta *state.State, env *hermit.Env, globalState G
 	// If we're running a binary from a different environment, activate it first.
 	activeEnv := os.Getenv("ACTIVE_HERMIT")
 	if env == nil || (activeEnv != "" && envDir != "" && activeEnv != envDir) {
-		env, err = hermit.OpenEnv(envDir, sta, globalState.Env, defaultHTTPClient)
+		env, err = hermit.OpenEnv(envDir, sta, cache.GetSource, globalState.Env, defaultHTTPClient)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/app/manifest_create_cmd.go
+++ b/app/manifest_create_cmd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alecthomas/hcl"
 	"github.com/pkg/errors"
 
+	"github.com/cashapp/hermit/cache"
 	"github.com/cashapp/hermit/github"
 	"github.com/cashapp/hermit/manifest"
 	"github.com/cashapp/hermit/ui"
@@ -17,8 +18,8 @@ type manifestCreateCmd struct {
 	URL        string `arg:"" required:"" help:"URL of a package artefact."`
 }
 
-func (m *manifestCreateCmd) Run(p *ui.UI, defaultHTTPClient *http.Client, ghClient *github.Client) error {
-	pkg, err := manifest.InferFromArtefact(p, defaultHTTPClient, ghClient, m.URL, m.PkgVersion)
+func (m *manifestCreateCmd) Run(p *ui.UI, cache *cache.Cache, defaultHTTPClient *http.Client, ghClient *github.Client) error {
+	pkg, err := manifest.InferFromArtefact(p, cache.GetSource, defaultHTTPClient, ghClient, m.URL, m.PkgVersion)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -3,17 +3,12 @@ package cache
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
-	multierror "go.uber.org/multierr"
 
 	"github.com/cashapp/hermit/ui"
 	"github.com/cashapp/hermit/util"
@@ -21,16 +16,13 @@ import (
 
 // Cache manages the Hermit cache.
 type Cache struct {
+	// GetSource determines how to retrieve packages.
+	GetSource PackageSourceSelector
+
 	root               string
 	httpClient         *http.Client
 	fastFailHTTPClient *http.Client
-	strategies         []DownloadStrategy
 }
-
-// DownloadStrategy defines a strategy for downloading URLs.
-//
-// Typically useful for packages behind authenticated endpoints, etc.
-type DownloadStrategy func(ctx context.Context, url string) (*http.Response, error)
 
 // BasePath returns the subfolder in the cache path for the given file
 func BasePath(checksum, uri string) string {
@@ -42,24 +34,28 @@ func BasePath(checksum, uri string) string {
 //
 // "stateDir" is the root of the Hermit state directory.
 //
+// "selector" is used to select a PackageSource for retrieving packages
+//
 // "fastFailClient" is a HTTP client configured to fail quickly if a remote
 // server is unavailable, for use in optional checks.
 //
 // "strategies" are used to download URLS, attempted in order.
 // A default raw HTTP download strategy will always be the first strategy attempted.
-func Open(stateDir string, strategies []DownloadStrategy, client *http.Client, fastFailClient *http.Client) (*Cache, error) {
+func Open(stateDir string, selector PackageSourceSelector, client *http.Client, fastFailClient *http.Client) (*Cache, error) {
 	stateDir = filepath.Join(stateDir, "cache")
 	err := os.MkdirAll(stateDir, os.ModePerm)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	if selector == nil {
+		selector = GetSource
+	}
 	c := &Cache{
 		root:               stateDir,
+		GetSource:          selector,
 		httpClient:         client,
 		fastFailHTTPClient: fastFailClient,
 	}
-	c.strategies = append(c.strategies, c.defaultDownloadStrategy)
-	c.strategies = append(c.strategies, strategies...)
 	return c, nil
 }
 
@@ -87,7 +83,7 @@ func (c *Cache) Create(checksum, uri string) (*os.File, error) {
 
 // OpenLocal opens a local cached copy of "uri", or errors.
 func (c *Cache) OpenLocal(checksum, uri string) (*os.File, error) {
-	source, err := GetSource(uri)
+	source, err := c.GetSource(c.httpClient, uri)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -124,7 +120,7 @@ func (c *Cache) Download(b *ui.Task, checksum, uri string, mirrors ...string) (p
 	var lastError error
 	for _, uri := range uris {
 		defer ui.LogElapsed(b, "Download %s", uri)()
-		source, err := GetSource(uri)
+		source, err := c.GetSource(c.httpClient, uri)
 		if err != nil {
 			return "", "", errors.WithStack(err)
 		}
@@ -145,11 +141,11 @@ func (c *Cache) Download(b *ui.Task, checksum, uri string, mirrors ...string) (p
 // Otherwise an empty string is returned
 func (c *Cache) ETag(b *ui.Task, uri string, mirrors ...string) (etag string, err error) {
 	for _, uri := range append([]string{uri}, mirrors...) {
-		source, err := GetSource(uri)
+		source, err := c.GetSource(c.fastFailHTTPClient, uri)
 		if err != nil {
 			return "", errors.WithStack(err)
 		}
-		result, err := source.ETag(b, c)
+		result, err := source.ETag(b)
 		if err != nil {
 			b.Debugf("%s failed: %s", uri, err)
 			continue
@@ -184,83 +180,6 @@ func (c *Cache) Clean() error {
 func (c *Cache) Path(checksum, uri string) string {
 	base := BasePath(checksum, uri)
 	return filepath.Join(c.root, base)
-}
-
-func (c *Cache) downloadHTTP(b *ui.Task, checksum string, uri string, cachePath string) (string, string, error) {
-	task := b.SubTask("download")
-	cacheDir := filepath.Dir(cachePath)
-	_ = os.MkdirAll(cacheDir, os.ModePerm)
-
-	w, err := ioutil.TempFile(cacheDir, filepath.Base(cachePath)+".*.hermit.tmp.download")
-	if err != nil {
-		return "", "", errors.Wrap(err, "couldn't create temporary for download")
-	}
-	defer w.Close() // nolint: gosec
-	defer os.Remove(w.Name())
-
-	// For HTTP files we download and cache them, then return the cached file.
-	task.Debugf("Downloading %s", uri)
-
-	ctx := context.Background()
-	var errs error
-	var response *http.Response
-	for _, strategy := range c.strategies {
-		resp, err := strategy(ctx, uri)
-		if err != nil {
-			errs = multierror.Append(errs, err)
-			task.Debugf("Download strategy failed: %s", err)
-		} else if resp.StatusCode < 200 || resp.StatusCode > 299 {
-			errs = multierror.Append(errs, errors.New(resp.Status))
-			task.Debugf("Download strategy failed: %s", resp.Status)
-		} else {
-			response = resp
-			defer response.Body.Close()
-			break
-		}
-	}
-	if response == nil {
-		return "", "", errors.Wrap(errs, "all download strategies failed")
-	}
-	etag := response.Header.Get("ETag")
-
-	info, err := w.Stat()
-	if err != nil {
-		return "", "", errors.WithStack(err)
-	}
-	resumed := info.Size()
-	task.Size(int(response.ContentLength + resumed))
-	task.Add(int(resumed))
-	defer task.Done()
-
-	h := sha256.New()
-	r := io.TeeReader(response.Body, h)
-	r = io.TeeReader(r, task.ProgressWriter())
-	_, err = io.Copy(w, r)
-	if err != nil {
-		_ = w.Close()
-		return "", "", errors.WithStack(err)
-	}
-	err = w.Close()
-	if err != nil {
-		return "", "", errors.WithStack(err)
-	}
-	// TODO: We'll need to checksum the existing content when resuming.
-	actualChecksum := hex.EncodeToString(h.Sum(nil))
-	if checksum != "" && checksum != actualChecksum {
-		return "", "", errors.Errorf("%s: checksum %s should have been %s", uri, actualChecksum, checksum)
-	}
-
-	err = response.Body.Close()
-	if err != nil {
-		return "", "", errors.WithStack(err)
-	}
-
-	// We finally have the checksummed file, move it into place.
-	err = os.Rename(w.Name(), cachePath)
-	if err != nil {
-		return "", "", errors.WithStack(err)
-	}
-	return cachePath, etag, nil
 }
 
 func (c *Cache) defaultDownloadStrategy(ctx context.Context, url string) (*http.Response, error) {

--- a/cache/git.go
+++ b/cache/git.go
@@ -1,0 +1,84 @@
+package cache
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/cashapp/hermit/ui"
+	"github.com/cashapp/hermit/util"
+)
+
+type gitSource struct {
+	URL string
+}
+
+func (s *gitSource) OpenLocal(c *Cache, checksum string) (*os.File, error) {
+	f, err := os.Open(c.Path(checksum, s.URL))
+	return f, errors.WithStack(err)
+}
+
+func (s *gitSource) Download(b *ui.Task, cache *Cache, checksum string) (string, string, error) {
+	base := BasePath(checksum, s.URL)
+	checkoutDir := filepath.Join(cache.root, base)
+	repo, tag := parseGitURL(s.URL)
+	args := []string{"git", "clone", "--depth=1", repo, checkoutDir}
+	if tag != "" {
+		args = append(args, "--branch="+tag)
+	}
+	err := util.RunInDir(b, cache.root, args...)
+	if err != nil {
+		return "", "", errors.WithStack(err)
+	}
+
+	bts, err := util.CaptureInDir(b, checkoutDir, "git", "rev-parse", "HEAD")
+	if err != nil {
+		return "", "", errors.WithStack(err)
+	}
+	etag := strings.Trim(string(bts), "\n")
+
+	return filepath.Join(cache.root, base), etag, nil
+}
+
+func (s *gitSource) ETag(b *ui.Task) (etag string, err error) {
+	repo, tag := parseGitURL(s.URL)
+	if tag == "" {
+		tag = "HEAD"
+	}
+	bts, err := util.Capture(b, "git", "ls-remote", repo, tag)
+	if err != nil {
+		return "", errors.Wrap(err, s.URL)
+	}
+	str := string(bts)
+	parts := strings.Split(str, "\t")
+	if len(parts) != 2 {
+		return "", errors.Errorf("invalid HEAD: %s", str)
+	}
+
+	return parts[0], nil
+}
+
+func (s *gitSource) Validate() error {
+	repo, tag := parseGitURL(s.URL)
+	if tag == "" {
+		tag = "HEAD"
+	}
+	cmd := exec.Command("git", "ls-remote", repo, tag)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "error getting remote HEAD: %s", string(out))
+	}
+	return nil
+}
+
+func parseGitURL(source string) (repo, tag string) {
+	parts := strings.SplitN(source, "#", 2)
+	repo = parts[0]
+	if len(parts) > 1 {
+		tag = parts[1]
+	}
+	return
+}

--- a/cache/http.go
+++ b/cache/http.go
@@ -1,0 +1,141 @@
+package cache
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/cashapp/hermit/ui"
+)
+
+type httpSource struct {
+	client *http.Client
+	url    string
+}
+
+// HTTPSource is a PackageSource for a HTTP URL.
+func HTTPSource(client *http.Client, url string) PackageSource {
+	return &httpSource{client, url}
+}
+
+func (s *httpSource) OpenLocal(c *Cache, checksum string) (*os.File, error) {
+	f, err := os.Open(c.Path(checksum, s.url))
+	return f, errors.WithStack(err)
+}
+
+func (s *httpSource) Download(b *ui.Task, cache *Cache, checksum string) (path string, etag string, err error) {
+	cachePath := cache.Path(checksum, s.url)
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, "GET", s.url, &bytes.Reader{})
+	if err != nil {
+		return "", "", errors.Wrap(err, "could not fetch")
+	}
+	response, err := s.client.Do(req)
+	if err != nil {
+		return "", "", errors.Wrap(err, "could not download to cache")
+	}
+	defer response.Body.Close()
+	return downloadHTTP(b, response, checksum, s.url, cachePath)
+}
+
+func (s *httpSource) ETag(b *ui.Task) (etag string, err error) {
+	uri := s.url
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodHead, uri, nil)
+	if err != nil {
+		return "", errors.Wrap(err, uri)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", errors.Wrap(err, uri)
+	}
+	defer resp.Body.Close()
+	// Normal HTTP error, log and try the next mirror.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", errors.Errorf("%s failed: %d", uri, resp.StatusCode)
+	}
+	result := resp.Header.Get("ETag")
+	return result, nil
+}
+
+func (s *httpSource) Validate() error {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodHead, s.url, nil)
+	if err != nil {
+		return errors.Wrap(err, s.url)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return errors.Errorf("could not retrieve source archive from %s: %s", s.url, resp.Status)
+	}
+
+	return nil
+}
+
+func downloadHTTP(b *ui.Task, response *http.Response, checksum string, uri string, cachePath string) (path string, etag string, err error) {
+	task := b.SubTask("download")
+	cacheDir := filepath.Dir(cachePath)
+	_ = os.MkdirAll(cacheDir, os.ModePerm)
+
+	w, err := ioutil.TempFile(cacheDir, filepath.Base(cachePath)+".*.hermit.tmp.download")
+	if err != nil {
+		return "", "", errors.Wrap(err, "couldn't create temporary for download")
+	}
+	defer w.Close() // nolint: gosec
+	defer os.Remove(w.Name())
+
+	// For HTTP files we download and cache them, then return the cached file.
+	task.Debugf("Downloading %s", uri)
+
+	etag = response.Header.Get("ETag")
+
+	info, err := w.Stat()
+	if err != nil {
+		return "", "", errors.WithStack(err)
+	}
+	resumed := info.Size()
+	task.Size(int(response.ContentLength + resumed))
+	task.Add(int(resumed))
+	defer task.Done()
+
+	h := sha256.New()
+	r := io.TeeReader(response.Body, h)
+	r = io.TeeReader(r, task.ProgressWriter())
+	_, err = io.Copy(w, r)
+	if err != nil {
+		_ = w.Close()
+		return "", "", errors.WithStack(err)
+	}
+	err = w.Close()
+	if err != nil {
+		return "", "", errors.WithStack(err)
+	}
+	// TODO: We'll need to checksum the existing content when resuming.
+	actualChecksum := hex.EncodeToString(h.Sum(nil))
+	if checksum != "" && checksum != actualChecksum {
+		return "", "", errors.Errorf("%s: checksum %s should have been %s", uri, actualChecksum, checksum)
+	}
+
+	err = response.Body.Close()
+	if err != nil {
+		return "", "", errors.WithStack(err)
+	}
+
+	// We finally have the checksummed file, move it into place.
+	err = os.Rename(w.Name(), cachePath)
+	if err != nil {
+		return "", "", errors.WithStack(err)
+	}
+	return cachePath, etag, nil
+}

--- a/cmd/hermit/main.go
+++ b/cmd/hermit/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cashapp/hermit/app"
 	"github.com/cashapp/hermit/sources"
 	"github.com/cashapp/hermit/state"
-	"github.com/cashapp/hermit/ui"
 )
 
 var (
@@ -21,18 +20,12 @@ var (
 )
 
 func main() {
-	level, err := ui.LevelFromString(envOrDefault("HERMIT_LOG", "info"))
-	if err != nil {
-		level = ui.LevelInfo
-	}
-
 	builtin, err := fs.Sub(builtin, "builtin")
 	if err != nil {
 		panic("this should never happen")
 	}
 
 	app.Main(app.Config{
-		LogLevel:    level,
 		BaseDistURL: baseDistURL + channel,
 		Version:     fmt.Sprintf("%s (%s)", version, channel),
 		State: state.Config{
@@ -40,11 +33,4 @@ func main() {
 		},
 		CI: os.Getenv("CI") != "",
 	})
-}
-
-func envOrDefault(name, dflt string) string {
-	if v := os.Getenv(name); v != "" {
-		return v
-	}
-	return dflt
 }

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/willdonnelly/passwd v0.0.0-20141013001024-7935dab3074c
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
 	go.etcd.io/bbolt v1.3.5
-	go.uber.org/multierr v1.7.0
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/net v0.0.0-20210916014120-12bc252f5db8
 	golang.org/x/sys v0.0.0-20210423082822-04245dca01da

--- a/go.sum
+++ b/go.sum
@@ -76,7 +76,6 @@ github.com/sassoftware/go-rpmutils v0.1.2-0.20210127001923-e5cf0f808585 h1:7T5We
 github.com/sassoftware/go-rpmutils v0.1.2-0.20210127001923-e5cf0f808585/go.mod h1:WbbeA9ea3sP6eCwBEvBMIUAHrMv7Y70HlUoBsil9O7Q=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -91,12 +90,8 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofm
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
-go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
-go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
-go.uber.org/multierr v1.7.0 h1:zaiO/rmgFjbmCXdSYJWQcdvOCsthmdaHfr3Gm2Kx4Ec=
-go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=

--- a/manifest/infer_test.go
+++ b/manifest/infer_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cashapp/hermit/cache"
 	"github.com/cashapp/hermit/github"
 	"github.com/cashapp/hermit/ui"
 )
@@ -27,7 +28,14 @@ func TestInfer(t *testing.T) {
 	}))
 	defer srv.Close()
 	p, _ := ui.NewForTesting()
-	actual, err := InferFromArtefact(p, http.DefaultClient, github.New(""), srv.URL+"/releases/download/0.1.1/pkg-0.1.1-linux-amd64.tgz", "")
+	actual, err := InferFromArtefact(
+		p,
+		cache.GetSource,
+		http.DefaultClient,
+		github.New(nil, ""),
+		srv.URL+"/releases/download/0.1.1/pkg-0.1.1-linux-amd64.tgz",
+		"",
+	)
 	require.NoError(t, err)
 	expected := &Manifest{
 		Layer: Layer{

--- a/manifest/validate.go
+++ b/manifest/validate.go
@@ -1,17 +1,18 @@
 package manifest
 
 import (
-	"github.com/cashapp/hermit/cache"
 	"net/http"
+
+	"github.com/cashapp/hermit/cache"
 
 	"github.com/pkg/errors"
 )
 
 // ValidatePackageSource checks that a package source is accessible.
-func ValidatePackageSource(httpClient *http.Client, url string) error {
-	source, err := cache.GetSource(url)
+func ValidatePackageSource(packageSource cache.PackageSourceSelector, httpClient *http.Client, url string) error {
+	source, err := packageSource(httpClient, url)
 	if err != nil {
 		return errors.Wrap(err, url)
 	}
-	return errors.Wrapf(source.Validate(httpClient), "invalid source")
+	return errors.Wrapf(source.Validate(), "invalid source")
 }

--- a/ui/level_string.go
+++ b/ui/level_string.go
@@ -8,17 +8,18 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[LevelTrace-0]
-	_ = x[LevelDebug-1]
-	_ = x[LevelInfo-2]
-	_ = x[LevelWarn-3]
-	_ = x[LevelError-4]
-	_ = x[LevelFatal-5]
+	_ = x[LevelAuto-0]
+	_ = x[LevelTrace-1]
+	_ = x[LevelDebug-2]
+	_ = x[LevelInfo-3]
+	_ = x[LevelWarn-4]
+	_ = x[LevelError-5]
+	_ = x[LevelFatal-6]
 }
 
-const _Level_name = "tracedebuginfowarnerrorfatal"
+const _Level_name = "autotracedebuginfowarnerrorfatal"
 
-var _Level_index = [...]uint8{0, 5, 10, 14, 18, 23, 28}
+var _Level_index = [...]uint8{0, 4, 9, 14, 18, 22, 27, 32}
 
 func (i Level) String() string {
 	if i < 0 || i >= Level(len(_Level_index)-1) {


### PR DESCRIPTION
1. "hermit test" did not paginate private GitHub release results
2. Added caching to the GH client.
3. Added HTTP tracing.
4. Fixed a bug where command-line flags would not set the log-level
   early enough.
5. Refactored the download strategies into PackageSource
   implementations.
6. Fixed a bug where ETag checks weren't using the fast HTTP client.
7. Factored out HTTP downloader function from the Cache into
   PackageSources.
8. Made PackageSources not use private internals of Cache.
9. Reusable HTTPSource().
10. Implemented a githubReleaseSource with proper ETag checks.
11. Don't retrieve _all_ GH releases when checking for just one.
12. Increase GH release listing pagination size to the max of 100.

There's still some slight unavoidable weirdness with logging. Because
Hermit does a bit of work before parsing the command line, command-line
logging flags won't take effect until flags are parsed, filtering out
logs below info prior to that point. Using DEBUG=1 or HERMIT_LOG=trace
will now work as expected though, where it wasn't previously.