### PR TITLE
Nmahendru/autoversion digest update

### DIFF
--- a/app/auto_version_cmd.go
+++ b/app/auto_version_cmd.go
@@ -3,6 +3,8 @@ package app
 import (
 	"net/http"
 
+	"github.com/cashapp/hermit/state"
+
 	"github.com/cashapp/hermit/github"
 	"github.com/cashapp/hermit/manifest/autoversion"
 	"github.com/cashapp/hermit/ui"
@@ -12,10 +14,10 @@ type autoVersionCmd struct {
 	Manifest []string `arg:"" type:"existingfile" required:"" help:"Manifests to upgrade." predictor:"hclfile"`
 }
 
-func (s *autoVersionCmd) Run(l *ui.UI, hclient *http.Client, client *github.Client) error {
+func (s *autoVersionCmd) Run(l *ui.UI, hclient *http.Client, client *github.Client, state *state.State) error {
 	for _, path := range s.Manifest {
 		l.Debugf("Auto-versioning %s", path)
-		version, err := autoversion.AutoVersion(hclient, client, path)
+		version, err := autoversion.AutoVersion(hclient, client, path, state, l)
 		if err != nil {
 			l.Warnf("could not auto-version %q: %s", path, err)
 			continue

--- a/manifest/autoversion/autoversion.go
+++ b/manifest/autoversion/autoversion.go
@@ -104,7 +104,10 @@ blocks:
 	if err != nil {
 		return "", errors.WithStack(err)
 	}
-	err = manifestutils.PopulateDigests(l, state, annotated)
+	version := hmanifest.VersionBlock{
+		Version: []string{latestVersion},
+	}
+	err = manifestutils.PopulateDigestsForVersion(l, state, annotated, &version)
 	if err != nil {
 		return "", errors.WithStack(err)
 	}

--- a/manifest/autoversion/autoversion_test.go
+++ b/manifest/autoversion/autoversion_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cashapp/hermit/ui"
+
 	"github.com/alecthomas/assert/v2"
 	"github.com/cashapp/hermit/errors"
 	"github.com/cashapp/hermit/github"
@@ -68,8 +70,9 @@ func TestAutoVersion(t *testing.T) {
 					Transport: testHTTPClient{httpInput},
 				}
 			}
-
-			_, err = AutoVersion(hClient, ghClient, tmpFile.Name())
+			s := NewStateTestFixture(t)
+			l := ui.New(ui.LevelInfo, os.Stdout, os.Stderr, true, true)
+			_, err = AutoVersion(hClient, ghClient, tmpFile.Name(), s.State(), l)
 			assert.NoError(t, err)
 
 			actualContent, err := os.ReadFile(tmpFile.Name())

--- a/manifest/autoversion/autoversion_test.go
+++ b/manifest/autoversion/autoversion_test.go
@@ -62,7 +62,7 @@ func TestAutoVersion(t *testing.T) {
 			assert.NoError(t, err)
 			tmpFile.Close()
 
-			ghClient := testGHAPI([]string{"v3.2.150", "v5.1.234"})
+			ghClient := testGHAPI([]string{"v3.2.150"})
 			var hClient *http.Client
 			httpInput := strings.ReplaceAll(input, ".input.hcl", ".http")
 			if _, err := os.Stat(httpInput); err == nil {

--- a/manifest/autoversion/autoversion_test.go
+++ b/manifest/autoversion/autoversion_test.go
@@ -71,7 +71,7 @@ func TestAutoVersion(t *testing.T) {
 				}
 			}
 			s := NewStateTestFixture(t)
-			l := ui.New(ui.LevelInfo, os.Stdout, os.Stderr, true, true)
+			l := ui.New(ui.LevelTrace, os.Stdout, os.Stderr, true, true)
 			_, err = AutoVersion(hClient, ghClient, tmpFile.Name(), s.State(), l)
 			assert.NoError(t, err)
 

--- a/manifest/autoversion/stateutils_test.go
+++ b/manifest/autoversion/stateutils_test.go
@@ -1,0 +1,80 @@
+package autoversion_test
+
+import (
+	"io/fs"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/cashapp/hermit/cache"
+	"github.com/cashapp/hermit/sources"
+	"github.com/cashapp/hermit/state"
+	"github.com/cashapp/hermit/ui"
+	"github.com/cashapp/hermit/vfs"
+)
+
+type StateTestFixture struct {
+	Server *httptest.Server
+
+	ui      *ui.UI
+	root    string
+	handler http.Handler
+	roots   map[string]bool
+	t       *testing.T
+}
+
+func NewStateTestFixture(t *testing.T) *StateTestFixture {
+	t.Helper()
+	ui, _ := ui.NewForTesting()
+	return &StateTestFixture{
+		t:     t,
+		ui:    ui,
+		roots: map[string]bool{},
+	}
+}
+
+func (f *StateTestFixture) Clean() {
+	f.t.Helper()
+	if f.Server != nil {
+		f.Server.Close()
+	}
+	for r := range f.roots {
+		_ = filepath.Walk(r, func(path string, info fs.FileInfo, err error) error {
+			_ = os.Chmod(path, 0700) // nolint
+			return nil
+		})
+		err := os.RemoveAll(r)
+		assert.NoError(f.t, err)
+	}
+}
+
+func (f *StateTestFixture) State() *state.State {
+	root := f.root
+	if root == "" {
+		nroot, err := ioutil.TempDir("", "")
+		assert.NoError(f.t, err)
+		root = nroot
+	}
+
+	if f.Server == nil {
+		f.Server = httptest.NewServer(f.handler)
+	}
+	f.roots[root] = true
+	client := f.Server.Client()
+	cache, err := cache.Open(root, nil, client, client)
+	assert.NoError(f.t, err)
+	sta, err := state.Open(root, state.Config{
+		Builtin: sources.NewBuiltInSource(vfs.InMemoryFS(nil)),
+	}, cache)
+	assert.NoError(f.t, err)
+	return sta
+}
+
+func (f *StateTestFixture) WithHTTPHandler(handler http.Handler) *StateTestFixture {
+	f.handler = handler
+	return f
+}

--- a/manifest/autoversion/stateutils_test.go
+++ b/manifest/autoversion/stateutils_test.go
@@ -1,4 +1,4 @@
-package autoversion_test
+package autoversion
 
 import (
 	"io/fs"

--- a/manifest/autoversion/testdata/github.expected.hcl
+++ b/manifest/autoversion/testdata/github.expected.hcl
@@ -18,14 +18,6 @@ version "3.2.137" "3.2.140" "3.2.150" {
   }
 }
 
-version "5.1.233" "5.1.234" {
-  auto-version {
-    github-release = "jenkins-x/jx"
-    version-pattern = "v(5\\.\\d+\\.\\d+)"
-    ignore-invalid-versions = true
-  }
-}
-
 channel "stable" {
   update = "24h"
   version = "3.*"

--- a/manifest/autoversion/testdata/github.expected.hcl
+++ b/manifest/autoversion/testdata/github.expected.hcl
@@ -22,3 +22,8 @@ channel "stable" {
   update = "24h"
   version = "3.*"
 }
+
+sha256sums = {
+  "https://github.com/jenkins-x/jx/releases/download/v3.2.150/jx-linux-amd64.tar.gz": "5c08292e49d54e238e886e86ec2d158f57fdad5cb716c157a4e3ebf210c0ffac",
+  "https://github.com/jenkins-x/jx/releases/download/v3.2.150/jx-darwin-amd64.tar.gz": "050a65ce222be92ecbfc9d56ffbfae4c9b9ebca61bf8744dfa388ca49e57d449",
+}

--- a/manifest/autoversion/testdata/github.input.hcl
+++ b/manifest/autoversion/testdata/github.input.hcl
@@ -17,14 +17,6 @@ version "3.2.137" "3.2.140" {
   }
 }
 
-version "5.1.233" {
-  auto-version {
-    github-release = "jenkins-x/jx"
-    version-pattern = "v(5\\.\\d+\\.\\d+)"
-    ignore-invalid-versions = true
-  }
-}
-
 channel "stable" {
   update = "24h"
   version = "3.*"

--- a/manifest/autoversion/testdata/html.expected.hcl
+++ b/manifest/autoversion/testdata/html.expected.hcl
@@ -14,3 +14,9 @@ version "1.17.3" "1.17.5" {
     }
   }
 }
+
+sha256sums = {
+  "https://golang.org/dl/go1.17.5.linux-amd64.tar.gz": "bd78114b0d441b029c8fe0341f4910370925a4d270a6a590668840675b0c653e",
+  "https://golang.org/dl/go1.17.5.darwin-amd64.tar.gz": "2db6a5d25815b56072465a2cacc8ed426c18f1d5fc26c1fc8c4f5a7188658264",
+  "https://golang.org/dl/go1.17.5.darwin-arm64.tar.gz": "111f71166de0cb8089bb3e8f9f5b02d76e1bf1309256824d4062a47b0e5f98e0",
+}

--- a/manifest/loader.go
+++ b/manifest/loader.go
@@ -181,6 +181,18 @@ func load(bundle fs.FS, name, filename string) *AnnotatedManifest {
 	return annotated
 }
 
+// LoadManifestBytes Utility function to parse bytes.
+func LoadManifestBytes(data []byte, annotated *AnnotatedManifest) (*AnnotatedManifest, error) {
+	manifest := &Manifest{}
+	err := hcl.Unmarshal(data, manifest)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	annotated.Manifest = manifest
+
+	return annotated, nil
+}
+
 // LoadManifestFile Utility function to just load a manifest file.
 func LoadManifestFile(dir fs.FS, name, filename string) (*AnnotatedManifest, error) {
 	annotated := &AnnotatedManifest{
@@ -193,14 +205,7 @@ func LoadManifestFile(dir fs.FS, name, filename string) (*AnnotatedManifest, err
 		return nil, errors.WithStack(err)
 	}
 
-	manifest := &Manifest{}
-	err = hcl.Unmarshal(data, manifest)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	annotated.Manifest = manifest
-
-	return annotated, nil
+	return LoadManifestBytes(data, annotated)
 }
 
 // Synthesise a "stable" channel and a channel for each major version.

--- a/manifest/manifestutils/package_digests.go
+++ b/manifest/manifestutils/package_digests.go
@@ -1,20 +1,24 @@
-package manifest
+package manifestutils
 
 import (
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/manifest"
 	"github.com/cashapp/hermit/platform"
 	pstate "github.com/cashapp/hermit/state"
 	"github.com/cashapp/hermit/ui"
 )
 
 // PopulateDigests Add missing digests to the manifest file.
-func PopulateDigests(l *ui.UI, state *pstate.State, localManifest *AnnotatedManifest) error {
+func PopulateDigests(l *ui.UI, state *pstate.State, localManifest *manifest.AnnotatedManifest) error {
+	if len(localManifest.Manifest.Versions) != 0 && localManifest.Manifest.SHA256Sums == nil {
+		localManifest.Manifest.SHA256Sums = make(map[string]string)
+	}
 	l.Infof("Working on %s package", localManifest.Name)
 	for _, mc := range localManifest.Manifest.Versions {
-		ref := ParseReference(localManifest.Name + "-" + mc.Version[0])
+		ref := manifest.ParseReference(localManifest.Name + "-" + mc.Version[0])
 		for _, p := range platform.Core {
 
-			pkg, err := NewPackage(localManifest, p, ref)
+			pkg, err := manifest.NewPackage(localManifest, p, ref)
 			if err != nil {
 				l.Tracef("Continuing with the next platform tuple.  Current %s: %s", p.OS, p.Arch)
 				continue
@@ -36,10 +40,10 @@ func PopulateDigests(l *ui.UI, state *pstate.State, localManifest *AnnotatedMani
 	return nil
 }
 
-func getDigest(l *ui.UI, state *pstate.State, pkg *Package, ref Reference) (string, error) {
+func getDigest(l *ui.UI, state *pstate.State, pkg *manifest.Package, ref manifest.Reference) (string, error) {
 	task := l.Task(ref.String())
 
-	digest, err := pstate.CacheAndDigest(state, task, pkg)
+	digest, err := state.CacheAndDigest(task, pkg)
 	if err != nil {
 		return "", errors.WithStack(err)
 	}

--- a/manifest/manifestutils/package_digests.go
+++ b/manifest/manifestutils/package_digests.go
@@ -1,0 +1,49 @@
+package manifest
+
+import (
+	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/platform"
+	pstate "github.com/cashapp/hermit/state"
+	"github.com/cashapp/hermit/ui"
+)
+
+// PopulateDigests Add missing digests to the manifest file.
+func PopulateDigests(l *ui.UI, state *pstate.State, localManifest *AnnotatedManifest) error {
+	l.Infof("Working on %s package", localManifest.Name)
+	for _, mc := range localManifest.Manifest.Versions {
+		ref := ParseReference(localManifest.Name + "-" + mc.Version[0])
+		for _, p := range platform.Core {
+
+			pkg, err := NewPackage(localManifest, p, ref)
+			if err != nil {
+				l.Tracef("Continuing with the next platform tuple.  Current %s: %s", p.OS, p.Arch)
+				continue
+			}
+			// optimize for an already present value.
+			// Trust model here is that an existing value is correct which is the assumption anyway.
+			if _, ok := localManifest.Manifest.SHA256Sums[pkg.Source]; ok {
+				l.Tracef("Skipping shasum for %s as it's already present", pkg.Source)
+				continue
+			}
+			var digest string
+			digest, err = getDigest(l, state, pkg, ref)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			localManifest.Manifest.SHA256Sums[pkg.Source] = digest
+		}
+	}
+	return nil
+}
+
+func getDigest(l *ui.UI, state *pstate.State, pkg *Package, ref Reference) (string, error) {
+	task := l.Task(ref.String())
+
+	digest, err := pstate.CacheAndDigest(state, task, pkg)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	task.Done()
+	return digest, nil
+
+}


### PR DESCRIPTION
The intent here is to add digests for all the autoversioned package versions.
As per the current usage patterns, that's how the manifest files are updated and so we want that the digest values also get autoupdated when autoversioning is applied.

Some tests and some utility functions have been refactored/moved around to avoid circular dependency problems. Open to suggestions if there is a cleaner approach.



