### PR TITLE
fix: recursively collect function decls when validating shell scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Init Hermit
         run: ./bin/hermit env -r >> $GITHUB_ENV
       - name: Test
-        run: make -C docs build schema
+        run: make -C docs schema
   it:
     # The integration tests cannot be run in an active Hermit environment,
     # so we don't activate it here.

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ testdata/env
 build
 pkgs
 registry
-bin/hermit.hcl
 .idea/
 .DS_Store
 .gradle/


### PR DESCRIPTION
This is best-effort, as it's impossible to do this statically in the general case.