### PR TITLE
config: Support opting into GitHub token auth

### DIFF
--- a/app/activate_cmd.go
+++ b/app/activate_cmd.go
@@ -27,7 +27,11 @@ func (a *activateCmd) Run(l *ui.UI, cache *cache.Cache, sta *state.State, global
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	env, err := hermit.OpenEnv(realdir, sta, cache.GetSource, globalState.Env, defaultClient, nil)
+	envInfo, err := hermit.LoadEnvInfo(realdir)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	env, err := hermit.OpenEnv(envInfo, sta, cache.GetSource, globalState.Env, defaultClient, nil)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/app/exec_cmd.go
+++ b/app/exec_cmd.go
@@ -28,9 +28,13 @@ func (e *execCmd) Run(l *ui.UI, cache *cache.Cache, sta *state.State, env *hermi
 	if err != nil {
 		return errors.WithStack(err)
 	}
+	envInfo, err := hermit.LoadEnvInfo(envDir)
+	if err != nil {
+		return errors.WithStack(err)
+	}
 
 	// Pass config.SHA256Sums because OpenEnv uses the defaults cashapp/hermit; internal builds inject additional SHA256Sums.
-	env, err = hermit.OpenEnv(envDir, sta, cache.GetSource, globalState.Env, defaultHTTPClient, config.SHA256Sums)
+	env, err = hermit.OpenEnv(envInfo, sta, cache.GetSource, globalState.Env, defaultHTTPClient, config.SHA256Sums)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/app/validate_env_cmd.go
+++ b/app/validate_env_cmd.go
@@ -15,7 +15,11 @@ type validateEnvCmd struct {
 }
 
 func (v *validateEnvCmd) Run(l *ui.UI, state *state.State, cache *cache.Cache, config Config, httpClient *http.Client) error {
-	env, err := hermit.OpenEnv(v.Env, state, cache.GetSource, nil, httpClient, config.SHA256Sums)
+	envInfo, err := hermit.LoadEnvInfo(v.Env)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	env, err := hermit.OpenEnv(envInfo, state, cache.GetSource, nil, httpClient, config.SHA256Sums)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/cache/github.go
+++ b/cache/github.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cashapp/hermit/errors"
 	"github.com/cashapp/hermit/github"
 	"github.com/cashapp/hermit/ui"
+	"github.com/gobwas/glob"
 )
 
 // matches: https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{ASSET}
@@ -18,6 +19,31 @@ var githubRe = regexp.MustCompile(`^https\://github.com/([^/]+)/([^/]+)/releases
 
 // RepoMatcher is used to determine which repositories will use authenticated requests.
 type RepoMatcher func(owner, repo string) bool
+
+// GlobRepoMatcher accepts a list of glob patterns and returns a [RepoMatcher]
+// that will match 'owner/repo' pairs against the globs.
+//
+// It returns an error if any of the patterns are invalid.
+func GlobRepoMatcher(patterns []string) (RepoMatcher, error) {
+	globs := make([]glob.Glob, len(patterns))
+	for i, pattern := range patterns {
+		g, err := glob.Compile(pattern)
+		if err != nil {
+			return nil, errors.Errorf("bad pattern [%d] %q: %v", i, pattern, err)
+		}
+		globs[i] = g
+	}
+
+	return func(owner, repo string) bool {
+		ownerRepo := owner + "/" + repo
+		for _, g := range globs {
+			if g.Match(ownerRepo) {
+				return true
+			}
+		}
+		return false
+	}, nil
+}
 
 // GitHubSourceSelector can download private release assets from GitHub using an authenticated GitHub client.
 func GitHubSourceSelector(getSource PackageSourceSelector, ghclient *github.Client, match RepoMatcher) PackageSourceSelector {

--- a/cache/github_test.go
+++ b/cache/github_test.go
@@ -1,0 +1,97 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestGlobRepoMatcher(t *testing.T) {
+	type ownerRepo struct{ owner, repo string }
+
+	tests := []struct {
+		name     string
+		patterns []string
+
+		expectMatches    []ownerRepo
+		expectNotMatches []ownerRepo
+	}{
+		{
+			name:     "all",
+			patterns: []string{"*"},
+			expectMatches: []ownerRepo{
+				{"example", "repo"},
+				{"foo", "bar"},
+				{"baz", "qux"},
+			},
+			// nothing not matched
+		},
+		{
+			name: "org",
+			patterns: []string{
+				"example/*",
+			},
+			expectMatches: []ownerRepo{
+				{"example", "repo"},
+				{"example", "bar"},
+			},
+			expectNotMatches: []ownerRepo{
+				{"foo", "bar"},
+				{"examplesuffix", "repo"},
+				{"prefixexample", "repo"},
+			},
+		},
+		{
+			name:     "partial org",
+			patterns: []string{"example-*/*"},
+			expectMatches: []ownerRepo{
+				{"example-foo", "repo"},
+				{"example-bar", "repo"},
+			},
+			expectNotMatches: []ownerRepo{
+				{"example", "repo"},
+			},
+		},
+		{
+			name: "multiple",
+			patterns: []string{
+				"example/*",
+				"*/homebrew-*",
+			},
+			expectMatches: []ownerRepo{
+				{"example", "repo"},
+				{"foo", "homebrew-tap"},
+				{"homebrew", "homebrew-tap"},
+			},
+			expectNotMatches: []ownerRepo{
+				{"foo", "bar"},
+				{"foo", "homebrew"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher, err := GlobRepoMatcher(tt.patterns)
+			assert.NoError(t, err)
+
+			for _, match := range tt.expectMatches {
+				t.Run(match.owner+"/"+match.repo, func(t *testing.T) {
+					assert.True(t, matcher(match.owner, match.repo))
+				})
+			}
+
+			for _, match := range tt.expectNotMatches {
+				t.Run(match.owner+"/"+match.repo, func(t *testing.T) {
+					assert.False(t, matcher(match.owner, match.repo))
+				})
+			}
+		})
+	}
+}
+
+func TestGlobRepoMatcherBadPattern(t *testing.T) {
+	_, err := GlobRepoMatcher([]string{"["})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), `bad pattern [0]`)
+}

--- a/hermittest/envfixture.go
+++ b/hermittest/envfixture.go
@@ -55,7 +55,9 @@ func NewEnvTestFixture(t *testing.T, handler http.Handler) *EnvTestFixture {
 		Builtin: sources.NewBuiltInSource(vfs.InMemoryFS(nil)),
 	}, cache)
 	assert.NoError(t, err)
-	env, err := hermit.OpenEnv(envDir, sta, cache.GetSource, envars.Envars{}, server.Client(), nil)
+	info, err := hermit.LoadEnvInfo(envDir)
+	assert.NoError(t, err)
+	env, err := hermit.OpenEnv(info, sta, cache.GetSource, envars.Envars{}, server.Client(), nil)
 	assert.NoError(t, err)
 
 	return &EnvTestFixture{
@@ -98,7 +100,9 @@ func (f *EnvTestFixture) NewEnv() *hermit.Env {
 	log, _ := ui.NewForTesting()
 	err = hermit.Init(log, envDir, "", f.State.Root(), hermit.Config{}, "BYPASS")
 	assert.NoError(f.t, err)
-	env, err := hermit.OpenEnv(envDir, f.State, f.Cache.GetSource, envars.Envars{}, f.Server.Client(), nil)
+	info, err := hermit.LoadEnvInfo(envDir)
+	assert.NoError(f.t, err)
+	env, err := hermit.OpenEnv(info, f.State, f.Cache.GetSource, envars.Envars{}, f.Server.Client(), nil)
 	assert.NoError(f.t, err)
 	return env
 }


### PR DESCRIPTION
Adds a new per-project configuration to hermit.hcl
allowing opting GitHub owner/repo patterns to opt into
token-based authentication instead of anonymous.
For example:

    github-auth-token {
      match = ["cashapp/*"]
    }

The option accepts any number of glob patterns,
allowing for fine-grained control over which dependencies
get authenticated requests.

This will make it possible to use Hermit with private repositories
without distributing a custom build.

The plumbing for this required a small amount of refactoring:
The new hermit.LoadEnvInfo inspects a Hermit environment
and loads the configuration, but does not open the environment.
The information is later passed to the old hermit.OpenEnv function.

This separation is necessary because cache and state are inputs to
OpenEnv, but we need to inspect the environment configuration to decide
on their inputs.

Resolves #406
