### PR TITLE
Normalise environment variable substitution

### DIFF
--- a/env.go
+++ b/env.go
@@ -945,11 +945,10 @@ func (e *Env) ListInstalled(l *ui.UI) ([]*manifest.Package, error) {
 // only variables defined in Hermit itself will be available.
 func (e *Env) Envars(l *ui.UI, inherit bool) ([]string, error) {
 	defer ui.LogElapsed(l, "envars")()
-	pkgs, err := e.ListInstalled(l)
+	ops, err := e.EnvOps(l)
 	if err != nil {
 		return nil, err
 	}
-	ops := e.allEnvarOpsForPackages(nil, pkgs...)
 	return e.envarsFromOps(inherit, ops), nil
 }
 
@@ -1189,8 +1188,6 @@ func (e *Env) pkgLink(pkg *manifest.Package) string {
 }
 
 // Returns combined system + Hermit + package environment variables, fully expanded.
-//
-// If "inherit" is true, system envars will be included.
 func (e *Env) allEnvarOpsForPackages(runtimeDeps []*manifest.Package, pkgs ...*manifest.Package) envars.Ops {
 	var ops envars.Ops
 	ops = append(ops, e.hermitPathEnvar())

--- a/env.go
+++ b/env.go
@@ -963,12 +963,7 @@ func (e *Env) EnvOps(l *ui.UI) (envars.Ops, error) {
 	if err != nil {
 		return nil, err
 	}
-	ops := e.envarsForPackages(pkgs...)
-	ops = append(ops, e.hermitPathEnvar())
-	ops = append(ops, e.hermitEnvarOps()...)
-	ops = append(ops, e.localEnvarOps()...)
-	ops = append(ops, e.ephemeralEnvars...)
-	return ops, nil
+	return e.allEnvarOpsForPackages(nil, pkgs...), nil
 }
 
 // SetEnv sets an extra environment variable.
@@ -1198,11 +1193,11 @@ func (e *Env) pkgLink(pkg *manifest.Package) string {
 // If "inherit" is true, system envars will be included.
 func (e *Env) allEnvarOpsForPackages(runtimeDeps []*manifest.Package, pkgs ...*manifest.Package) envars.Ops {
 	var ops envars.Ops
+	ops = append(ops, e.hermitPathEnvar())
+	ops = append(ops, e.hermitEnvarOps()...)
+	ops = append(ops, e.hermitRuntimeDepOps(runtimeDeps)...)
 	ops = append(ops, e.envarsForPackages(pkgs...)...)
 	ops = append(ops, e.localEnvarOps()...)
-	ops = append(ops, e.hermitPathEnvar())
-	ops = append(ops, e.hermitRuntimeDepOps(runtimeDeps)...)
-	ops = append(ops, e.hermitEnvarOps()...)
 	ops = append(ops, e.ephemeralEnvars...)
 	return ops
 }

--- a/env.go
+++ b/env.go
@@ -1190,7 +1190,6 @@ func (e *Env) pkgLink(pkg *manifest.Package) string {
 // Returns combined system + Hermit + package environment variables, fully expanded.
 func (e *Env) allEnvarOpsForPackages(runtimeDeps []*manifest.Package, pkgs ...*manifest.Package) envars.Ops {
 	var ops envars.Ops
-	ops = append(ops, e.hermitPathEnvar())
 	ops = append(ops, e.hermitEnvarOps()...)
 	ops = append(ops, e.hermitRuntimeDepOps(runtimeDeps)...)
 	ops = append(ops, e.envarsForPackages(pkgs...)...)
@@ -1210,10 +1209,6 @@ func (e *Env) envarsFromOps(inherit bool, ops envars.Ops) []string {
 	return transform.Changed(false).System()
 }
 
-func (e *Env) hermitPathEnvar() envars.Op {
-	return &envars.Prepend{Name: "PATH", Value: e.binDir}
-}
-
 // envarsForPackages returns the environment variable operations by the given packages.
 func (e *Env) envarsForPackages(pkgs ...*manifest.Package) envars.Ops {
 	out := envars.Ops{}
@@ -1231,6 +1226,7 @@ func (e *Env) localEnvarOps() envars.Ops {
 // hermitEnvarOps returns the environment variables created and required by hermit itself
 func (e *Env) hermitEnvarOps() envars.Ops {
 	return envars.Ops{
+		&envars.Prepend{Name: "PATH", Value: e.binDir},
 		&envars.Force{Name: "HERMIT_BIN", Value: e.binDir},
 		&envars.Force{Name: "HERMIT_ENV", Value: e.envDir},
 	}

--- a/env_test.go
+++ b/env_test.go
@@ -396,3 +396,20 @@ func TestManifestValidation(t *testing.T) {
 	_, err = f.Env.ValidateManifest(f.P, "test", &hermit.ValidationOptions{CheckSources: false})
 	require.NoError(t, err)
 }
+
+func TestEnv_EphemeralVariableSubstitutionOverride(t *testing.T) {
+	fixture := hermittest.NewEnvTestFixture(t, nil)
+	defer fixture.Clean()
+
+	err := fixture.Env.SetEnv("TOOL_HOME", "$HERMIT_ENV/.hermit/tool")
+	require.NoError(t, err)
+
+	envop := &envars.Set{Name: "TOOL_HOME", Value: "$HERMIT_ENV/.hermit/tool"}
+	ops, err := fixture.Env.EnvOps(fixture.P)
+	require.NoError(t, err)
+	require.Contains(t, ops, envop)
+
+	vars, err := fixture.Env.Envars(fixture.P, false)
+	require.NoError(t, err)
+	require.Contains(t, vars, "TOOL_HOME="+fixture.Env.Root()+"/.hermit/tool")
+}


### PR DESCRIPTION
One code path would setup environment variable overrides in the order of: _(later beats earlier)_
1. Packages
2. `PATH`
3. `HERMIT_BIN` / `HERMIT_ENV`
4. The local `hermit.hcl`
5. Command-line parameters

And another would do it in order of:
1. Packages
2. The local `hermit.hcl`
3. `PATH`
4. Runtime dependencies
5. `HERMIT_BIN` / `HERMIT_ENV`
6. Command-line parameters

This refactor refactors to a single codepath in the order of:
1. `PATH` / `HERMIT_BIN` / `HERMIT_ENV` (now inseparable)
2. Runtime dependencies
3. Packages
4. The local `hermit.hcl`
5. Command-line parameters

A test is attached. A _better_ test would define the priority order of these overrides … but that's for a better person than me.