### PR TITLE
feat: add json format to list and search

### DIFF
--- a/app/command_info_test.go
+++ b/app/command_info_test.go
@@ -25,7 +25,12 @@ func TestCommandInfoJson(t *testing.T) {
 	})
 	defer f.Clean()
 
-	cmd := infoCmd{Packages: []manifest.GlobSelector{manifest.MustParseGlobSelector("test-version-1.1")}, JSON: true}
+	cmd := infoCmd{
+		Packages: []manifest.GlobSelector{manifest.MustParseGlobSelector("test-version-1.1")},
+		JSONFormattable: JSONFormattable{
+			JSON: true,
+		},
+	}
 	require.NoError(t, cmd.Run(l, f.Env, f.State))
 
 	var jss []map[string]json.RawMessage

--- a/app/info_cmd.go
+++ b/app/info_cmd.go
@@ -19,7 +19,7 @@ import (
 
 type infoCmd struct {
 	Packages []manifest.GlobSelector `arg:"" required:"" help:"Packages to retrieve information for" predictor:"package"`
-	JSON     bool                    `help:"Format information as a JSON array" default:"false"`
+	JSONFormattable
 }
 
 func (i *infoCmd) Run(l *ui.UI, env *hermit.Env, sta *state.State) error {

--- a/app/search_cmd.go
+++ b/app/search_cmd.go
@@ -13,6 +13,7 @@ import (
 type searchCmd struct {
 	Short      bool   `short:"s" help:"Short listing."`
 	Constraint string `arg:"" help:"Package regex." optional:""`
+	JSONFormattable
 }
 
 func (s *searchCmd) Run(l *ui.UI, env *hermit.Env, state *state.State) error {
@@ -49,6 +50,9 @@ func (s *searchCmd) Run(l *ui.UI, env *hermit.Env, state *state.State) error {
 		}
 		return nil
 	}
-	listPackages(pkgs, true)
+	err = listPackages(pkgs, true, s.JSON, l)
+	if err != nil {
+		return errors.Wrapf(err, "error listing search result")
+	}
 	return nil
 }


### PR DESCRIPTION
This PR let `list` and `search` command able to print out Machine readable JSON output.

Also creates `JSONFormattable` flag shared among `info`, `list`, and `search` command.