### PR TITLE
ops: don't re-apply already applied operations

### DIFF
--- a/env_test.go
+++ b/env_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -417,10 +416,8 @@ func TestEnv_EphemeralVariableSubstitutionOverride(t *testing.T) {
 
 func opsContains[T any](t *testing.T, slice []T, needle T) {
 	t.Helper()
-	for _, el := range slice {
-		if reflect.DeepEqual(el, needle) {
-			return
-		}
+	if envars.OpsContains(slice, needle) {
+		return
 	}
 	t.Fatalf("%v does not contain %v", slice, needle)
 }

--- a/envars/ops_test.go
+++ b/envars/ops_test.go
@@ -118,6 +118,18 @@ func TestIssue47(t *testing.T) {
 	assert.Equal(t, original, reverted)
 }
 
+func TestSkipEnvarReapply(t *testing.T) {
+	original := Envars{
+		"PATH":           "/bin:/usr/bin",
+		"HERMIT_ENV_OPS": "[{\"p\":{\"n\":\"PATH\",\"v\":\"/usr/bin\"}}]",
+	}
+	ops := Ops{
+		&Prepend{Name: "PATH", Value: "/usr/bin"},
+	}
+	actual := original.Apply("/home/user/project", ops).Combined()
+	assert.Equal(t, original, actual)
+}
+
 func TestEncodeDecodeOps(t *testing.T) {
 	actual := Ops{
 		&Append{"APPEND", "${APPEND}:text"},


### PR DESCRIPTION
_(This solution is _horrible_ as it interacts with the `HERMIT_ENV_OPS` envar setup in the activate script. I'd appreciate suggestions for a better approach!)_

Hermit environment variable operations can be overrode by the user after
an environment has already been opened. If this is the case, then we
shouldn't re-apply the operations; we should instead expressed respect
the wish of a mangled environment by the user.

This is relevant for constructs like Python virtual environments.

Context: https://square.slack.com/archives/C01RTEH4MFV/p1685522543591719