### PR TITLE
feat: allow "platform <pattern>" to match <os>-<arch>

### DIFF
--- a/manifest/config.go
+++ b/manifest/config.go
@@ -65,6 +65,7 @@ func (c Layer) layers(os string, arch string) (out layers) {
 			}
 		}
 	}
+	osArch := os + "-" + arch
 nextPlatform:
 	for _, platform := range c.Platform {
 		for _, attr := range platform.Attrs {
@@ -72,7 +73,7 @@ nextPlatform:
 			if err != nil {
 				continue
 			}
-			if !re.MatchString(os) && !re.MatchString(arch) {
+			if !re.MatchString(os) && !re.MatchString(arch) && !re.MatchString(osArch) {
 				continue nextPlatform
 			}
 		}
@@ -104,7 +105,7 @@ type HTMLAutoVersionBlock struct {
 //
 // The PlatformBlock replaces "linux" and "darwin".
 type PlatformBlock struct {
-	Attrs []string `hcl:"attr,label" help:"Platform attributes to match."`
+	Attrs []string `hcl:"attr,label" help:"Regex to match against platform attributes <arch>, <os>, and <arch>-<os>."`
 	Layer
 }
 

--- a/manifest/config_test.go
+++ b/manifest/config_test.go
@@ -121,6 +121,28 @@ func TestManifest(t *testing.T) {
 				Source:    "https://arm-linux-golang.org/dl/go1.14.4.linux-arm.tar.gz",
 			},
 		},
+		{name: "OSArchPlatformMatch",
+			manifest: `
+				binaries = ["bin/go"]
+				description = "Go"
+				platform "(darwin|linux)-amd64" {
+					source = "https://golang.org/dl/go${version}.${os}-${arch}.tar.gz"
+				}
+
+				platform arm64 {
+					source = "https://arm64-golang.org/dl/go${version}.${os}-${arch}.tar.gz"
+				}
+
+				version "1.14.4" {}
+			`,
+			os:   "linux",
+			arch: "amd64",
+			pkg:  "go-1.14.4",
+			expected: &Package{
+				Binaries: []string{"bin/go"},
+				Source:   "https://golang.org/dl/go1.14.4.linux-amd64.tar.gz",
+			},
+		},
 		{name: "PlatformOverlay",
 			manifest: `
 				description = "Go"


### PR DESCRIPTION
This will simplify some trickier packages that currently require a lot of duplication to work, such as [opa](https://github.com/cashapp/hermit-packages/blob/dd0f7b4e48b35354fae264e78ba5a6b82883a98d/opa.hcl#L29).