### PR TITLE
Support autoversion package sha256 verification

### DIFF
--- a/manifest/config.go
+++ b/manifest/config.go
@@ -40,7 +40,8 @@ type Layer struct {
 	Vars        map[string]string `hcl:"vars,optional" help:"Set local variables used during manifest evaluation."`
 	Source      string            `hcl:"source,optional" help:"URL for source package. Valid URLs are Git repositories (using .git[#<tag>] suffix), Local Files (using file:// prefix), and Remote Files (using http:// or https:// prefix)"`
 	Mirrors     []string          `hcl:"mirrors,optional" help:"Mirrors to use if the primary source is unavailable."`
-	SHA256      string            `hcl:"sha256,optional" help:"SHA256 of source package for verification."`
+	SHA256      string            `hcl:"sha256,optional" help:"SHA256 of source package for verification. When in conflict with SHA256 in sha256sums, this value takes precedence."`
+	SHA256Sums  map[string]string `hcl:"sha256sums,optional" help:"SHA256 checksums of source packages for verification."`
 	Darwin      []*Layer          `hcl:"darwin,block" help:"Darwin-specific configuration."`
 	Linux       []*Layer          `hcl:"linux,block" help:"Linux-specific configuration."`
 	Platform    []*PlatformBlock  `hcl:"platform,block" help:"Platform-specific configuration. <attr> is a set regexes that must all match against one of CPU, OS, etc.."`


### PR DESCRIPTION
This change makes it possible to do package sha256 check during package
installation for autoversioned packages. We do so by using an attribute
named `sha256sums` in the package manifest file, which is a map of
format

    {
     source1: source1_sha256,
     source2: source2_sha256
    }

e.g,

    sha256sums = {
      "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64": "3e8692fa751983b75b11392968b6244e48b8b56a3363257286840ac35a696c06",
      "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-linux-x86_64": "7cfd5c00b8bc7215bc99972017da1837c514856db6d72b8e44e9136cb4fe9054"
    }

When the package sha256 checksums in the `sha256` and `sha256sums`
attributes do not agree, the `sha256` attribute takes precedence over the
`sha256sums` attribute, for package integrity verification.

## Manual testing
Here's how I manually tested this change, on a `darwin-amd64` machine

1. Build `Hermit` from the PR branch
   ```bash
   # pwd is ~/Development/syncom/hermit
   make build CHANNEL=test
   gunzip build/hermit-darwin-amd64.gz # executable is build/hermit-darwin-amd64
   ```
2. Create a test project directory, and initialize Hermit in it
   ```bash
   mkdir -p /tmp/testp
   ~/Development/syncom/hermit/build/hermit-darwin-amd64 init
   export HERMIT_EXE=~/Development/syncom/hermit/build/hermit-darwin-amd64
   . bin/activate-hermit
   ```
3. Override the package sources in `bin/hermit.hcl` to using the `bin/` local directory for package manifest files
   ```text
   sources = ["env:///bin"]
   ```
4. Create a test manifest for package `sf-signer` to test positive and negative cases. Start with a known working manifest, [sfsigner.hcl](https://github.com/syncom/sf-signer/blob/9ce38739b22ef1086700dd6f5ff732f44d55da26/bin/sfsigner.hcl), which contains the right `sha256` values for either package source.  Tweak the content of this manifest file, and look at the result of `hermit install sfsigner-0.0.0`.
   - Expect success. Remove `sha256` attributes, and put the package checksums in `sha256sums`. The resulting `bin/sfsigner.hcl` has the following content.
     ```hcl
     description = "S/MIME File Signer"
     binaries    = ["sfsigner"]
     test        = "sfsigner version"

     version "0.0.0" {
       platform darwin amd64 {
         source = "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64"
         on unpack {
           rename { from = "${root}/sfsigner-darwin-x86_64" to = "${root}/sfsigner" }
         }
       }

       platform linux amd64 {
         source = "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-linux-x86_64"
         on unpack {
           rename { from = "${root}/sfsigner-linux-x86_64" to = "${root}/sfsigner" }
         }
       }
     }

     sha256sums = {
       "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64": "3e8692fa751983b75b11392968b6244e48b8b56a3363257286840ac35a696c06",
       "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-linux-x86_64": "7cfd5c00b8bc7215bc99972017da1837c514856db6d72b8e44e9136cb4fe9050"
     }
     ```
     Run `hermit install sfsigner-0.0.0`.
     ```bash
     testp🐚 /tmp/testp $ hermit install sfsigner-0.0.0
     hermit: sfsigner-0.0.0 is not supported on these Hermit platforms: [darwin-arm64], are you sure you want to install it? [y/N]
     y
     info:sfsigner-0.0.0:install: Installing sfsigner-0.0.0
     testp🐚 /tmp/testp $ echo $?
     0
     ```
   - Expect failure. Tamper with the last digit of the sha256 digest value for key "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64", in `sha256sums`. The resulting `bin/sfsigner.hcl` has the following content
     ```hcl
     description = "S/MIME File Signer"
     binaries    = ["sfsigner"]
     test        = "sfsigner version"

     version "0.0.0" {
       platform darwin amd64 {
         source = "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64"
         on unpack {
           rename { from = "${root}/sfsigner-darwin-x86_64" to = "${root}/sfsigner" }
         }
       }

       platform linux amd64 {
         source = "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-linux-x86_64"
         on unpack {
           rename { from = "${root}/sfsigner-linux-x86_64" to = "${root}/sfsigner" }
         }
       }
     }

     sha256sums = {
       "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64": "3e8692fa751983b75b11392968b6244e48b8b56a3363257286840ac35a696c07",
       "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-linux-x86_64": "7cfd5c00b8bc7215bc99972017da1837c514856db6d72b8e44e9136cb4fe9050"
     }
     ```
     Run `hermit install sfsigner-0.0.0`.
     ```bash
     testp🐚 /tmp/testp $ hermit uninstall sfsigner-0.0.0
     testp🐚 /tmp/testp $ sudo rm -rf ~/Library/Caches/hermit/
     testp🐚 /tmp/testp $ hermit install sfsigner-0.0.0
     [...]
     warn:sfsigner-0.0.0: Failed to download any of https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64 on attempt 3/3: https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64: checksum 3e8692fa751983b75b11392968b6244e48b8b56a3363257286840ac35a696c06 should have been 3e8692fa751983b75b11392968b6244e48b8b56a3363257286840ac35a696c07
     fatal:hermit: https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64: https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64: checksum 3e8692fa751983b75b11392968b6244e48b8b56a3363257286840ac35a696c06 should have been 3e8692fa751983b75b11392968b6244e48b8b56a3363257286840ac35a696c07
     $ echo $?
     1
     ```
   - Expect success. Add the `sha256` attribute for the `darwin-amd64` package, with the correct checksum value. Keep the incorrect checksum value in the corresponding `sha256sums` map. The resulting `bin/sfsigner.hcl` has the following content
     ```hcl
     description = "S/MIME File Signer"
     binaries    = ["sfsigner"]
     test        = "sfsigner version"

     version "0.0.0" {
       platform darwin amd64 {
         source = "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64"
         sha256 = "3e8692fa751983b75b11392968b6244e48b8b56a3363257286840ac35a696c06"
         on unpack {
           rename { from = "${root}/sfsigner-darwin-x86_64" to = "${root}/sfsigner" }
         }
       }

       platform linux amd64 {
         source = "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-linux-x86_64"
         on unpack {
           rename { from = "${root}/sfsigner-linux-x86_64" to = "${root}/sfsigner" }
         }
       }
     }

     sha256sums = {
       "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64": "3e8692fa751983b75b11392968b6244e48b8b56a3363257286840ac35a696c07",
       "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-linux-x86_64": "7cfd5c00b8bc7215bc99972017da1837c514856db6d72b8e44e9136cb4fe9050"
     }
     ```
     Run `hermit install sfsigner-0.0.0`.
     ```bash
     testp🐚 /tmp/testp $ hermit install sfsigner-0.0.0
     hermit: sfsigner-0.0.0 is not supported on these Hermit platforms: [darwin-arm64], are you sure you want to install it? [y/N]
     y
     info:sfsigner-0.0.0:install: Installing sfsigner-0.0.0
     testp🐚 /tmp/testp $ echo $?
     0
     ```
     This shows that the `sha256` attribute takes precedence over `sha256sums`, when there's a conflict in source package checksum.

   - Test autoversion. Expect failure. Use an autoversion block for package manifest, and tamper with the last digit of sha256 digest value for key "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64", in `sha256sums`. The resulting `bin/sfsigner.hcl` has the following content.
     ```hcl
     description = "S/MIME File Signer"
     binaries    = ["sfsigner"]
     test        = "sfsigner version"

     source = "https://github.com/syncom/sf-signer/releases/download/v${version}/sfsigner-${os}-${xarch}"

     on unpack {
       rename { from = "${root}/sfsigner-${os}-${xarch}" to = "${root}/sfsigner" }
     }

     version "0.0.0" {
       auto-version {
         github-release = "syncom/sf-signer"
       }
     }

     sha256sums = {
       "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64": "3e8692fa751983b75b11392968b6244e48b8b56a3363257286840ac35a696c07",
       "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-linux-x86_64": "7cfd5c00b8bc7215bc99972017da1837c514856db6d72b8e44e9136cb4fe9050"
     }
     ```
     Run `hermit install sfsigner-0.0.0`.
     ```bash
     testp🐚 /tmp/testp $ hermit uninstall sfsigner-0.0.0
     testp🐚 /tmp/testp $ sudo rm -rf ~/Library/Caches/hermit/
     testp🐚 /tmp/testp $ hermit install sfsigner-0.0.0
     [...]
     warn:sfsigner-0.0.0: Failed to download any of https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64 on attempt 3/3: https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64: checksum 3e8692fa751983b75b11392968b6244e48b8b56a3363257286840ac35a696c06 should have been 3e8692fa751983b75b11392968b6244e48b8b56a3363257286840ac35a696c07
     fatal:hermit: https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64: https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64: checksum 3e8692fa751983b75b11392968b6244e48b8b56a3363257286840ac35a696c06 should have been 3e8692fa751983b75b11392968b6244e48b8b56a3363257286840ac35a696c07
     ```

   - Test autoversion. Expect success. Use the correct `sha256` value for key "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64", in `sha256sums` in the above manifest file with an autoversion block. The resulting `bin/sfsigner.hcl` has the following content.

     ```hcl
     description = "S/MIME File Signer"
     binaries    = ["sfsigner"]
     test        = "sfsigner version"

     source = "https://github.com/syncom/sf-signer/releases/download/v${version}/sfsigner-${os}-${xarch}"

     on unpack {
       rename { from = "${root}/sfsigner-${os}-${xarch}" to = "${root}/sfsigner" }
     }

     version "0.0.0" {
       auto-version {
         github-release = "syncom/sf-signer"
       }
     }

     sha256sums = {
       "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-darwin-x86_64": "3e8692fa751983b75b11392968b6244e48b8b56a3363257286840ac35a696c06",
       "https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-linux-x86_64": "7cfd5c00b8bc7215bc99972017da1837c514856db6d72b8e44e9136cb4fe9050"
     }
     ```
     Run `hermit install sfsigner-0.0.0`.
     ```bash
     testp🐚 /tmp/testp $ hermit install sfsigner-0.0.0
     info:sfsigner-0.0.0:install: Installing sfsigner-0.0.0
     testp🐚 /tmp/testp $ echo $?
     0
     ```
