### PR TITLE
fix: streamlined search output

### DIFF
--- a/app/search_cmd.go
+++ b/app/search_cmd.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"fmt"
-
 	"github.com/cashapp/hermit"
 	"github.com/cashapp/hermit/errors"
 	"github.com/cashapp/hermit/manifest"
@@ -14,6 +13,54 @@ type searchCmd struct {
 	Short      bool   `short:"s" help:"Short listing."`
 	Constraint string `arg:"" help:"Package regex." optional:""`
 	JSONFormattable
+}
+
+// searchResult resolved from a manifest.
+type searchResult struct {
+	Name           string
+	Versions       []string
+	Channels       []string
+	CurrentVersion string
+	Description    string
+}
+
+// buildSearchResult constructs a search result from packages with same name
+// p is an array expected to be package with same name
+func buildSearchResult(p []*manifest.Package) *searchResult {
+	out := &searchResult{
+		Versions: make([]string, 0),
+		Channels: make([]string, 0),
+	}
+
+	for _, pkg := range p {
+		if out.Name == "" {
+			out.Name = pkg.Reference.Name
+			out.Description = pkg.Description
+		}
+		ver := pkg.Reference.StringNoName()
+		if pkg.Reference.IsChannel() {
+			out.Channels = append(out.Channels, ver)
+		} else {
+			out.Versions = append(out.Versions, ver)
+		}
+		if pkg.Linked {
+			out.CurrentVersion = ver
+		}
+	}
+
+	return out
+}
+
+func buildSearchJSONResults(byName map[string][]*manifest.Package, names []string) interface{} {
+	packages := make([]*searchResult, 0)
+
+	for _, name := range names {
+		pg := byName[name]
+
+		packages = append(packages, buildSearchResult(pg))
+	}
+
+	return packages
 }
 
 func (s *searchCmd) Run(l *ui.UI, env *hermit.Env, state *state.State) error {
@@ -50,9 +97,16 @@ func (s *searchCmd) Run(l *ui.UI, env *hermit.Env, state *state.State) error {
 		}
 		return nil
 	}
-	err = listPackages(pkgs, true, s.JSON, l)
+
+	err = listPackages(pkgs, &listPackageOption{
+		AllVersions:   false,
+		TransformJSON: buildSearchJSONResults,
+		UI:            l,
+		JSON:          s.JSON,
+	})
 	if err != nil {
-		return errors.Wrapf(err, "error listing search result")
+		return errors.Wrapf(err, "error listing packages")
 	}
+
 	return nil
 }


### PR DESCRIPTION
This PR streamlined the output of search result

an example of the result looks like this

`go run ./cmd/hermit search "^go$|hugo" --json | jq | pbcopy`

```
[
  {
    "Name": "go",
    "Versions": [
      "1.17rc1",
      "1.18beta1",
      "1.18beta2",
      "1.13.5",
      "1.14.4",
      "1.14.7",
      "1.15.2",
      "1.15.3",
      "1.15.6",
      "1.15.7",
      "1.15.11",
      "1.16",
      "1.16.3",
      "1.16.4",
      "1.16.5",
      "1.16.6",
      "1.16.7",
      "1.17",
      "1.17.1",
      "1.17.2",
      "1.17.3",
      "1.17.7",
      "1.17.8",
      "1.17.9",
      "1.17.10",
      "1.18",
      "1.18.1",
      "1.18.2"
    ],
    "Channels": [
      "@1",
      "@1.13",
      "@1.14",
      "@1.15",
      "@1.16",
      "@1.17",
      "@1.18",
      "@latest",
      "@tip"
    ],
    "CurrentVersion": "1.17.10",
    "Description": "Go is an open source programming language that makes it easy to build simple, reliable, and efficient software."
  },
  {
    "Name": "hugo",
    "Versions": [
      "0.82.0",
      "0.84.3",
      "0.84.4",
      "0.85.0",
      "0.86.0",
      "0.86.1",
      "0.87.0",
      "0.88.0",
      "0.88.1",
      "0.89.0",
      "0.89.1",
      "0.89.2",
      "0.89.3",
      "0.89.4",
      "0.91.2",
      "0.92.0",
      "0.92.1",
      "0.92.2",
      "0.93.0",
      "0.93.1",
      "0.93.2",
      "0.93.3",
      "0.94.0",
      "0.94.1",
      "0.94.2",
      "0.95.0",
      "0.96.0",
      "0.97.0",
      "0.97.1",
      "0.97.2",
      "0.97.3",
      "0.98.0",
      "0.99.0"
    ],
    "Channels": [
      "@0",
      "@0.82",
      "@0.84",
      "@0.85",
      "@0.86",
      "@0.87",
      "@0.88",
      "@0.89",
      "@0.91",
      "@0.92",
      "@0.93",
      "@0.94",
      "@0.95",
      "@0.96",
      "@0.97",
      "@0.98",
      "@0.99",
      "@latest"
    ],
    "CurrentVersion": "0.91.2",
    "Description": "Hugo is one of the most popular open-source static site generators. With its amazing speed and flexibility, Hugo makes building websites fun again."
  }
]

```