### PR TITLE
feat: add Repository attribute in Manifest and Package  struct, will infer if empty

### DIFF
--- a/app/search_cmd.go
+++ b/app/search_cmd.go
@@ -23,6 +23,7 @@ type searchResult struct {
 	Channels       []string
 	CurrentVersion string
 	Description    string
+	Repository     string
 }
 
 // buildSearchResult constructs a search result from packages with same name
@@ -34,6 +35,9 @@ func buildSearchResult(p []*manifest.Package) *searchResult {
 	}
 
 	for _, pkg := range p {
+		if out.Repository == "" {
+			out.Repository = pkg.Repository
+		}
 		if out.Name == "" {
 			out.Name = pkg.Reference.Name
 			out.Description = pkg.Description

--- a/manifest/config.go
+++ b/manifest/config.go
@@ -146,6 +146,7 @@ type Manifest struct {
 	Default     string         `hcl:"default,optional" help:"Default version or channel if not specified."`
 	Description string         `hcl:"description" help:"Human readable description of the package."`
 	Homepage    string         `hcl:"homepage,optional" help:"Home page."`
+	Repository  string         `hcl:"repository,optional" help:"Source Repository."`
 	Versions    []VersionBlock `hcl:"version,block" help:"Definition of and configuration for a specific version."`
 	Channels    []ChannelBlock `hcl:"channel,block" help:"Definition of and configuration for an auto-update channel."`
 }

--- a/manifest/resolver_repository_test.go
+++ b/manifest/resolver_repository_test.go
@@ -1,0 +1,48 @@
+package manifest
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestInferRepository(t *testing.T) {
+	tests := []struct {
+		name               string
+		Package            *Package
+		expectedRepository string
+	}{
+		{
+			name:               "empty repository on no source",
+			Package:            &Package{},
+			expectedRepository: "",
+		},
+		{
+			name:               "not changing repository on exists",
+			Package:            &Package{Repository: "https://github.com/cashapp/hermit-packages", Source: "https://github.com/bpkg/bpkg/archive/refs/tags/${version}.tar.gz"},
+			expectedRepository: "https://github.com/cashapp/hermit-packages",
+		},
+		{
+			name:               "only able to infer repository from github com",
+			Package:            &Package{Source: "https://awscli.amazonaws.com/AWSCLIV2-2.5.0.pkg"},
+			expectedRepository: "",
+		},
+		{
+			name:               "not inferring from https://github.com/cashapp/hermit-build",
+			Package:            &Package{Source: "https://github.com/cashapp/hermit-build/releases/download/bash/bash-4.3.0-osx-arm64.xz"},
+			expectedRepository: "",
+		},
+		{
+			name:               "infer github.com repository from source",
+			Package:            &Package{Source: "https://github.com/bpkg/bpkg/archive/refs/tags/${version}.tar.gz"},
+			expectedRepository: "https://github.com/bpkg/bpkg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inferPackageRepository(tt.Package)
+
+			require.Equal(t, tt.Package.Repository, tt.expectedRepository)
+		})
+	}
+}


### PR DESCRIPTION
This PR add Repository attribute in the Manifest and Package struct

1. If it is not specified in the Manifest struct, it will try to infer it from package's source url
2. Passing the Repository attribute in Package struct so that we could have it in the info/list/search commands

Purpose of this is to have the repository url so that renovate could lift this up and fetch changelog/release note when constructing the PR. 