### PR TITLE
feat: configurable lock timeout

### DIFF
--- a/app/commands.go
+++ b/app/commands.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"github.com/alecthomas/kong"
+	"time"
 
 	"github.com/cashapp/hermit/envars"
 	"github.com/cashapp/hermit/ui"
@@ -20,6 +21,7 @@ type cliInterface interface {
 	getQuiet() bool
 	getLevel() ui.Level
 	getGlobalState() GlobalState
+	getLockTimeout() time.Duration
 }
 
 type cliBase struct {
@@ -30,6 +32,7 @@ type cliBase struct {
 	Trace       bool             `help:"Enable trace logging." short:"t"`
 	Quiet       bool             `help:"Disable logging and progress UI, except fatal errors." env:"HERMIT_QUIET" short:"q"`
 	Level       ui.Level         `help:"Set minimum log level (${enum})." env:"HERMIT_LOG" default:"auto" enum:"auto,trace,debug,info,warn,error,fatal"`
+	LockTimeout time.Duration    `help:"Timeout for waiting on the lock" default:"30s" `
 	GlobalState
 
 	Init       initCmd       `cmd:"" help:"Initialise an environment (idempotent)." group:"env"`
@@ -51,13 +54,14 @@ type cliBase struct {
 
 var _ cliInterface = &cliBase{}
 
-func (u *cliBase) getCPUProfile() string       { return u.CPUProfile }
-func (u *cliBase) getMemProfile() string       { return u.MemProfile }
-func (u *cliBase) getTrace() bool              { return u.Trace }
-func (u *cliBase) getDebug() bool              { return u.Debug }
-func (u *cliBase) getQuiet() bool              { return u.Quiet }
-func (u *cliBase) getLevel() ui.Level          { return ui.AutoLevel(u.Level) }
-func (u *cliBase) getGlobalState() GlobalState { return u.GlobalState }
+func (u *cliBase) getCPUProfile() string         { return u.CPUProfile }
+func (u *cliBase) getMemProfile() string         { return u.MemProfile }
+func (u *cliBase) getTrace() bool                { return u.Trace }
+func (u *cliBase) getDebug() bool                { return u.Debug }
+func (u *cliBase) getQuiet() bool                { return u.Quiet }
+func (u *cliBase) getLevel() ui.Level            { return ui.AutoLevel(u.Level) }
+func (u *cliBase) getGlobalState() GlobalState   { return u.GlobalState }
+func (u *cliBase) getLockTimeout() time.Duration { return u.LockTimeout }
 
 // CLI structure.
 type unactivated struct {

--- a/app/main.go
+++ b/app/main.go
@@ -221,6 +221,12 @@ func Main(config Config) {
 	if err != nil {
 		log.Fatalf("failed to open cache: %s", err)
 	}
+
+	ctx, err := parser.Parse(os.Args[1:])
+	parser.FatalIfErrorf(err)
+	configureLogging(cli, ctx.Command(), p)
+
+	config.State.LockTimeout = cli.getLockTimeout()
 	sta, err = state.Open(hermit.UserStateDir, config.State, cache)
 	if err != nil {
 		log.Fatalf("failed to open state: %s", err)
@@ -242,10 +248,6 @@ func Main(config Config) {
 		kongplete.WithPredictor("hclfile", complete.PredictFiles("*.hcl")),
 		kongplete.WithPredictor("file", complete.PredictFiles("*")),
 	)
-
-	ctx, err := parser.Parse(os.Args[1:])
-	parser.FatalIfErrorf(err)
-	configureLogging(cli, ctx.Command(), p)
 
 	if pprofPath := cli.getCPUProfile(); pprofPath != "" {
 		f, err := os.Create(pprofPath)

--- a/util/flock.go
+++ b/util/flock.go
@@ -51,7 +51,8 @@ func (l *FileLock) Acquire(ctx context.Context, log ui.Logger) error {
 						return nil
 					}
 				case <-ctx.Done():
-					return errors.New("timeout while waiting for the lock")
+					deadLine, _ := ctx.Deadline()
+					return errors.Errorf("timeout while waiting for the lock after %s", time.Until(deadLine))
 				}
 			}
 		}

--- a/util/flock_test.go
+++ b/util/flock_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,7 +34,8 @@ func TestFileLockTimeout(t *testing.T) {
 
 	lock2 := NewLock(file, 10*time.Millisecond)
 	err2 := lock2.Acquire(timeoutCtx, logger2)
-	require.Equal(t, "timeout while waiting for the lock", err2.Error())
+
+	require.Equal(t, strings.HasPrefix(err2.Error(), "timeout while waiting for the lock"), true)
 
 	require.Contains(t, logger2buf.String(), "Waiting for a lock at "+file)
 }


### PR DESCRIPTION
This PR provides `--lock-timeout` flag in the CLI to make acquire lock timeout from a hard coded `30s` to configurable via CLI. 

default value is set to `30s` so it would have no impact for current users .