### PR TITLE
Drop ioutil

### DIFF
--- a/app/auto_version_cmd.go
+++ b/app/auto_version_cmd.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -26,7 +25,7 @@ func (a *autoVersionCmd) Run(l *ui.UI, hclient *http.Client, state *state.State,
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		original, err := ioutil.ReadFile(path)
+		original, err := os.ReadFile(path)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -36,7 +35,7 @@ func (a *autoVersionCmd) Run(l *ui.UI, hclient *http.Client, state *state.State,
 				return errors.Wrap(err, path)
 			}
 			l.Warnf("Could not update digests for %q: %s", path, err)
-			err = ioutil.WriteFile(path, original, info.Mode())
+			err = os.WriteFile(path, original, info.Mode())
 			if err != nil {
 				return errors.Wrapf(err, "could not restore original manifest: %s", path)
 			}

--- a/app/log_test.go
+++ b/app/log_test.go
@@ -2,8 +2,8 @@ package app
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -151,7 +151,7 @@ func staticFileHTTPHandler(t *testing.T, dir string) http.HandlerFunc {
 	t.Helper()
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("ETag", "testtag")
-		dat, err := ioutil.ReadFile(filepath.Join(dir, r.RequestURI))
+		dat, err := os.ReadFile(filepath.Join(dir, r.RequestURI))
 		if err != nil {
 			w.WriteHeader(http.StatusNotFound)
 		} else {

--- a/app/user_config.go
+++ b/app/user_config.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/alecthomas/hcl"
@@ -37,7 +36,7 @@ func LoadUserConfig() (UserConfig, error) {
 	config := UserConfig{}
 	// always return a valid config on error, with defaults set.
 	_ = hcl.Unmarshal([]byte{}, &config)
-	data, err := ioutil.ReadFile(kong.ExpandPath(userConfigPath))
+	data, err := os.ReadFile(kong.ExpandPath(userConfigPath))
 	if os.IsNotExist(err) {
 		return config, nil
 	} else if err != nil {

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -79,7 +78,7 @@ func Extract(b *ui.Task, source string, pkg *manifest.Package) (finalise func() 
 		return finalise, errors.WithStack(err)
 	}
 
-	tmpDest, err := ioutil.TempDir(parentDir, filepath.Base(pkg.Dest)+"-*")
+	tmpDest, err := os.MkdirTemp(parentDir, filepath.Base(pkg.Dest)+"-*")
 	if err != nil {
 		return finalise, errors.WithStack(err)
 	}
@@ -363,7 +362,7 @@ func extractMacPKG(b *ui.Task, path, dest string, strip int) error {
 	}
 	task := b.SubProgress("install", 2)
 	defer task.Done()
-	changesf, err := ioutil.TempFile("", "hermit-*.xml")
+	changesf, err := os.CreateTemp("", "hermit-*.xml")
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -414,7 +413,7 @@ func extractZipFile(zf *zip.File, destFile string) error {
 	}
 	// Handle symlinks.
 	if zf.Mode()&os.ModeSymlink != 0 {
-		symlink, err := ioutil.ReadAll(zfr)
+		symlink, err := io.ReadAll(zfr)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -623,7 +622,7 @@ func extractRpmPackage(r io.Reader, dest string, pkg *manifest.Package) error {
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			err = ioutil.WriteFile(filename, bts, os.FileMode(header.Mode()))
+			err = os.WriteFile(filename, bts, os.FileMode(header.Mode()))
 			if err != nil {
 				return errors.WithStack(err)
 			}

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -1,7 +1,6 @@
 package archive
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,7 +34,7 @@ func TestExtract(t *testing.T) {
 		t.Run(test.file, func(t *testing.T) {
 			p, _ := ui.NewForTesting()
 
-			dest, err := ioutil.TempDir("", "")
+			dest, err := os.MkdirTemp("", "")
 			assert.NoError(t, err)
 			defer os.RemoveAll(dest)
 

--- a/cache/http.go
+++ b/cache/http.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -91,7 +90,7 @@ func downloadHTTP(b *ui.Task, response *http.Response, checksum string, uri stri
 	cacheDir := filepath.Dir(cachePath)
 	_ = os.MkdirAll(cacheDir, os.ModePerm)
 
-	w, err := ioutil.TempFile(cacheDir, filepath.Base(cachePath)+".*.hermit.tmp.download")
+	w, err := os.CreateTemp(cacheDir, filepath.Base(cachePath)+".*.hermit.tmp.download")
 	if err != nil {
 		return "", "", "", errors.Wrap(err, "couldn't create temporary for download")
 	}

--- a/env.go
+++ b/env.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -153,7 +152,7 @@ func Init(l *ui.UI, env string, distURL string, stateDir string, config Config, 
 				return errors.WithStack(err)
 			}
 
-			err = ioutil.WriteFile(extDepPath, extDepData, 0600)
+			err = os.WriteFile(extDepPath, extDepData, 0600)
 			if err != nil {
 				return errors.WithStack(err)
 			}
@@ -177,7 +176,7 @@ func Init(l *ui.UI, env string, distURL string, stateDir string, config Config, 
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		err = ioutil.WriteFile(configPath, data, 0600)
+		err = os.WriteFile(configPath, data, 0600)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -263,7 +262,7 @@ func getSources(l *ui.UI, envDir string, config *Config, state *state.State, def
 
 func readConfig(configFile string) (*Config, error) {
 	config := &Config{Envars: map[string]string{}, ManageGit: true}
-	source, err := ioutil.ReadFile(configFile)
+	source, err := os.ReadFile(configFile)
 	if !os.IsNotExist(err) {
 		if err != nil {
 			return nil, errors.Wrap(err, "couldn't load environment config")
@@ -388,7 +387,7 @@ func (e *Env) ValidateManifests(l *ui.UI) (manifest.ManifestErrors, error) {
 
 // LinkedBinaries lists just the binaries installed in the environment.
 func (e *Env) LinkedBinaries(pkg *manifest.Package) (binaries []string, err error) {
-	files, err := ioutil.ReadDir(e.binDir)
+	files, err := os.ReadDir(e.binDir)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -1005,7 +1004,7 @@ func (e *Env) SetEnv(key, value string) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	return ioutil.WriteFile(e.configFile, data, 0600)
+	return os.WriteFile(e.configFile, data, 0600)
 }
 
 // DelEnv deletes a custom environment variable.
@@ -1015,7 +1014,7 @@ func (e *Env) DelEnv(key string) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	return ioutil.WriteFile(e.configFile, data, 0600)
+	return os.WriteFile(e.configFile, data, 0600)
 }
 
 // Clean parts of the hermit system.
@@ -1404,7 +1403,7 @@ func writeFileToEnvBin(l *ui.Task, useGit bool, src, envDir string, vars map[str
 	for key, value := range vars {
 		source = bytes.ReplaceAll(source, []byte(key), []byte(value))
 	}
-	if err = ioutil.WriteFile(dest, source, perm); err != nil {
+	if err = os.WriteFile(dest, source, perm); err != nil {
 		return errors.WithStack(err)
 	}
 	if useGit {

--- a/env_test.go
+++ b/env_test.go
@@ -1,7 +1,6 @@
 package hermit_test
 
 import (
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -48,7 +47,7 @@ func TestUpdateTimestampOnInstall(t *testing.T) {
 	calls := 0
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("ETag", "testtag")
-		dat, _ := ioutil.ReadFile("archive/testdata/archive.tar.gz")
+		dat, _ := os.ReadFile("archive/testdata/archive.tar.gz")
 		_, err := w.Write(dat)
 		assert.NoError(t, err)
 		calls++
@@ -116,7 +115,7 @@ func TestEnsureUpToDate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, getCalls)
 	assert.Equal(t, 0, headCalls)
-	file, _ := ioutil.ReadFile(filepath.Join(pkg.Dest, "bin"))
+	file, _ := os.ReadFile(filepath.Join(pkg.Dest, "bin"))
 	assert.Equal(t, data, string(file))
 
 	// Update after a check is needed but etag has not changed
@@ -125,7 +124,7 @@ func TestEnsureUpToDate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, getCalls)
 	assert.Equal(t, 1, headCalls)
-	file, _ = ioutil.ReadFile(filepath.Join(pkg.Dest, "bin"))
+	file, _ = os.ReadFile(filepath.Join(pkg.Dest, "bin"))
 	assert.Equal(t, data, string(file))
 
 	// Update after a check is needed and the etag has changed
@@ -136,7 +135,7 @@ func TestEnsureUpToDate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 2, getCalls)
 	assert.Equal(t, 2, headCalls)
-	file, _ = ioutil.ReadFile(filepath.Join(pkg.Dest, "bin"))
+	file, _ = os.ReadFile(filepath.Join(pkg.Dest, "bin"))
 	assert.Equal(t, data, string(file))
 
 	// Check that the package is still in the DB after the upgrade
@@ -156,7 +155,7 @@ func TestEnsureUpToDate(t *testing.T) {
 
 // Test that files referred in the Files map are copied correctly
 func TestCopyFiles(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -182,7 +181,7 @@ func TestCopyFiles(t *testing.T) {
 
 // Test that files referred in the Files map are copied correctly
 func TestCopyFilesAction(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -213,7 +212,7 @@ func TestCopyFilesAction(t *testing.T) {
 }
 
 func TestTriggers(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
 

--- a/hermittest/envfixture.go
+++ b/hermittest/envfixture.go
@@ -2,7 +2,6 @@ package hermittest
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -36,10 +35,10 @@ type EnvTestFixture struct {
 // A test handler can be given to be used as an test http server for testing http interactions
 func NewEnvTestFixture(t *testing.T, handler http.Handler) *EnvTestFixture {
 	t.Helper()
-	envDir, err := ioutil.TempDir("", "")
+	envDir, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)
 
-	stateDir, err := ioutil.TempDir("", "")
+	stateDir, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)
 
 	log, buf := ui.NewForTesting()
@@ -94,7 +93,7 @@ func (f *EnvTestFixture) Clean() {
 
 // NewEnv returns a new environment using the state directory from this fixture
 func (f *EnvTestFixture) NewEnv() *hermit.Env {
-	envDir, err := ioutil.TempDir("", "")
+	envDir, err := os.MkdirTemp("", "")
 	assert.NoError(f.t, err)
 	log, _ := ui.NewForTesting()
 	err = hermit.Init(log, envDir, "", f.State.Root(), hermit.Config{}, "BYPASS")

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -462,7 +461,7 @@ type prep []preparation
 func addFile(name, content string) preparation {
 	return func(t *testing.T, dir string) string {
 		t.Helper()
-		err := ioutil.WriteFile(filepath.Join(dir, name), []byte(content), 0600)
+		err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0600)
 		assert.NoError(t, err)
 		return ""
 	}

--- a/sources/git.go
+++ b/sources/git.go
@@ -2,7 +2,6 @@ package sources
 
 import (
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -90,7 +89,7 @@ func syncGit(b *ui.Task, dir, source, finalDest string, runner util.CommandRunne
 		// If pull fails, assume the repo is corrupted and just try and re-clone it.
 	}
 	// No git repo, clone down to temporary directory.
-	dest, err := ioutil.TempDir(dir, filepath.Base(finalDest)+"-*")
+	dest, err := os.MkdirTemp(dir, filepath.Base(finalDest)+"-*")
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/sources/git_test.go
+++ b/sources/git_test.go
@@ -1,7 +1,7 @@
 package sources_test
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
@@ -27,7 +27,7 @@ func TestGitDoesNotRemoveSourceAfterSyncFailure(t *testing.T) {
 	u, _ := ui.NewForTesting()
 	err := source.Sync(u, true)
 	assert.NoError(t, err)
-	files, err := ioutil.ReadDir(sourceDir)
+	files, err := os.ReadDir(sourceDir)
 	assert.NoError(t, err)
 	assert.Equal(t, len(files), 1)
 	gitDir := files[0].Name()
@@ -40,7 +40,7 @@ func TestGitDoesNotRemoveSourceAfterSyncFailure(t *testing.T) {
 	assert.NoError(t, err)
 
 	// the directory should still be in place after git failed to update
-	files, err = ioutil.ReadDir(sourceDir)
+	files, err = os.ReadDir(sourceDir)
 	assert.NoError(t, err)
 	assert.Equal(t, len(files), 1)
 	assert.Equal(t, gitDir, files[0].Name())

--- a/state/stateutils_test.go
+++ b/state/stateutils_test.go
@@ -2,7 +2,6 @@ package state_test
 
 import (
 	"io/fs"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -55,7 +54,7 @@ func (f *StateTestFixture) Clean() {
 func (f *StateTestFixture) State() *state.State {
 	root := f.root
 	if root == "" {
-		nroot, err := ioutil.TempDir("", "")
+		nroot, err := os.MkdirTemp("", "")
 		assert.NoError(f.t, err)
 		root = nroot
 	}

--- a/util/filepatcher.go
+++ b/util/filepatcher.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -29,7 +28,7 @@ func (fp *FilePatcher) Patch(fileName, content string) (bool, error) {
 	}
 	defer file.Close() // nolint: gosec
 
-	previousBts, err := ioutil.ReadFile(fileName)
+	previousBts, err := os.ReadFile(fileName)
 	if err != nil {
 		return false, errors.WithStack(err)
 	}

--- a/util/filepatcher_test.go
+++ b/util/filepatcher_test.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -82,7 +81,7 @@ foobar
 `,
 	}}
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -109,7 +108,7 @@ func fileWith(t *testing.T, dir, content string) (fileName string) {
 	file, err := os.CreateTemp(dir, ".file")
 	assert.NoError(t, err)
 	name := file.Name()
-	err = ioutil.WriteFile(name, []byte(content), 0644) // nolint: gosec
+	err = os.WriteFile(name, []byte(content), 0644) // nolint: gosec
 	assert.NoError(t, err)
 	return name
 }

--- a/util/flock_test.go
+++ b/util/flock_test.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,7 +14,7 @@ import (
 
 // Test that a lock eventually times out if the lock has been opened by someone else
 func TestFileLockTimeout(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -41,7 +40,7 @@ func TestFileLockTimeout(t *testing.T) {
 
 // Test that releasing a lock allows others to lock it again
 func TestFileLockRelease(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -65,7 +64,7 @@ func TestFileLockRelease(t *testing.T) {
 
 // Test that releasing a lock allows other waiting locks to proceed
 func TestFileLockProceed(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
 


### PR DESCRIPTION
ioutil is deprecated and shouldn't be used anymore.
Drop all uses in favor of equivalent functions from os and io.
