### PR TITLE
Allow read-write for all users in shared cache

### DIFF
--- a/internal/dao/dao.go
+++ b/internal/dao/dao.go
@@ -24,7 +24,7 @@ type Package struct {
 // Open returns a new DAO at the given state directory
 func Open(stateDir string) (*DAO, error) {
 	metadataDir := filepath.Join(stateDir, "metadata")
-	if err := os.MkdirAll(metadataDir, 0700); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(metadataDir, 0777); err != nil && !os.IsExist(err) {
 		return nil, errors.WithStack(err)
 	}
 	return &DAO{stateDir: stateDir, metadataDir: metadataDir}, nil

--- a/manifest/actions.go
+++ b/manifest/actions.go
@@ -185,7 +185,7 @@ func (m *MkdirAction) String() string {
 func (m *MkdirAction) Apply(*Package) error { // nolint
 	mode := m.Mode
 	if mode == 0 {
-		mode = 0750
+		mode = 0755
 	}
 	return os.MkdirAll(m.Dir, mode)
 }

--- a/sources/git.go
+++ b/sources/git.go
@@ -64,7 +64,7 @@ func (s *GitSource) Bundle() fs.FS { // nolint: golint
 }
 
 func (s *GitSource) ensureSourcesDirExists() error {
-	if err := os.MkdirAll(s.sourceDir, 0700); err != nil {
+	if err := os.MkdirAll(s.sourceDir, 1755); err != nil {
 		return errors.WithStack(err)
 	}
 	return nil

--- a/sources/git.go
+++ b/sources/git.go
@@ -64,7 +64,7 @@ func (s *GitSource) Bundle() fs.FS { // nolint: golint
 }
 
 func (s *GitSource) ensureSourcesDirExists() error {
-	if err := os.MkdirAll(s.sourceDir, 1755); err != nil {
+	if err := os.MkdirAll(s.sourceDir, 0755); err != nil {
 		return errors.WithStack(err)
 	}
 	return nil

--- a/state/state.go
+++ b/state/state.go
@@ -348,7 +348,7 @@ func (s *State) linkBinaries(p *manifest.Package) error {
 		return errors.WithStack(err)
 	}
 
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0777); err != nil {
 		return errors.WithStack(err)
 	}
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -74,7 +74,7 @@ func TestCacheAndUnpackHooksRunOnMutablePackage(t *testing.T) {
 
 	info, err = os.Stat(filepath.Join(state.PkgDir(), "file_renamed"))
 	assert.NoError(t, err)
-	assert.Equal(t, os.FileMode(0500), info.Mode()&0777, info.Mode().String())
+	assert.Equal(t, os.FileMode(0555), info.Mode()&0777, info.Mode().String())
 }
 
 func TestLinksMissingBinaries(t *testing.T) {


### PR DESCRIPTION
In order to help make hermit more friendly in multi-user machines, this PR changes permissions to default more open and allow read-write by everyone.