### PR TITLE
fix: ensure missing package dependencies trigger a sync

### DIFF
--- a/app/exec_cmd.go
+++ b/app/exec_cmd.go
@@ -70,8 +70,8 @@ func (e *execCmd) Run(l *ui.UI, cache *cache.Cache, sta *state.State, env *hermi
 		return errors.WithStack(err)
 	}
 
-	// Collect dependencies we might have to install
-	// if they are not in the cache
+	// Collect dependencies we might have to install if they are not in the
+	// cache
 	deps := map[string]*manifest.Package{}
 	err = env.ResolveWithDeps(l, installed, manifest.ExactSelector(pkg.Reference), deps)
 	if err != nil {

--- a/env.go
+++ b/env.go
@@ -1314,7 +1314,7 @@ func (e *Env) ResolveWithDeps(l *ui.UI, installed []manifest.Reference, selector
 			return nil
 		}
 	}
-	pkg, err := e.Resolve(l, selector, false)
+	pkg, err := e.Resolve(l, selector, true)
 	if err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
This manifested because the gradle package depends on "jre". The installed JRE satisfied this constraint initially but was later upgraded. Because dependency resolving didn't set syncOnMissing, this resulted in a "package not found" error.