### PR TITLE
fix: allow `requires = [...]` to secify versions

### DIFF
--- a/env.go
+++ b/env.go
@@ -1300,7 +1300,11 @@ func (e *Env) ResolveWithDeps(l *ui.UI, installed []manifest.Reference, selector
 		ref, err := e.resolveVirtual(l, req)
 		if err != nil && errors.Is(err, manifest.ErrUnknownPackage) {
 			// Secondly search by the package name
-			if err = e.ResolveWithDeps(l, installed, manifest.NameSelector(req), out); err != nil {
+			sel, err := manifest.ParseGlobSelector(req)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			if err = e.ResolveWithDeps(l, installed, sel, out); err != nil {
 				return errors.WithStack(err)
 			}
 		} else if err != nil {


### PR DESCRIPTION
Currently only a package name can be specified, but it's sometimes the
case that we need to specify an explicit version or version channel.