### PR TITLE
fix: only sync packages if forced or update frequency is hit

### DIFF
--- a/env.go
+++ b/env.go
@@ -1271,8 +1271,13 @@ func (e *Env) Update(l *ui.UI, force bool) error {
 	}
 	for _, pkg := range pkgs {
 		if pkg.Reference.IsChannel() {
-			if err := e.state.UpgradeChannel(l.Task(pkg.String()), pkg); err != nil {
-				return errors.Wrap(err, pkg.String())
+			log := l.Task(pkg.String())
+			if force || time.Since(pkg.UpdatedAt) > pkg.UpdateInterval {
+				if err := e.state.UpgradeChannel(log, pkg); err != nil {
+					return errors.Wrap(err, pkg.String())
+				}
+			} else {
+				log.Debugf("Update skipped, updated within the last %s", pkg.UpdateInterval)
 			}
 		}
 	}


### PR DESCRIPTION
I noticed that the check is occurring even on search, eg.

    🐚 ~/Development/orc $ hermit search cashcache
    info:cashkite-conventional-commits@stable: No updated required
    info:go@latest: No updated required
    cashcache (@0, @0.0, @latest, 0.0.18, 0.0.21, 0.0.23, 0.0.25, 0.0.27, 0.0.28, 0.0.29, 0.0.30, 0.0.31)
      cashcache is CI cache to improve build times