### PR TITLE
fix: sync packages if "hermit install" fails to find a package

### DIFF
--- a/app/install_cmd.go
+++ b/app/install_cmd.go
@@ -41,7 +41,7 @@ func (i *installCmd) Run(l *ui.UI, env *hermit.Env, state *state.State) error {
 		// Checking that all the packages are downloaded and unarchived
 		for _, ref := range installed {
 			task := l.Task(ref.String())
-			pkg, err := env.Resolve(l, manifest.ExactSelector(ref), false)
+			pkg, err := env.Resolve(l, manifest.ExactSelector(ref), true)
 			if err != nil {
 				return errors.WithStack(err)
 			}

--- a/sources/sources.go
+++ b/sources/sources.go
@@ -1,13 +1,14 @@
 package sources
 
 import (
-	"github.com/cashapp/hermit/util"
 	"io/fs"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/cashapp/hermit/util"
 
 	"github.com/cashapp/hermit/errors"
 	"github.com/cashapp/hermit/ui"
@@ -55,7 +56,7 @@ func (s *Sources) Add(source Source) {
 // Will be synced at most every SyncFrequency unless "force" is true.
 // A Sources set can only be synchronised once. Following calls will not have any effect.
 func (s *Sources) Sync(p *ui.UI, force bool) error {
-	if s.isSynchronised {
+	if s.isSynchronised && !force {
 		return nil
 	}
 	s.isSynchronised = true


### PR DESCRIPTION
This occasionally breaks enabling the hermit IntelliJ plugin that installs dependencies automatically at startup.

We also skipt the test if we had synchronized previously if we are forcing a sync. This is needed as "hermit install" does a non forced sync at the beginning, marking source as synced, and this prevents the later forced sync from running when the package is not found.

Fixes https://github.com/cashapp/hermit/issues/363