### PR TITLE
fix: buggy lock-free fast-path check

### DIFF
--- a/manifest/manifesttest/pkgbuilder.go
+++ b/manifest/manifesttest/pkgbuilder.go
@@ -97,7 +97,7 @@ func (b PkgBuilder) WithFile(src, dst string, fs fs.FS) PkgBuilder {
 	b.result.Files = append(b.result.Files, &manifest.ResolvedFileRef{
 		FS:       fs,
 		FromPath: src,
-		ToPAth:   dst,
+		ToPath:   dst,
 	})
 	return b
 }

--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -62,7 +62,7 @@ func (p Packages) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
 type ResolvedFileRef struct {
 	FS       fs.FS
 	FromPath string
-	ToPAth   string
+	ToPath   string
 }
 
 // Package resolved from a manifest.
@@ -814,7 +814,7 @@ func resolveFiles(manifest *AnnotatedManifest, pkg *Package, files map[string]st
 		pkg.Files = append(pkg.Files, &ResolvedFileRef{
 			FromPath: k,
 			FS:       manifest.FS,
-			ToPAth:   v,
+			ToPath:   v,
 		})
 	}
 	return nil

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -104,6 +104,7 @@ func TestLinksMissingBinaries(t *testing.T) {
 	assert.Error(t, err, "linux_exe should not exist")
 
 	pkg = manifesttest.NewPkgBuilder(state.PkgDir()).
+		WithBinaries("darwin_exe", "linux_exe").
 		WithSource(fixture.Server.URL).Result()
 
 	err = state.CacheAndUnpack(log.Task("test"), pkg)


### PR DESCRIPTION
The fast-path check to short-circuit locking was buggy becaues it was statting the `Package.Binaries` slice without glob expansion. That is, it ended up statting globs like `bin/*`, resulting in frequent unnecessary locking.