### PR TITLE
feat: add exact flag to search

### DIFF
--- a/app/search_cmd.go
+++ b/app/search_cmd.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/cashapp/hermit"
 	"github.com/cashapp/hermit/errors"
@@ -11,9 +12,9 @@ import (
 )
 
 type searchCmd struct {
-	Short      bool   `short:"s" help:"Short listing."`
-	Constraint string `arg:"" help:"Package regex." optional:""`
-	Exact      bool   `short:"e" long:"exact" help:"Exact name matches only."`
+	Short   bool   `short:"s" help:"Short listing."`
+	Pattern string `arg:"" help:"Either a search term or regex to match a package name." optional:""`
+	Exact   bool   `short:"e" long:"exact" help:"Exact name matches only. Not compatible with regex patterns."`
 	JSONFormattable
 }
 
@@ -74,15 +75,16 @@ func (s *searchCmd) Run(l *ui.UI, env *hermit.Env, state *state.State) error {
 		pkgs manifest.Packages
 		err  error
 	)
+	pattern := s.Pattern
 	if s.Exact {
-		s.Constraint = "^" + s.Constraint + "$"
+		pattern = "^" + regexp.QuoteMeta(pattern) + "$"
 	}
 	if env != nil {
 		err = env.Update(l, false)
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		pkgs, err = env.Search(l, s.Constraint)
+		pkgs, err = env.Search(l, pattern)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -95,7 +97,7 @@ func (s *searchCmd) Run(l *ui.UI, env *hermit.Env, state *state.State) error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		pkgs, err = state.Search(l, s.Constraint)
+		pkgs, err = state.Search(l, pattern)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -112,7 +114,7 @@ func (s *searchCmd) Run(l *ui.UI, env *hermit.Env, state *state.State) error {
 		TransformJSON: buildSearchJSONResults,
 		UI:            l,
 		JSON:          s.JSON,
-		Prefix:        s.Constraint,
+		Prefix:        s.Pattern,
 	})
 	if err != nil {
 		return errors.Wrapf(err, "error listing packages")

--- a/app/search_cmd.go
+++ b/app/search_cmd.go
@@ -13,6 +13,7 @@ import (
 type searchCmd struct {
 	Short      bool   `short:"s" help:"Short listing."`
 	Constraint string `arg:"" help:"Package regex." optional:""`
+	Exact      bool   `short:"e" long:"exact" help:"Exact name matches only."`
 	JSONFormattable
 }
 
@@ -73,6 +74,9 @@ func (s *searchCmd) Run(l *ui.UI, env *hermit.Env, state *state.State) error {
 		pkgs manifest.Packages
 		err  error
 	)
+	if s.Exact {
+		s.Constraint = "^" + s.Constraint + "$"
+	}
 	if env != nil {
 		err = env.Update(l, false)
 		if err != nil {


### PR DESCRIPTION
checks for exact package name match only.

an alternative approach is to add the `exact` flag to `(*Resolver).Search` - which would have the benefit of being faster (fewer packages to manage) but would add more complexity to an already complex function. happy to make that change instead if you'd prefer!

test cases

```
▶  go run cmd/hermit/main.go search python -e
(returns nothing, no exact matches)

▶ go run cmd/hermit/main.go search go -e
go (@1.15, @1.16, @1.17, 1.17rc1, @1, @1.13, @1.14, @1.18, @latest, 1.18beta1, 1.18beta2, 1.19beta1, @tip, 1.13.5, 1.14.4, 1.14.7, 1.15.2, 1.15.3, 1.15.6, 1.15.7, 1.15.11, 1.16, 1.16.3, 1.16.4, 1.16.5, 1.16.6, 1.16.7, 1.17, 1.17.1, 1.17.2, 1.17.3, 1.17.7, 1.17.8, 1.17.9, 1.17.10, 1.18, 1.18.1, 1.18.2, 1.18.3)
  Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.

▶ go run cmd/hermit/main.go search go
go (1.17rc1, @1, @1.13, @1.14, @1.15, @1.16, @1.17, @1.18, @latest, @tip, 1.18beta1, 1.18beta2, 1.19beta1, 1.13.5, 1.14.4, 1.14.7, 1.15.2, 1.15.3, 1.15.6, 1.15.7, 1.15.11, 1.16, 1.16.3, 1.16.4, 1.16.5, 1.16.6, 1.16.7, 1.17, 1.17.1, 1.17.2, 1.17.3, 1.17.7, 1.17.8, 1.17.9, 1.17.10, 1.18, 1.18.1, 1.18.2, 1.18.3)
  Go is an open source programming language that makes it easy to build simple, reliable, and efficient software.
go-swagger (@0, @0.28, @0.29, @latest, 0.28.0, 0.29.0)
  Swagger 2.0 implementation for Go
[additional output truncated]
```