### PR TITLE
refactor: pull out common CLI into a base structure

### DIFF
--- a/app/validate_cmd.go
+++ b/app/validate_cmd.go
@@ -1,7 +1,11 @@
 package app
 
-type validateCmd struct {
+type unactivatedValidateCmd struct {
 	Source validateSourceCmd `default:"withargs" cmd:"" help:"Check a package manifest source for errors." group:"global"`
 	Env    validateEnvCmd    `cmd:"" help:"Verify an environment." group:"global"`
+}
+
+type activatedValidateCmd struct {
+	unactivatedValidateCmd
 	Script validateScriptCmd `cmd:"" help:"Verify a shell script uses only builtin or Hermit commands." group:"env"`
 }

--- a/app/validate_script_cmd.go
+++ b/app/validate_script_cmd.go
@@ -60,7 +60,7 @@ var (
 type validateScriptCmd struct {
 	Allow  []string `short:"a" enum:"none,relative,var-relative" help:"Enable optional features (${enum})." default:"none"`
 	Cmds   []string `short:"c" placeholder:"CMD" help:"Extra commands to allow."`
-	Script []string `arg:"" placeholder:"SCRIPT" type:"existingfile" help:"Bourne-compatible shell scripts to validate."`
+	Script []string `arg:"" placeholder:"SCRIPT" type:"existingfile" help:"Bourne-compatible shell scripts to validate." predictor:"file"`
 }
 
 func (v *validateScriptCmd) Help() string {


### PR DESCRIPTION
This fixes an issue where "validate script" was available outside an
env.