### PR TITLE
fix: ignore-invalid-versions will iterate releases

### DIFF
--- a/github/api.go
+++ b/github/api.go
@@ -93,18 +93,21 @@ func (a *Client) LatestRelease(repo string) (*Release, error) {
 	return release, a.decode(url, release)
 }
 
-// Releases for a particular repo.
-func (a *Client) Releases(repo string) (releases []Release, err error) {
+// Releases for a particular repo. If limit is 0, fetches all releases.
+func (a *Client) Releases(repo string, limit int) (releases []*Release, err error) {
 	url := fmt.Sprintf("https://api.github.com/repos/%s/releases", repo)
 	// Paginate.
 	for n := 1; n < 100; n++ {
-		var page []Release
+		var page []*Release
 		url = fmt.Sprintf("%s?per_page=100&page=%d", url, n)
 		err = a.decode(url, &page)
 		if err != nil {
 			return nil, err
 		}
 		releases = append(releases, page...)
+		if limit > 0 && len(releases) >= limit {
+			return releases[:limit], nil
+		}
 		if len(page) < 100 {
 			return releases, nil
 		}

--- a/manifest/autoversion/autoversion.go
+++ b/manifest/autoversion/autoversion.go
@@ -15,6 +15,7 @@ import (
 // GitHubClient is the GitHub API subset that we need for auto-versioning.
 type GitHubClient interface {
 	LatestRelease(repo string) (*github.Release, error)
+	Releases(repo string, limit int) (releases []*github.Release, err error)
 }
 
 // AutoVersion rewrites the given manifest with new version information if applicable.

--- a/manifest/autoversion/autoversion_test.go
+++ b/manifest/autoversion/autoversion_test.go
@@ -15,10 +15,17 @@ import (
 	"github.com/cashapp/hermit/github"
 )
 
-type testGHAPI string
+type testGHAPI []string
 
 func (v testGHAPI) LatestRelease(repo string) (*github.Release, error) {
-	return &github.Release{TagName: string(v)}, nil
+	return &github.Release{TagName: v[0]}, nil
+}
+
+func (v testGHAPI) Releases(repo string, limit int) (releases []*github.Release, err error) {
+	for i := 0; i < limit && i < len(v); i++ {
+		releases = append(releases, &github.Release{TagName: v[i]})
+	}
+	return
 }
 
 type testHTTPClient struct {
@@ -54,7 +61,7 @@ func TestAutoVersion(t *testing.T) {
 			require.NoError(t, err)
 			tmpFile.Close()
 
-			ghClient := testGHAPI("v3.2.150")
+			ghClient := testGHAPI([]string{"v3.2.150"})
 			var hClient *http.Client
 			httpInput := strings.ReplaceAll(input, ".input.hcl", ".http")
 			if _, err := os.Stat(httpInput); err == nil {

--- a/manifest/autoversion/github_test.go
+++ b/manifest/autoversion/github_test.go
@@ -11,31 +11,43 @@ func TestGitHubVersions(t *testing.T) {
 	tests := []struct {
 		name            string
 		ignoreInvalid   bool
-		latestVersion   string
+		versions        []string
+		versionPattern  string
 		expectedVersion string
 		error           bool
 	}{
 		{
 			name:            "valid version",
-			latestVersion:   "v3.2",
+			versions:        []string{"v3.2"},
+			versionPattern:  "v(.*)",
 			expectedVersion: "3.2",
 		},
 		{
-			name:          "invalid version",
-			latestVersion: "3.2",
-			error:         true,
+			name:           "invalid version",
+			versions:       []string{"3.2"},
+			versionPattern: "v(.*)",
+			error:          true,
 		},
 		{
-			name:            "ignore invalid version",
-			latestVersion:   "3.2",
+			name:            "ignore invalid version with no valid versions",
+			versions:        []string{"kyaml/v0.13.9", "api/v3.2.2"},
+			versionPattern:  "kustomize/v(.*)",
 			ignoreInvalid:   true,
 			expectedVersion: "",
+			error:           true,
+		},
+		{
+			name:            "ignore invalid version containing valid version",
+			versions:        []string{"kyaml/v0.13.9", "kustomize/v3.2.2"},
+			versionPattern:  "kustomize/v(.*)",
+			ignoreInvalid:   true,
+			expectedVersion: "3.2.2",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			version, err := gitHub(testGHAPI(test.latestVersion), &manifest.AutoVersionBlock{
-				VersionPattern:        "v(.*)",
+			version, err := gitHub(testGHAPI(test.versions), &manifest.AutoVersionBlock{
+				VersionPattern:        test.versionPattern,
 				IgnoreInvalidVersions: test.ignoreInvalid,
 			})
 			if test.error {


### PR DESCRIPTION
Previously, it only looked at the last release. If multiple releases are published at the same time, and the latest one is invalid, hermit will not pick up any new releases.