### PR TITLE
fix: Do not remove source dir from disk if both pull and clone fail

### DIFF
--- a/sources/git_test.go
+++ b/sources/git_test.go
@@ -1,0 +1,47 @@
+package sources_test
+
+import (
+	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/sources"
+	"github.com/cashapp/hermit/ui"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"testing"
+)
+
+type FailingGit struct {
+	err error
+}
+
+func (f *FailingGit) RunInDir(_ *ui.Task, _ string, _ ...string) error {
+	return f.err
+}
+
+func TestGitDoesNotRemoveSourceAfterSyncFailure(t *testing.T) {
+	git := &FailingGit{}
+	sourceDir := t.TempDir()
+	source := sources.NewGitSource("git://test", sourceDir, git)
+
+	// Create the initial directory for sources by successfully syncing
+	u, _ := ui.NewForTesting()
+	err := source.Sync(u, true)
+	require.NoError(t, err)
+	files, err := ioutil.ReadDir(sourceDir)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	gitDir := files[0].Name()
+
+	// Fail the sync
+	git.err = errors.New("failing git fails")
+	err = source.Sync(u, true)
+
+	// no error as it was not an initial clone
+	require.NoError(t, err)
+
+	// the directory should still be in place after git failed to update
+	files, err = ioutil.ReadDir(sourceDir)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, gitDir, files[0].Name())
+
+}

--- a/sources/sources.go
+++ b/sources/sources.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"github.com/cashapp/hermit/util"
 	"io/fs"
 	"net/url"
 	"os"
@@ -90,7 +91,7 @@ func getSource(b *ui.UI, source, dir, env string) (Source, error) {
 	defer task.Done()
 
 	if strings.HasSuffix(source, ".git") {
-		return NewGitSource(source, dir), nil
+		return NewGitSource(source, dir, &util.RealCommandRunner{}), nil
 	}
 
 	uri, err := url.Parse(source)

--- a/util/run.go
+++ b/util/run.go
@@ -12,6 +12,19 @@ import (
 	"github.com/cashapp/hermit/ui"
 )
 
+// CommandRunner abstracts how we run command in a given directory
+type CommandRunner interface {
+	// RunInDir runs a command in the given directory.
+	RunInDir(log *ui.Task, dir string, args ...string) error
+}
+
+// RealCommandRunner actually calls command
+type RealCommandRunner struct{}
+
+func (g *RealCommandRunner) RunInDir(task *ui.Task, dir string, commands ...string) error { // nolint: golint
+	return errors.WithStack(RunInDir(task, dir, commands...))
+}
+
 // Run a command, outputting to stdout and stderr.
 func Run(log *ui.Task, args ...string) error {
 	return RunInDir(log, "", args...)


### PR DESCRIPTION
Turns out that we were removing the source directory before running `git clone` If that failed, the directory was removed, leading to potentially wrong manifests being used from separate sources.

Fixes https://github.com/cashapp/hermit/issues/282