### PR TITLE
fix: call listPackages in List command and fix allVersions in Search command CLI

### DIFF
--- a/app/list_cmd.go
+++ b/app/list_cmd.go
@@ -54,11 +54,11 @@ func (cmd *listCmd) Run(l *ui.UI, env *hermit.Env) error {
 		}
 		return nil
 	}
-	err = listPackagesInJSONFormat(pkgs, &listPackageOption{
+	err = listPackages(pkgs, &listPackageOption{
 		AllVersions:   false,
 		TransformJSON: buildListJSONResult,
 		UI:            l,
-		JSON:          false,
+		JSON:          cmd.JSON,
 	})
 	if err != nil {
 		return errors.Wrapf(err, "error listing packages")

--- a/app/search_cmd.go
+++ b/app/search_cmd.go
@@ -99,7 +99,7 @@ func (s *searchCmd) Run(l *ui.UI, env *hermit.Env, state *state.State) error {
 	}
 
 	err = listPackages(pkgs, &listPackageOption{
-		AllVersions:   false,
+		AllVersions:   true,
 		TransformJSON: buildSearchJSONResults,
 		UI:            l,
 		JSON:          s.JSON,


### PR DESCRIPTION
This PR fixes errors in the argument passing in both list and search command

1. list command should call `listPackages`
2. search command should pass in AllVersions = true in the options for CLI output