### PR TITLE
chore: separate command flags in help

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -184,6 +184,16 @@ func Main(config Config) {
 		kong.Description(help),
 		kong.BindTo(cli, (*cliCommon)(nil)),
 		kong.Bind(userConfig, config),
+		kong.AutoGroup(func(parent kong.Visitable, flag *kong.Flag) *kong.Group {
+			node, ok := parent.(*kong.Command)
+			if !ok {
+				return nil
+			}
+			return &kong.Group{
+				Key:   node.Name,
+				Title: "Command flags:",
+			}
+		}),
 		kong.Vars{
 			"version": config.Version,
 			"env":     envPath,

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/alecthomas/colour v0.1.0
 	github.com/alecthomas/hcl v0.2.1
-	github.com/alecthomas/kong v0.4.1
+	github.com/alecthomas/kong v0.5.0
 	github.com/alecthomas/participle v0.7.1
 	github.com/alecthomas/repr v0.0.0-20220113201626-b1b626ac65ae
 	github.com/antchfx/htmlquery v1.2.4

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/alecthomas/colour v0.1.0/go.mod h1:QO9JBoKquHd+jz9nshCh40fOfO+JzsoXy8
 github.com/alecthomas/hcl v0.2.1 h1:2Pn/xtIyEnYBW0yJguwebpDWk2TbYab6LUlfyDqhgwg=
 github.com/alecthomas/hcl v0.2.1/go.mod h1:VEYcgruQ39ELu6c0Bb+VRm3trQPt7dQUdAwF7QrG7AQ=
 github.com/alecthomas/kong v0.2.22/go.mod h1:uzxf/HUh0tj43x1AyJROl3JT7SgsZ5m+icOv1csRhc0=
-github.com/alecthomas/kong v0.4.1 h1:0sFnMts+ijOiFuSHsMB9MlDi3NGINBkx9KIw1/gcuDw=
-github.com/alecthomas/kong v0.4.1/go.mod h1:uzxf/HUh0tj43x1AyJROl3JT7SgsZ5m+icOv1csRhc0=
+github.com/alecthomas/kong v0.5.0 h1:u8Kdw+eeml93qtMZ04iei0CFYve/WPcA5IFh+9wSskE=
+github.com/alecthomas/kong v0.5.0/go.mod h1:uzxf/HUh0tj43x1AyJROl3JT7SgsZ5m+icOv1csRhc0=
 github.com/alecthomas/participle v0.6.1-0.20200911005820-318127ca69ac/go.mod h1:HfdmEuwvr12HXQN44HPWXR0lHmVolVYe4dyL6lQ3duY=
 github.com/alecthomas/participle v0.7.1 h1:2bN7reTw//5f0cugJcTOnY/NYZcWQOaajW+BwZB5xWs=
 github.com/alecthomas/participle v0.7.1/go.mod h1:HfdmEuwvr12HXQN44HPWXR0lHmVolVYe4dyL6lQ3duY=


### PR DESCRIPTION
    Usage: hermit env [<name> [<value>]]

    Manage environment variables.

    Without arguments the "env" command will display environment variables for the active
    Hermit environment.

    Passing "<name>" will print the value for that environment variable.

    Passing "<name> <value>" will set the value for an environment variable in the active
    Hermit environment."

    Arguments:
      [<name>]     Name of the environment variable.
      [<value>]    Value to set the variable to.

    Flags:
      -h, --help                 Show context-sensitive help.
          --version              Show version.
      -d, --debug                Enable debug logging.
      -t, --trace                Enable trace logging.
      -q, --quiet                Disable logging and progress UI, except fatal errors
                                ($HERMIT_QUIET).
          --level=auto           Set minimum log level
                                (auto,trace,debug,info,warn,error,fatal) ($HERMIT_LOG).
          --env=KEY=VALUE;...    Extra environment variables to apply to environments.

    Command flags:
      -r, --raw                        Output raw values without shell quoting.
          --ops                        Print the operations needed to manipulate the
                                      environment.
          --activate                   Print the commands needed to set the environment to
                                      the activated state.
          --deactivate                 Print the commands needed to reset the environment
                                      to the deactivated state.
          --deactivate-from-ops=OPS    Decodes the operations, and prints the shell
                                      commands to to reset the environment to the
                                      deactivated state.
      -i, --inherit                    Inherit variables from parent environment.
      -n, --names                      Show only names.
      -u, --unset                      Unset the specified environment variable.