### PR TITLE
chore: remove dependency on deprecated golang.org/x/crypto/ssh/terminal

### DIFF
--- a/app/list_cmd.go
+++ b/app/list_cmd.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/alecthomas/colour"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 
 	"github.com/cashapp/hermit"
 	"github.com/cashapp/hermit/errors"
@@ -128,7 +128,7 @@ func listPackagesInCLI(pkgs manifest.Packages, option *listPackageOption) {
 	byName, names := groupPackages(pkgs)
 	sortSliceWithPrefix(names, option.Prefix)
 
-	w, _, _ := terminal.GetSize(0)
+	w, _, _ := term.GetSize(0)
 	if w == -1 {
 		w = 80
 	}

--- a/go.mod
+++ b/go.mod
@@ -30,9 +30,9 @@ require (
 	github.com/willabides/kongplete v0.3.0
 	github.com/willdonnelly/passwd v0.0.0-20141013001024-7935dab3074c
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
-	golang.org/x/crypto v0.0.0-20220214200702-86341886e292
 	golang.org/x/net v0.0.0-20221004154528-8021a29435af
 	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	howett.net/plist v1.0.0
 	mvdan.cc/sh v2.6.4+incompatible
 )
@@ -50,7 +50,7 @@ require (
 	github.com/saracen/go7z-fixtures v0.0.0-20190623165746-aa6b8fba1d2f // indirect
 	github.com/saracen/solidblock v0.0.0-20190426153529-45df20abab6f // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
+	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"syscall"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 
 	"github.com/cashapp/hermit/errors"
 )
@@ -314,7 +314,7 @@ func (w *UI) operationState() uint64 {
 func (w *UI) updateWidth() {
 	w.lock.Lock()
 	var err error
-	w.width, _, err = terminal.GetSize(int(w.tty.Fd()))
+	w.width, _, err = term.GetSize(int(w.tty.Fd()))
 	if err != nil || w.width < 20 { // Assume it's borked.
 		w.width = 80
 	}


### PR DESCRIPTION
From pkg.go.dev:
> Deprecated: this package moved to golang.org/x/term.
