### PR TITLE
feat: add ability to supply additional sources by command line or environment

### DIFF
--- a/app/commands.go
+++ b/app/commands.go
@@ -22,17 +22,19 @@ type cliInterface interface {
 	getLevel() ui.Level
 	getGlobalState() GlobalState
 	getLockTimeout() time.Duration
+	getAdditionalSources() []string
 }
 
 type cliBase struct {
-	VersionFlag kong.VersionFlag `help:"Show version." name:"version"`
-	CPUProfile  string           `placeholder:"PATH" name:"cpu-profile" help:"Enable CPU profiling to PATH." hidden:""`
-	MemProfile  string           `placeholder:"PATH" name:"mem-profile" help:"Enable memory profiling to PATH." hidden:""`
-	Debug       bool             `help:"Enable debug logging." short:"d"`
-	Trace       bool             `help:"Enable trace logging." short:"t"`
-	Quiet       bool             `help:"Disable logging and progress UI, except fatal errors." env:"HERMIT_QUIET" short:"q"`
-	Level       ui.Level         `help:"Set minimum log level (${enum})." env:"HERMIT_LOG" default:"auto" enum:"auto,trace,debug,info,warn,error,fatal"`
-	LockTimeout time.Duration    `help:"Timeout for waiting on the lock" default:"30s" env:"HERMIT_LOCK_TIMEOUT"`
+	VersionFlag       kong.VersionFlag `help:"Show version." name:"version"`
+	CPUProfile        string           `placeholder:"PATH" name:"cpu-profile" help:"Enable CPU profiling to PATH." hidden:""`
+	MemProfile        string           `placeholder:"PATH" name:"mem-profile" help:"Enable memory profiling to PATH." hidden:""`
+	Debug             bool             `help:"Enable debug logging." short:"d"`
+	Trace             bool             `help:"Enable trace logging." short:"t"`
+	Quiet             bool             `help:"Disable logging and progress UI, except fatal errors." env:"HERMIT_QUIET" short:"q"`
+	Level             ui.Level         `help:"Set minimum log level (${enum})." env:"HERMIT_LOG" default:"auto" enum:"auto,trace,debug,info,warn,error,fatal"`
+	LockTimeout       time.Duration    `help:"Timeout for waiting on the lock" default:"30s" env:"HERMIT_LOCK_TIMEOUT"`
+	AdditionalSources []string         `help:"Additional sources. Matched before those supplied in bin/hermit.hcl" env:"HERMIT_ADDITIONAL_SOURCES"`
 	GlobalState
 
 	Init       initCmd       `cmd:"" help:"Initialise an environment (idempotent)." group:"env"`
@@ -54,14 +56,15 @@ type cliBase struct {
 
 var _ cliInterface = &cliBase{}
 
-func (u *cliBase) getCPUProfile() string         { return u.CPUProfile }
-func (u *cliBase) getMemProfile() string         { return u.MemProfile }
-func (u *cliBase) getTrace() bool                { return u.Trace }
-func (u *cliBase) getDebug() bool                { return u.Debug }
-func (u *cliBase) getQuiet() bool                { return u.Quiet }
-func (u *cliBase) getLevel() ui.Level            { return ui.AutoLevel(u.Level) }
-func (u *cliBase) getGlobalState() GlobalState   { return u.GlobalState }
-func (u *cliBase) getLockTimeout() time.Duration { return u.LockTimeout }
+func (u *cliBase) getCPUProfile() string          { return u.CPUProfile }
+func (u *cliBase) getMemProfile() string          { return u.MemProfile }
+func (u *cliBase) getTrace() bool                 { return u.Trace }
+func (u *cliBase) getDebug() bool                 { return u.Debug }
+func (u *cliBase) getQuiet() bool                 { return u.Quiet }
+func (u *cliBase) getLevel() ui.Level             { return ui.AutoLevel(u.Level) }
+func (u *cliBase) getGlobalState() GlobalState    { return u.GlobalState }
+func (u *cliBase) getLockTimeout() time.Duration  { return u.LockTimeout }
+func (u *cliBase) getAdditionalSources() []string { return u.AdditionalSources }
 
 // CLI structure.
 type unactivated struct {

--- a/app/main.go
+++ b/app/main.go
@@ -236,6 +236,13 @@ func Main(config Config) {
 	configureLogging(cli, ctx.Command(), p)
 
 	config.State.LockTimeout = cli.getLockTimeout()
+	// Note. Set default sources before applying additional sources so that the
+	// defaulting behavior doesn't change depending on if additional sources are applied.
+	// The default sources shouldn't disappear if additional sources are supplied.
+	if config.State.Sources == nil {
+		config.State.Sources = state.DefaultSources
+	}
+	// Note. Pre-pend additional sources so that they are earlier in the list.
 	config.State.Sources = append(cli.getAdditionalSources(), config.State.Sources...)
 
 	sta, err = state.Open(hermit.UserStateDir, config.State, cache)

--- a/app/main.go
+++ b/app/main.go
@@ -235,17 +235,13 @@ func Main(config Config) {
 	parser.FatalIfErrorf(err)
 	configureLogging(cli, ctx.Command(), p)
 
-	config.State.LockTimeout = cli.getLockTimeout()
-	// Note. Set default sources before applying additional sources so that the
-	// defaulting behavior doesn't change depending on if additional sources are applied.
-	// The default sources shouldn't disappear if additional sources are supplied.
-	if config.State.Sources == nil {
-		config.State.Sources = state.DefaultSources
-	}
-	// Note. Pre-pend additional sources so that they are earlier in the list.
-	config.State.Sources = append(cli.getAdditionalSources(), config.State.Sources...)
-
-	sta, err = state.Open(hermit.UserStateDir, config.State, cache)
+	sta, err = state.Open(
+		hermit.UserStateDir,
+		config.State,
+		cli.getLockTimeout(),
+		cli.getAdditionalSources(),
+		cache,
+	)
 	if err != nil {
 		log.Fatalf("failed to open state: %s", err)
 	}

--- a/app/main.go
+++ b/app/main.go
@@ -236,6 +236,8 @@ func Main(config Config) {
 	configureLogging(cli, ctx.Command(), p)
 
 	config.State.LockTimeout = cli.getLockTimeout()
+	config.State.Sources = append(cli.getAdditionalSources(), config.State.Sources...)
+
 	sta, err = state.Open(hermit.UserStateDir, config.State, cache)
 	if err != nil {
 		log.Fatalf("failed to open state: %s", err)

--- a/env.go
+++ b/env.go
@@ -256,7 +256,7 @@ func getSources(l *ui.UI, envDir string, config *Config, state *state.State, def
 		return nil, errors.WithStack(err)
 	}
 	// Always include the builtin sources required by Hermit.
-	ss.Prepend(state.Config().Builtin)
+	ss.Prepend(state.Builtin())
 	return ss, nil
 }
 
@@ -1392,7 +1392,7 @@ func (e *Env) sources(l *ui.UI) (*sources.Sources, error) {
 	if e.lazySources != nil {
 		return e.lazySources, nil
 	}
-	sources, err := getSources(l, e.envDir, e.config, e.state, e.state.Config().Sources)
+	sources, err := getSources(l, e.envDir, e.config, e.state, e.state.DefaultSources())
 	if err != nil {
 		return nil, errors.Wrap(err, e.configFile)
 	}

--- a/hermittest/envfixture.go
+++ b/hermittest/envfixture.go
@@ -52,10 +52,16 @@ func NewEnvTestFixture(t *testing.T, handler http.Handler) *EnvTestFixture {
 	client := server.Client()
 	cache, err := cache.Open(stateDir, nil, client, client)
 	require.NoError(t, err)
-	sta, err := state.Open(stateDir, state.Config{
-		Sources: []string{},
-		Builtin: sources.NewBuiltInSource(vfs.InMemoryFS(nil)),
-	}, cache)
+	sta, err := state.Open(
+		stateDir,
+		state.Config{
+			Sources: []string{},
+			Builtin: sources.NewBuiltInSource(vfs.InMemoryFS(nil)),
+		},
+		0,
+		nil,
+		cache,
+	)
 	require.NoError(t, err)
 	env, err := hermit.OpenEnv(envDir, sta, cache.GetSource, envars.Envars{}, server.Client(), nil)
 	require.NoError(t, err)

--- a/state/state.go
+++ b/state/state.go
@@ -79,9 +79,6 @@ func Open(stateDir string, config Config, cache *cache.Cache) (*State, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	if config.Sources == nil {
-		config.Sources = DefaultSources
-	}
 
 	autoMirrors, err := validateAndCompileAutoMirrors(config)
 	if err != nil {

--- a/state/stateutils_test.go
+++ b/state/stateutils_test.go
@@ -68,9 +68,15 @@ func (f *StateTestFixture) State() *state.State {
 	client := f.Server.Client()
 	cache, err := cache.Open(root, nil, client, client)
 	require.NoError(f.t, err)
-	sta, err := state.Open(root, state.Config{
-		Builtin: sources.NewBuiltInSource(vfs.InMemoryFS(nil)),
-	}, cache)
+	sta, err := state.Open(
+		root,
+		state.Config{
+			Builtin: sources.NewBuiltInSource(vfs.InMemoryFS(nil)),
+		},
+		0,
+		nil,
+		cache,
+	)
 	require.NoError(f.t, err)
 	return sta
 }


### PR DESCRIPTION
Proposed Solution (1) from https://github.com/cashapp/hermit/issues/310.

Note, I didn't want the default source (`https://github.com/cashapp/hermit-packages.git`) to disappear when adding an additional source so the defaulting logic was moved up a level.

### Example Usage

Without additional sources:
```
> go run ./cmd/hermit status
Sources:
  builtin:///
  https://github.com/cashapp/hermit-packages.git
...
```

With additional sources:
```
> HERMIT_ADDITIONAL_SOURCES="https://github.com/example/hermit-packages.git" go run ./cmd/hermit status
Sources:
  builtin:///
  https://github.com/example/hermit-packages.git
  https://github.com/cashapp/hermit-packages.git
...
```