### PR TITLE
fix: pick up repository from auto-version => github-release

### DIFF
--- a/manifest/resolver_repository_test.go
+++ b/manifest/resolver_repository_test.go
@@ -10,6 +10,7 @@ func TestInferRepository(t *testing.T) {
 		name               string
 		Package            *Package
 		expectedRepository string
+		Manifest           *Manifest
 	}{
 		{
 			name:               "empty repository on no source",
@@ -36,11 +37,26 @@ func TestInferRepository(t *testing.T) {
 			Package:            &Package{Source: "https://github.com/bpkg/bpkg/archive/refs/tags/${version}.tar.gz"},
 			expectedRepository: "https://github.com/bpkg/bpkg",
 		},
+		{
+			name:    "able to figure out from manifest from github auto version",
+			Package: &Package{Source: "git@github.com:cashapp/test-project.git#v${version"},
+			Manifest: &Manifest{
+				Versions: []VersionBlock{
+					{
+						Version: nil,
+						AutoVersion: &AutoVersionBlock{
+							GitHubRelease: "cashapp/test-project",
+						},
+					},
+				},
+			},
+			expectedRepository: "https://github.com/cashapp/test-project",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			inferPackageRepository(tt.Package)
+			inferPackageRepository(tt.Package, tt.Manifest)
 
 			require.Equal(t, tt.Package.Repository, tt.expectedRepository)
 		})


### PR DESCRIPTION
This PR picks up github repository from auto-version => github-release. Making it easy form some repository on github but ship their releases from places other than github

example.

```
go run ./cmd/hermit search consul --json | jq                         ─╯
[
  {
    "Name": "consul",
    "Versions": [
      "1.9.17",
      "1.10.3",
      "1.11.1",
      "1.11.2",
      "1.11.3",
      "1.11.4",
      "1.11.5",
      "1.12.0"
    ],
    "Channels": [
      "@1",
      "@1.10",
      "@1.11",
      "@1.12",
      "@1.9",
      "@latest"
    ],
    "CurrentVersion": "",
    "Description": "Consul is a distributed, highly available, and data center aware solution to connect and configure applications across dynamic, distributed infrastructure.",
    "Repository": "https://github.com/hashicorp/consul"
  }
]
```

also source of the concul hermit-packages

https://github.com/cashapp/hermit-packages/blob/master/consul.hcl