### PR TITLE
feat: add data uri scheme encoding as valid source

### DIFF
--- a/docs/content/usage/config.md
+++ b/docs/content/usage/config.md
@@ -21,5 +21,4 @@ Hermit supports three different manifest sources:
 1. Git repositories; any cloneable URI ending with `.git`, eg.<br/>`https://github.com/cashapp/hermit-packages.git`. An optional `#<tag>` suffix can be added to checkout a specific tag.
 2. Local filesystem, eg. `file:///home/user/my-packages`.<br/>This is mostly only useful for local development and testing.
 3. Environment relative, eg. `env:///my-packages`.<br/>This will search for package manifests in the directory `${HERMIT_ENV}/my-packages`. Useful for local overrides.
-
-	
+4. Data URI encode sources, eg. `data:application/json;base64,[BASE64 ENCODED JSON MAP]`.<br/>This will decode the data source as a JSON map of key binary name to value content. Useful for local overrides.

--- a/sources/data.go
+++ b/sources/data.go
@@ -1,0 +1,25 @@
+package sources
+
+import (
+	"encoding/json"
+
+	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/sources/datauri"
+)
+
+// NewDataSource parsed the uri as a [Data URI scheme](https://en.wikipedia.org/wiki/Data_URI_scheme).
+// See [RFC2397](https://www.rfc-editor.org/rfc/rfc2397) for additional information on the scheme.
+// The only valid content type is "application/json", the only valid encoding is "base64", &
+// it's assumed that the content encoded is a json map of binary name to file contents.
+func NewDataSource(uri string) (MemSource, error) {
+	decoded, err := datauri.Decode(uri)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to decode the data uri")
+	}
+
+	sources := map[string]string{}
+	if err := json.Unmarshal(decoded, &sources); err != nil {
+		return nil, errors.Wrap(err, "unable to unmarshall the json")
+	}
+	return NewMemSources(sources), nil
+}

--- a/sources/datauri/datauri.go
+++ b/sources/datauri/datauri.go
@@ -1,0 +1,36 @@
+package datauri
+
+import (
+	"encoding/base64"
+	"strings"
+
+	"github.com/cashapp/hermit/errors"
+)
+
+// Encoding using the [Data URI scheme](https://en.wikipedia.org/wiki/Data_URI_scheme)
+// See [RFC2397](https://www.rfc-editor.org/rfc/rfc2397) for additional information.
+const contentType = "application/json"
+const encoding = "base64"
+const prefix = "data:" + contentType + ";" + encoding + ","
+
+// Encode takes a `[]byte` content and generates a valid data URI.
+// This URI can be put into a browser to see the contents.
+func Encode(content []byte) string {
+	return prefix + base64.StdEncoding.EncodeToString(content)
+}
+
+var doesNotHavePrefixErr = errors.Errorf("Only data uris with json-type, base64-encoded are valid. URI must have prefix \"%s\"", prefix)
+
+// Decode takes a data URI and extracts the `[]byte` contents.
+func Decode(uri string) ([]byte, error) {
+	if !strings.HasPrefix(uri, prefix) {
+		//nolint: wrapcheck
+		return nil, doesNotHavePrefixErr
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(uri[len(prefix):])
+	if err != nil {
+		return nil, errors.Wrap(err, "error decoding data uri")
+	}
+	return decoded, nil
+}

--- a/sources/datauri/datauri_test.go
+++ b/sources/datauri/datauri_test.go
@@ -1,0 +1,24 @@
+package datauri
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test(t *testing.T) {
+	for _, expected := range [][]byte{
+		[]byte("{}"),
+		[]byte("{\"foo\":\"bar\"}"),
+		[]byte("[\n  1,\n  2\n]\n"),
+	} {
+		t.Run(string(expected), func(t *testing.T) {
+			encoded := Encode(expected)
+			fmt.Println(encoded)
+			actual, err := Decode(encoded)
+			require.NoError(t, err)
+			require.Equal(t, expected, actual)
+		})
+	}
+}

--- a/sources/memory.go
+++ b/sources/memory.go
@@ -1,33 +1,40 @@
 package sources
 
 import (
+	"encoding/json"
+	"fmt"
 	"io/fs"
 
+	"github.com/cashapp/hermit/sources/datauri"
 	"github.com/cashapp/hermit/ui"
 	"github.com/cashapp/hermit/vfs"
 )
 
 // MemSource is a new Source based on a name and content kept in memory
-type MemSource struct {
-	name    string
-	content string
-}
+type MemSource map[string]string
 
 // NewMemSource returns a new MemSource
-func NewMemSource(name, content string) *MemSource {
-	return &MemSource{name, content}
+func NewMemSource(name, content string) MemSource {
+	return NewMemSources(map[string]string{name: content})
 }
 
-func (s *MemSource) Sync(_ *ui.UI, _ bool) error { // nolint: golint
+// NewMemSources returns a new MemSource
+func NewMemSources(sources map[string]string) MemSource {
+	return sources
+}
+
+func (MemSource) Sync(_ *ui.UI, _ bool) error { // nolint: golint
 	return nil
 }
 
-func (s *MemSource) URI() string { // nolint: golint
-	return s.name
+func (s MemSource) URI() string { // nolint: golint
+	marshalled, err := json.Marshal(s)
+	if err != nil {
+		panic(fmt.Sprintf("json.Marshalling a map[string]string should never fail: %s", err))
+	}
+	return datauri.Encode(marshalled)
 }
 
-func (s *MemSource) Bundle() fs.FS { // nolint: golint
-	return vfs.InMemoryFS(map[string]string{
-		s.name: s.content,
-	})
+func (s MemSource) Bundle() fs.FS { // nolint: golint
+	return vfs.InMemoryFS(s)
 }

--- a/sources/sources.go
+++ b/sources/sources.go
@@ -98,6 +98,11 @@ func getSource(b *ui.UI, source, dir, env string) (Source, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid source")
 	}
+
+	if uri.Scheme == "data" {
+		return NewDataSource(source)
+	}
+
 	var (
 		// Directory of source, if any, to check for existence.
 		checkDir  string


### PR DESCRIPTION
Proposed Solution (2.b.) from https://github.com/cashapp/hermit/issues/310.

### Example Usage
Without additional sources:

```bash
example_config=$(cat <<EOF
description = "Description for example"
binaries = ["example"]
channel "unstable" {
 update = "5m"
 source = "git@github.com:cashapp/example.git#$EXAMPLE_VERSION"
}
EOF
)

override_sources=$(cat <<EOF
{"example": $(echo "$example_config" | jq -R -s '.')}
EOF
)

override_uri="data:application/json;base64,$(echo "$override_sources" | base64)"

HERMIT_ADDITIONAL_SOURCES="$override_uri" hermit ...
```

### Example URI

```bash
> echo "$override_uri"
data:application/json;base64,eyJleGFtcGxlIjogImRlc2NyaXB0aW9uID0gXCJEZXNjcmlwdGlvbiBmb3IgZXhhbXBsZVwiCmJpbmFyaWVzID0gW1wiZXhhbXBsZVwiXQpjaGFubmVsIFwidW5zdGFibGVcIiB7CiB1cGRhdGUgPSBcIjVtXCIKIHNvdXJjZSA9IFwiZ2l0QGdpdGh1Yi5jb206Y2FzaGFwcC9leGFtcGxlLmdpdCNtYWluXCIKfQoifQo
```