### PR TITLE
fix: use custom UserHomeDir and UserCacheDir

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,6 +69,7 @@ linters-settings:
   forbidigo:
     forbid:
       - '^fmt.Errorf'
+      - '^os.User.*Dir'
 
 
 issues:

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -25,11 +25,13 @@ import (
 	"github.com/xi2/xz"
 	"howett.net/plist"
 
+	"github.com/otiai10/copy"
+
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/internal/system"
 	"github.com/cashapp/hermit/manifest"
 	"github.com/cashapp/hermit/ui"
 	"github.com/cashapp/hermit/util"
-	"github.com/otiai10/copy"
 )
 
 // Extract from "source" to package destination.
@@ -179,7 +181,7 @@ func installMacDMG(b *ui.Task, source string, pkg *manifest.Package) error {
 		return errors.WithStack(err)
 	}
 	defer os.RemoveAll(dest)
-	home, err := os.UserHomeDir()
+	home, err := system.UserHomeDir()
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/env.go
+++ b/env.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cashapp/hermit/cache"
 	"github.com/cashapp/hermit/envars"
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/internal/system"
 	"github.com/cashapp/hermit/manifest"
 	"github.com/cashapp/hermit/platform"
 	"github.com/cashapp/hermit/shell"
@@ -65,10 +66,9 @@ var (
 		if explicit != "" {
 			return explicit
 		}
-
-		cache, err := os.UserCacheDir()
+		cache, err := system.UserCacheDir()
 		if err != nil {
-			panic(err)
+			panic(fmt.Sprintf("could not find user cache dir: %s", err))
 		}
 		return filepath.Join(cache, "hermit")
 	}()

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -1,0 +1,55 @@
+package system
+
+import (
+	"os"
+	"os/user"
+	"runtime"
+
+	"github.com/cashapp/hermit/errors"
+)
+
+// UserHomeDir tries to determine the current user's home directory.
+func UserHomeDir() (string, error) {
+	dir, err := os.UserHomeDir() // nolint: forbidigo
+	if err == nil {
+		return dir, nil
+	}
+	if dir = os.Getenv("HERMIT_USER_HOME"); dir != "" {
+		return dir, nil
+	}
+	user, err := user.Current()
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	return user.HomeDir, nil
+}
+
+// UserCacheDir tries to determine the location of the user's local cache directory.
+func UserCacheDir() (dir string, err error) {
+	switch runtime.GOOS {
+	case "windows":
+		dir = os.Getenv("LocalAppData")
+		if dir == "" {
+			return "", errors.New("%LocalAppData% is not defined")
+		}
+
+	case "darwin", "ios":
+		dir, err = UserHomeDir()
+		if err != nil {
+			return "", errors.WithStack(err)
+		}
+		dir += "/Library/Caches"
+
+	default: // Unix
+		dir = os.Getenv("XDG_CACHE_HOME")
+		if dir == "" {
+			dir, err = UserHomeDir()
+			if err != nil {
+				return "", errors.WithStack(err)
+			}
+			dir += "/.cache"
+		}
+	}
+
+	return dir, nil
+}

--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cashapp/hermit/envars"
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/internal/system"
 	"github.com/cashapp/hermit/platform"
 	"github.com/cashapp/hermit/sources"
 	"github.com/cashapp/hermit/ui"
@@ -488,7 +489,7 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 	// If "ignoreMissing" is false, any referenced variables that are unknown will result in an error.
 	//
 	// TODO: Factor this out (there's a lot of captured state though).
-	home, err := os.UserHomeDir()
+	home, err := system.UserHomeDir()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/shell/bash.go
+++ b/shell/bash.go
@@ -2,10 +2,10 @@ package shell
 
 import (
 	"io"
-	"os"
 	"path/filepath"
 
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/internal/system"
 )
 
 var bashShellHooks = `
@@ -35,7 +35,7 @@ func (sh *Bash) ActivationScript(w io.Writer, config ActivationConfig) error { /
 }
 
 func (sh *Bash) ActivationHooksInstallation() (path, script string, err error) { // nolint: golint
-	home, err := os.UserHomeDir()
+	home, err := system.UserHomeDir()
 	if err != nil {
 		return "", "", errors.WithStack(err)
 	}

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -2,10 +2,10 @@ package shell
 
 import (
 	"io"
-	"os"
 	"path/filepath"
 
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/internal/system"
 )
 
 var zshShellHooks = `
@@ -35,7 +35,7 @@ func (sh *Zsh) ActivationScript(w io.Writer, config ActivationConfig) error { //
 }
 
 func (sh *Zsh) ActivationHooksInstallation() (path, script string, err error) { // nolint: golint
-	home, err := os.UserHomeDir()
+	home, err := system.UserHomeDir()
 	if err != nil {
 		return "", "", errors.WithStack(err)
 	}


### PR DESCRIPTION
Some tools/libraries such as AWS Lambda emulators strip down the
environment before being executed. We want Hermit to be able to
work in these situations so this implements custom functions
to work around this.

Fixes #239 