### PR TITLE
Add a "sha256-source" attribute.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .henv
+/docs/.hugo_build.lock
 testdata/env
 build
 pkgs

--- a/manifest/config.go
+++ b/manifest/config.go
@@ -24,29 +24,30 @@ const (
 
 // A Layer contributes to the final merged manifest definition.
 type Layer struct {
-	Arch        string            `hcl:"arch,optional" help:"CPU architecture to match (amd64, 386, arm, etc.)."`
-	Binaries    []string          `hcl:"binaries,optional" help:"Relative glob from $root to individual terminal binaries."`
-	Apps        []string          `hcl:"apps,optional" help:"Relative paths to Mac .app packages to install."`
-	Rename      map[string]string `hcl:"rename,optional" help:"Rename files after unpacking to ${root}."`
-	Requires    []string          `hcl:"requires,optional" help:"Packages this one requires."`
-	RuntimeDeps []string          `hcl:"runtime-dependencies,optional" help:"Packages used internally by this package, but not installed to the target environment"`
-	Provides    []string          `hcl:"provides,optional" help:"This package provides the given virtual packages."`
-	Dest        string            `hcl:"dest,optional" help:"Override archive extraction destination for package."`
-	Files       map[string]string `hcl:"files,optional" help:"Files to load strings from to be used in the manifest."`
-	Strip       int               `hcl:"strip,optional" help:"Number of path prefix elements to strip."`
-	Root        string            `hcl:"root,optional" help:"Override root for package."`
-	Test        *string           `hcl:"test,optional" help:"Command that will test the package is operational."`
-	Env         envars.Envars     `hcl:"env,optional" help:"Environment variables to export."`
-	Vars        map[string]string `hcl:"vars,optional" help:"Set local variables used during manifest evaluation."`
-	Source      string            `hcl:"source,optional" help:"URL for source package. Valid URLs are Git repositories (using .git[#<tag>] suffix), Local Files (using file:// prefix), and Remote Files (using http:// or https:// prefix)"`
-	DontExtract bool              `hcl:"dont-extract,optional" help:"Don't extract the package source, just copy it into the installation directory."`
-	Mirrors     []string          `hcl:"mirrors,optional" help:"Mirrors to use if the primary source is unavailable."`
-	SHA256      string            `hcl:"sha256,optional" help:"SHA256 of source package for verification. When in conflict with SHA256 in sha256sums, this value takes precedence."`
-	Darwin      []*Layer          `hcl:"darwin,block" help:"Darwin-specific configuration."`
-	Linux       []*Layer          `hcl:"linux,block" help:"Linux-specific configuration."`
-	Platform    []*PlatformBlock  `hcl:"platform,block" help:"Platform-specific configuration. <attr> is a set regexes that must all match against one of CPU, OS, etc.."`
-	Triggers    []*Trigger        `hcl:"on,block" help:"Triggers to run on lifecycle events."`
-	Mutable     bool              `hcl:"mutable,optional" help:"Package will not be made read-only."`
+	Arch         string            `hcl:"arch,optional" help:"CPU architecture to match (amd64, 386, arm, etc.)."`
+	Binaries     []string          `hcl:"binaries,optional" help:"Relative glob from $root to individual terminal binaries."`
+	Apps         []string          `hcl:"apps,optional" help:"Relative paths to Mac .app packages to install."`
+	Rename       map[string]string `hcl:"rename,optional" help:"Rename files after unpacking to ${root}."`
+	Requires     []string          `hcl:"requires,optional" help:"Packages this one requires."`
+	RuntimeDeps  []string          `hcl:"runtime-dependencies,optional" help:"Packages used internally by this package, but not installed to the target environment"`
+	Provides     []string          `hcl:"provides,optional" help:"This package provides the given virtual packages."`
+	Dest         string            `hcl:"dest,optional" help:"Override archive extraction destination for package."`
+	Files        map[string]string `hcl:"files,optional" help:"Files to load strings from to be used in the manifest."`
+	Strip        int               `hcl:"strip,optional" help:"Number of path prefix elements to strip."`
+	Root         string            `hcl:"root,optional" help:"Override root for package."`
+	Test         *string           `hcl:"test,optional" help:"Command that will test the package is operational."`
+	Env          envars.Envars     `hcl:"env,optional" help:"Environment variables to export."`
+	Vars         map[string]string `hcl:"vars,optional" help:"Set local variables used during manifest evaluation."`
+	Source       string            `hcl:"source,optional" help:"URL for source package. Valid URLs are Git repositories (using .git[#<tag>] suffix), Local Files (using file:// prefix), and Remote Files (using http:// or https:// prefix)"`
+	DontExtract  bool              `hcl:"dont-extract,optional" help:"Don't extract the package source, just copy it into the installation directory."`
+	Mirrors      []string          `hcl:"mirrors,optional" help:"Mirrors to use if the primary source is unavailable."`
+	SHA256       string            `hcl:"sha256,optional" help:"SHA256 of source package for verification. When in conflict with SHA256 in sha256sums, this value takes precedence."`
+	SHA256Source string            `hcl:"sha256-source,optional" help:"URL for SHA256 checksum file for source package."`
+	Darwin       []*Layer          `hcl:"darwin,block" help:"Darwin-specific configuration."`
+	Linux        []*Layer          `hcl:"linux,block" help:"Linux-specific configuration."`
+	Platform     []*PlatformBlock  `hcl:"platform,block" help:"Platform-specific configuration. <attr> is a set regexes that must all match against one of CPU, OS, etc.."`
+	Triggers     []*Trigger        `hcl:"on,block" help:"Triggers to run on lifecycle events."`
+	Mutable      bool              `hcl:"mutable,optional" help:"Package will not be made read-only."`
 }
 
 func (c Layer) layers(os string, arch string) (out layers) {

--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -79,6 +79,7 @@ type Package struct {
 	Provides             []string
 	Env                  envars.Ops
 	Source               string
+	SHA256Source         string
 	DontExtract          bool // Don't extract the package, just download it.
 	Mirrors              []string
 	Root                 string
@@ -455,6 +456,9 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 		if layer.Source != "" {
 			p.Source = layer.Source
 		}
+		if layer.SHA256Source != "" {
+			p.SHA256Source = layer.SHA256Source
+		}
 		if layer.DontExtract {
 			p.DontExtract = layer.DontExtract
 		}
@@ -608,6 +612,7 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 		p.Provides[i] = expand(provides, false)
 	}
 	p.Source = expand(p.Source, false)
+	p.SHA256Source = expand(p.SHA256Source, false)
 	for i, mirror := range p.Mirrors {
 		p.Mirrors[i] = expand(mirror, false)
 	}


### PR DESCRIPTION
This is an optional URL to a sha256 checksum file used as an optimisation when adding digests to manifests. Parsing of the file is very lenient and if anything fails, the update will fall back to downloading and computing the digest manually.