### PR TITLE
fix: log source url on http download failure

### DIFF
--- a/cache/http.go
+++ b/cache/http.go
@@ -85,7 +85,7 @@ func (s *httpSource) Validate() error {
 
 func downloadHTTP(b *ui.Task, response *http.Response, checksum string, uri string, cachePath string) (path string, etag string, returnChecksum string, err error) {
 	if response.StatusCode < 200 || response.StatusCode > 299 {
-		return "", "", "", errors.Errorf("download failed: %s (%d)", response.Status, response.StatusCode)
+		return "", "", "", errors.Errorf("download failed: %s (%d), source url: %s", response.Status, response.StatusCode, uri)
 	}
 	task := b.SubTask("download")
 	cacheDir := filepath.Dir(cachePath)


### PR DESCRIPTION
context: when hitting a download error the log only has the url in hermit manifest but not the one from the source.

we are trying to figure out why hermit is getting 429 which does seem to come from github straight instead of the internal source url. 