### PR TITLE
fix: publish versioned installer script to canary

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -22,6 +22,10 @@ jobs:
           make GOOS=darwin GOARCH=amd64 CHANNEL=canary build
           make GOOS=darwin GOARCH=arm64 CHANNEL=canary build
           go run ./cmd/geninstaller --dest=build/install.sh --dist-url=https://github.com/cashapp/hermit/releases/download/canary
+          INSTALLER_VERSION=$(go run ./cmd/geninstaller \
+            --dest=build/install.sh \
+            --dist-url=https://github.com/cashapp/hermit/releases/download/canary)
+          cp build/install.sh build/install-"${INSTALLER_VERSION}".sh
       - name: Release canary
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
The ScriptSHA for the corresponding `bin/hermit` has already been added.