### PR TITLE
Support running hermit from different environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test: ## run tests
 
 build: ## builds binary and gzips it
 	mkdir -p $(BUILD_DIR)
-	CGO_ENABLED=0 go build -ldflags "-X main.version=$(VERSION) -X main.channel=$(CHANNEL)" -o $(BIN) $(ROOT)/cmd/hermit
+	CGO_ENABLED=0 ./bin/go build -ldflags "-X main.version=$(VERSION) -X main.channel=$(CHANNEL)" -o $(BIN) $(ROOT)/cmd/hermit
 	gzip -9 $(BIN)
 
 help: ## Display this help message

--- a/app/exec_cmd.go
+++ b/app/exec_cmd.go
@@ -23,17 +23,14 @@ type execCmd struct {
 }
 
 func (e *execCmd) Run(l *ui.UI, cache *cache.Cache, sta *state.State, env *hermit.Env, globalState GlobalState, config Config, defaultHTTPClient *http.Client) error {
-	envDir, err := hermit.EnvDirFromProxyLink(e.Binary)
+	envDir, err := hermit.FindEnvDir(e.Binary)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	// If we're running a binary from a different environment, activate it first.
-	activeEnv := os.Getenv("ACTIVE_HERMIT")
-	if env == nil || (activeEnv != "" && envDir != "" && activeEnv != envDir) {
-		env, err = hermit.OpenEnv(envDir, sta, cache.GetSource, globalState.Env, defaultHTTPClient, nil)
-		if err != nil {
-			return errors.WithStack(err)
-		}
+
+	env, err = hermit.OpenEnv(envDir, sta, cache.GetSource, globalState.Env, defaultHTTPClient, nil)
+	if err != nil {
+		return errors.WithStack(err)
 	}
 
 	args := []string{e.Binary}

--- a/app/main.go
+++ b/app/main.go
@@ -154,20 +154,20 @@ func Main(config Config) {
 		env *hermit.Env
 		sta *state.State
 	)
+	// By default, we assume Hermit will run in an unactivated state
 	isActivated := false
-	envPath := os.Getenv("HERMIT_ENV")
+	envPath, err := os.Getwd()
 	if err != nil {
-		log.Fatalf("failed to open state: %s", err) // nolint: gocritic
+		log.Fatalf("couldn't get working directory: %s", err) // nolint: gocritic
 	}
 	common := cliBase{Plugins: config.KongPlugins}
-	if envPath != "" {
+
+	// But we activate any environment we find
+	if envDir, err := hermit.FindEnvDir(os.Args[0]); err == nil {
+		envPath = envDir
 		isActivated = true
 		cli = &activated{cliBase: common}
 	} else {
-		envPath, err = os.Getwd()
-		if err != nil {
-			log.Fatalf("couldn't get working directory: %s", err)
-		}
 		cli = &unactivated{cliBase: common}
 	}
 

--- a/env.go
+++ b/env.go
@@ -220,8 +220,30 @@ func EnvDirFromProxyLink(executable string) (string, error) {
 	if filepath.Base(last) != "hermit" {
 		return "", errors.Errorf("binary is not a Hermit symlink: %s", links[0])
 	}
-	envDir := filepath.Dir(filepath.Dir(last))
-	return envDir, nil
+	last = filepath.Dir(last)
+	if filepath.Base(last) != "bin" {
+		return "", errors.Errorf("Hermit not in a bin directory: %s", links[0])
+	}
+	last = filepath.Dir(last)
+	return last, nil
+}
+
+// FindEnvDir finds the highest priority active Hermit environment
+func FindEnvDir(binary string) (envDir string, err error) {
+	// Prefer an adjacent environment
+	envDir, err = EnvDirFromProxyLink(binary)
+	if err == nil {
+		return
+	}
+
+	// Fallback to the environment from the environment variable
+	envDir = os.Getenv("HERMIT_ENV")
+	if envDir != "" {
+		return envDir, nil
+	}
+
+	// Pass up the error from EnvDirFromProxyLink
+	return
 }
 
 func getSources(l *ui.UI, envDir string, config *Config, state *state.State, defaultSources []string) (*sources.Sources, error) {

--- a/it/full/spec/it_spec.sh
+++ b/it/full/spec/it_spec.sh
@@ -135,6 +135,15 @@ Describe "Hermit"
       The stderr should be blank
       The stdout should not be blank
     End
+
+    It "stub from other environment get environment variables"
+      cd ../anotherenv
+      . bin/activate-hermit
+      When call ../testenv/bin/hermit env
+      The status should be success
+      The stderr should be blank
+      The stdout should include "GOBIN='$(cd ../testenv && pwd)/out/bin'"
+    End
   End
 
   Describe "uninstalling a package"


### PR DESCRIPTION
- [x] 📈 Improve the comments
- [x] ❌ Remove the special case in exec_cmd.go
- [x] 🏁 Check for `bin/hermit` instead of `bin/hermit.hcl`
- [x] ❓ Move `bin/hermit` check into env