### PR TITLE
fix: don't overwrite user-modified envars

### DIFF
--- a/envars/ops_test.go
+++ b/envars/ops_test.go
@@ -3,6 +3,7 @@ package envars
 import (
 	"testing"
 
+	"github.com/alecthomas/repr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -115,4 +116,21 @@ func TestIssue47(t *testing.T) {
 	require.Equal(t, expected, actual)
 	reverted := expected.Revert("/home/user/project", ops).Combined()
 	require.Equal(t, original, reverted)
+}
+
+func TestEncodeDecodeOps(t *testing.T) {
+	actual := Ops{
+		&Append{"APPEND", "${APPEND}:text"},
+		&Prepend{"PREPEND", "text:${PREPEND}"},
+		&Set{"SET", "text"},
+		&Unset{"UNSET"},
+		&Force{"FORCE", "text"},
+		&Prefix{"PREFIX", "prefix_"},
+	}
+	data, err := MarshalOps(actual)
+	require.NoError(t, err)
+	t.Log(string(data))
+	expected, err := UnmarshalOps(data)
+	require.NoError(t, err)
+	require.Equal(t, repr.String(expected, repr.Indent("  ")), repr.String(actual, repr.Indent("  ")))
 }

--- a/it/full/spec/it_spec.sh
+++ b/it/full/spec/it_spec.sh
@@ -103,6 +103,15 @@ Describe "Hermit"
         The stderr should be blank
         The variable PKG_TEST_VAR should equal "before"
       End
+
+      It "does not overwrite user-overridden variables"
+        export PKG_TEST_VAR="modified"
+        When call deactivate-hermit
+        The status should be success
+        The stdout should not be blank
+        The stderr should be blank
+        The variable PKG_TEST_VAR should equal "modified"
+      End
     End
   End
 

--- a/shell/files/activate.tmpl.sh
+++ b/shell/files/activate.tmpl.sh
@@ -17,10 +17,11 @@ fi
 
 _hermit_deactivate() {
   echo "Hermit environment $(${HERMIT_ENV}/bin/hermit env HERMIT_ENV) deactivated"
-  eval "$HERMIT_DEACTIVATION"
+  eval "$(${ACTIVE_HERMIT}/bin/hermit env --deactivate-from-ops="${HERMIT_ENV_OPS}")"
   unset -f deactivate-hermit >/dev/null 2>&1
   unset -f update_hermit_env >/dev/null 2>&1
   unset ACTIVE_HERMIT
+  unset HERMIT_ENV_OPS
 
   hash -r 2>/dev/null
 
@@ -47,7 +48,7 @@ deactivate-hermit() {
 
 unset DEACTIVATED_HERMIT
 export ACTIVE_HERMIT=$HERMIT_ENV
-export HERMIT_DEACTIVATION="$(${HERMIT_ENV}/bin/hermit env --deactivate)"
+export HERMIT_ENV_OPS="$(${HERMIT_ENV}/bin/hermit env --ops)"
 export HERMIT_BIN_CHANGE=$(date -r ${HERMIT_ENV}/bin +"%s")
 
 {{- if ne .Prompt "none" }}
@@ -58,9 +59,9 @@ update_hermit_env() {
   local CURRENT=$(date -r ${HERMIT_ENV}/bin +"%s")
   test "$CURRENT" = "$HERMIT_BIN_CHANGE" && return 0
   local CUR_HERMIT=${HERMIT_ENV}/bin/hermit
-  eval "$HERMIT_DEACTIVATION"
+  eval "$(${ACTIVE_HERMIT}/bin/hermit env --deactivate-from-ops="${HERMIT_ENV_OPS}")"
   eval "$(${CUR_HERMIT} env --activate)"
-  export HERMIT_DEACTIVATION=$(${HERMIT_ENV}/bin/hermit env --deactivate)
+  export HERMIT_ENV_OPS=$(${HERMIT_ENV}/bin/hermit env --ops)
   export HERMIT_BIN_CHANGE=$CURRENT
 }
 


### PR DESCRIPTION
This works be storing the JSON-encoded operations for an environment, 
rather than the explicit values for each environment variable. This 
allows Orc's Op.Revert functionality to correctly mutate each 
environment variable as it is being restored, rathern than blindly 
overwriting.

Fixes #218