### PR TITLE
Read from shell environment variable if exists

### DIFF
--- a/shell/shell.go
+++ b/shell/shell.go
@@ -94,7 +94,13 @@ func Resolve(name string) (Shell, error) {
 
 // Detect the user's shell.
 func Detect() (Shell, error) {
-	// First look for shell in parent processes.
+	// Check for SHELL environment variable.
+	shell, ok := shells[filepath.Base(os.Getenv("SHELL"))]
+	if ok {
+		return shell, nil
+	}
+
+	// Then, look for shell in parent processes.
 	pid := os.Getppid()
 	for {
 		process, err := ps.FindProcess(pid)


### PR DESCRIPTION
This solves an issue when hermit is activated by non interactive bash scripts (as it happens [in Slurm for example](https://slurm.schedmd.com/job_launch.html#task_launch)) and when the /etc/passwd is not populated as its dynamically set by some system daemon (example: [OS Login in GCP](https://cloud.google.com/compute/docs/oslogin)).

This leads to the following error:

```
fatal:hermit: /etc/passwd file entry for "gerardc_squareup_com" is missing
```

SHELL should be populated automatically by [login on all unix systems](https://unix.stackexchange.com/questions/277944/what-sets-the-shell-environment-variable) (which gets set by reading from passwd database or by checking the default). So we can just use it to set it.