### PR TITLE
refactor: simplify file-based DAO

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/willabides/kongplete v0.3.0
 	github.com/willdonnelly/passwd v0.0.0-20141013001024-7935dab3074c
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
-	go.etcd.io/bbolt v1.3.6
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,6 @@ github.com/willdonnelly/passwd v0.0.0-20141013001024-7935dab3074c h1:4+NVyrLUuEm
 github.com/willdonnelly/passwd v0.0.0-20141013001024-7935dab3074c/go.mod h1:xcvfY9pOw6s4wyrhilFSbMthL6KzgrfCIETHHUOQ/fQ=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
-go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
-go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
 go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -116,7 +114,6 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/hermittest/envfixture.go
+++ b/hermittest/envfixture.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	bolt "go.etcd.io/bbolt"
 
 	"github.com/cashapp/hermit"
 	"github.com/cashapp/hermit/cache"
@@ -83,13 +82,6 @@ func (f *EnvTestFixture) DAO() *dao.DAO {
 	d, err := dao.Open(f.State.Root())
 	require.NoError(f.t, err)
 	return d
-}
-
-// BoltDB returns the underlying DB
-func (f *EnvTestFixture) BoltDB() *bolt.DB {
-	db, err := bolt.Open(filepath.Join(f.State.Root(), "hermit.bolt.db"), 0600, nil)
-	require.NoError(f.t, err)
-	return db
 }
 
 // Clean removes all files and directories from this environment

--- a/internal/dao/dao.go
+++ b/internal/dao/dao.go
@@ -36,67 +36,41 @@ func (d *DAO) Dump(w io.Writer) error {
 
 // GetPackage returns information for a specific package.
 func (d *DAO) GetPackage(pkgRef string) (*Package, error) {
-	pkg := Package{}
-	if updatedAt, err := d.getUpdateCheckedAt(pkgRef); err != nil && !os.IsNotExist(err) {
-		return nil, errors.WithStack(err)
-	} else { // nolint
-		pkg.UpdateCheckedAt = updatedAt
+	r, err := os.Open(d.metadataPath(pkgRef))
+	if os.IsNotExist(err) {
+		return &Package{}, nil
 	}
-	if etag, err := d.getETag(pkgRef); err != nil && !os.IsNotExist(err) {
+	if err != nil {
 		return nil, errors.WithStack(err)
-	} else { // nolint
-		pkg.Etag = etag
 	}
-	return &pkg, nil
+	defer r.Close() // nolint
+	info, err := r.Stat()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	etag, err := io.ReadAll(r)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return &Package{
+		Etag:            string(etag),
+		UpdateCheckedAt: info.ModTime(),
+	}, nil
 }
 
 // UpdatePackage Updates the update check time, etag, and the used at time for a package
 func (d *DAO) UpdatePackage(pkgRef string, pkg *Package) error {
-	if err := d.updateCheckedAt(pkgRef); err != nil {
-		return errors.WithStack(err)
-	}
-	if err := d.writeETag(pkgRef, pkg.Etag); err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
+	return errors.WithStack(os.WriteFile(d.metadataPath(pkgRef), []byte(pkg.Etag), 0600))
 }
 
 // DeletePackage removes a package from the DB
 func (d *DAO) DeletePackage(pkgRef string) error {
-	if err := os.Remove(d.metadataPath(pkgRef, "etag")); err != nil {
-		return errors.WithStack(err)
-	}
-	if err := os.Remove(d.metadataPath(pkgRef, "updated")); err != nil {
+	if err := os.Remove(d.metadataPath(pkgRef)); err != nil {
 		return errors.WithStack(err)
 	}
 	return nil
 }
 
-func (d *DAO) metadataPath(pkgRef, key string) string {
-	return filepath.Join(d.stateDir, pkgRef+"."+key)
-}
-
-func (d *DAO) getETag(pkgRef string) (string, error) {
-	data, err := os.ReadFile(d.metadataPath(pkgRef, "etag"))
-	return string(data), errors.WithStack(err)
-}
-
-func (d *DAO) writeETag(pkgRef, etag string) error {
-	return errors.WithStack(os.WriteFile(d.metadataPath(pkgRef, "etag"), []byte(etag), 0600))
-}
-
-func (d *DAO) getUpdateCheckedAt(pkgRef string) (time.Time, error) {
-	info, err := os.Stat(d.metadataPath(pkgRef, "updated"))
-	if err != nil {
-		return time.Time{}, errors.WithStack(err)
-	}
-	return info.ModTime(), nil
-}
-
-func (d *DAO) updateCheckedAt(pkgRef string) error {
-	f, err := os.OpenFile(d.metadataPath(pkgRef, "updated"), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	return f.Close()
+func (d *DAO) metadataPath(pkgRef string) string {
+	return filepath.Join(d.stateDir, pkgRef+".etag")
 }


### PR DESCRIPTION
Just use the .etag file's mtime for UpdatedAt timestamps rathern than a
separate file.