### PR TITLE
feat: add "package-index" command

### DIFF
--- a/app/commands.go
+++ b/app/commands.go
@@ -1,8 +1,9 @@
 package app
 
 import (
-	"github.com/alecthomas/kong"
 	"time"
+
+	"github.com/alecthomas/kong"
 
 	"github.com/cashapp/hermit/envars"
 	"github.com/cashapp/hermit/ui"
@@ -49,6 +50,7 @@ type cliBase struct {
 	DumpUserConfigSchema dumpUserConfigSchema `cmd:"" help:"Dump user configuration schema." hidden:""`
 	ScriptSHA            scriptSHACmd         `cmd:"" help:"Print known sha256 sums of activate-hermit and hermit scripts." hidden:""`
 	GenInstaller         genInstallerCmd      `cmd:"" help:"Generate Hermit installer script." group:"global"`
+	PackageIndex         packageIndexCmd      `cmd:"" help:"Generate a static package index from a set of package sources." group:"global"`
 	kong.Plugins
 }
 

--- a/app/package_index_cmd.go
+++ b/app/package_index_cmd.go
@@ -1,0 +1,40 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/cashapp/hermit"
+	"github.com/cashapp/hermit/cache"
+	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/state"
+	"github.com/cashapp/hermit/ui"
+	"github.com/qdm12/reprint"
+)
+
+type packageIndexCmd struct {
+	Source []string `help:"Set of sources to index."`
+}
+
+func (i *packageIndexCmd) Run(config Config, l *ui.UI, cache *cache.Cache) error {
+	var stateConfig state.Config
+	if err := reprint.FromTo(&config.State, &stateConfig); err != nil {
+		return errors.Wrap(err, "failed to copy config?!")
+	}
+	if len(i.Source) > 0 {
+		stateConfig.Sources = i.Source
+	}
+	st, err := state.Open(hermit.UserStateDir, stateConfig, cache)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	pkgs, err := st.Search(l, "")
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	err = json.NewEncoder(os.Stdout).Encode(pkgs)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}

--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -70,25 +70,26 @@ type ResolvedFileRef struct {
 
 // Package resolved from a manifest.
 type Package struct {
-	Description          string
-	Homepage             string
-	Repository           string
-	Reference            Reference
-	Arch                 string
-	Binaries             []string
-	Apps                 []string
-	Requires             []string
-	RuntimeDeps          []Reference
-	Provides             []string
-	Env                  envars.Ops
-	Source               string
-	Mirrors              []string
-	Root                 string
-	SHA256               string
-	Mutable              bool
-	Dest                 string
-	Test                 string
-	Strip                int
+	Description string      `json:",omitempty"`
+	Homepage    string      `json:",omitempty"`
+	Repository  string      `json:",omitempty"`
+	Reference   Reference   `json:",omitempty"`
+	Arch        string      `json:",omitempty"`
+	Binaries    []string    `json:",omitempty"`
+	Apps        []string    `json:",omitempty"`
+	Requires    []string    `json:",omitempty"`
+	RuntimeDeps []Reference `json:",omitempty"`
+	Provides    []string    `json:",omitempty"`
+	Env         envars.Ops  `json:",omitempty"`
+	Source      string      `json:",omitempty"`
+	Mirrors     []string    `json:",omitempty"`
+	Root        string      `json:",omitempty"`
+	SHA256      string      `json:",omitempty"`
+	Mutable     bool        `json:",omitempty"`
+	Dest        string      `json:",omitempty"`
+	Test        string      `json:",omitempty"`
+	Strip       int         `json:",omitempty"`
+
 	Triggers             map[Event][]Action  `json:"-"` // Triggers keyed by event.
 	UpdateInterval       time.Duration       // How often should we check for updates? 0, if never
 	Files                []*ResolvedFileRef  `json:"-"`
@@ -99,8 +100,8 @@ type Package struct {
 	// Filled in by Env.
 	Linked    bool `json:"-"` // Linked into environment.
 	State     PackageState
-	ETag      string
-	UpdatedAt time.Time
+	ETag      string    `json:",omitempty"`
+	UpdatedAt time.Time `json:",omitempty"`
 }
 
 func (p *Package) String() string {

--- a/manifest/version.go
+++ b/manifest/version.go
@@ -190,8 +190,8 @@ func (r References) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
 // A Reference to a package, potentially only providing partial versions, etc.
 type Reference struct {
 	Name    string
-	Version Version
-	Channel string
+	Version Version `json:",omitempty"`
+	Channel string  `json:",omitempty"`
 }
 
 // ParseReference parses a name+version for a package.

--- a/state/state.go
+++ b/state/state.go
@@ -144,12 +144,14 @@ func (s *State) Resolve(l *ui.UI, mathcer manifest.Selector) (*manifest.Package,
 }
 
 // Search for packages without an active environment.
-func (s *State) Search(l *ui.UI, glob string) (manifest.Packages, error) {
+//
+// "pattern" is passed to Resolver.Search
+func (s *State) Search(l *ui.UI, pattern string) (manifest.Packages, error) {
 	resolver, err := s.resolver(l)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	pkgs, err := resolver.Search(l, glob)
+	pkgs, err := resolver.Search(l, pattern)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}


### PR DESCRIPTION
This dumps the fully resolved list of all versions of all packages. This can be used for static package indexes, but is initially intended for use with Renovate.

One aspect I'm not 100% happy about is that this promotes what was previously just a public part of the Go API, into a permanent part of the Hermit "persistent" interface (similar to the bin dir, config files, etc.). But I don't have a better idea other than duplicating the entire structure 1:1.