### PR TITLE
fix: update digests before writing manifest on auto-update

### DIFF
--- a/app/auto_version_cmd.go
+++ b/app/auto_version_cmd.go
@@ -3,10 +3,8 @@ package app
 import (
 	"net/http"
 
-	"github.com/cashapp/hermit/errors"
 	"github.com/cashapp/hermit/github"
 	"github.com/cashapp/hermit/manifest/autoversion"
-	"github.com/cashapp/hermit/manifest/digest"
 	"github.com/cashapp/hermit/state"
 	"github.com/cashapp/hermit/ui"
 )
@@ -19,16 +17,13 @@ type autoVersionCmd struct {
 func (a *autoVersionCmd) Run(l *ui.UI, hclient *http.Client, state *state.State, client *github.Client) error {
 	for _, path := range a.Manifest {
 		l.Debugf("Auto-versioning %s", path)
-		version, err := autoversion.AutoVersion(hclient, client, path)
+		version, err := autoversion.AutoVersion(l, hclient, client, state, path, a.UpdateDigests)
 		if err != nil {
 			l.Warnf("could not auto-version %q: %s", path, err)
 			continue
 		}
-		if version != "" && a.UpdateDigests {
+		if version != "" {
 			l.Infof("Auto-versioned %s to %s", path, version)
-			if err := digest.UpdateDigests(l, hclient, state, path); err != nil {
-				return errors.WithStack(err)
-			}
 		}
 	}
 	return nil

--- a/manifest/autoversion/autoversion.go
+++ b/manifest/autoversion/autoversion.go
@@ -1,9 +1,6 @@
 package autoversion
 
 import (
-	"github.com/cashapp/hermit/manifest/digest"
-	"github.com/cashapp/hermit/state"
-	"github.com/cashapp/hermit/ui"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -13,6 +10,9 @@ import (
 	"github.com/cashapp/hermit/errors"
 	"github.com/cashapp/hermit/github"
 	hmanifest "github.com/cashapp/hermit/manifest"
+	"github.com/cashapp/hermit/manifest/digest"
+	"github.com/cashapp/hermit/state"
+	"github.com/cashapp/hermit/ui"
 )
 
 // GitHubClient is the GitHub API subset that we need for auto-versioning.

--- a/manifest/autoversion/autoversion_test.go
+++ b/manifest/autoversion/autoversion_test.go
@@ -69,7 +69,7 @@ func TestAutoVersion(t *testing.T) {
 				}
 			}
 
-			_, err = AutoVersion(hClient, ghClient, tmpFile.Name())
+			_, err = AutoVersion(nil, hClient, ghClient, nil, tmpFile.Name(), false)
 			assert.NoError(t, err)
 
 			actualContent, err := os.ReadFile(tmpFile.Name())


### PR DESCRIPTION
If digest updates fail, abort the update and warn (instead of failing the entire auto-update).