### PR TITLE
fix: Increase github version lookup to 200

### DIFF
--- a/manifest/autoversion/github.go
+++ b/manifest/autoversion/github.go
@@ -13,7 +13,7 @@ func gitHub(client GitHubClient, autoVersion *hmanifest.AutoVersionBlock) (strin
 		releases []*github.Release
 		err      error
 	)
-	const history = 100
+	const history = 200
 	// When there may be invalid versions, we need to fetch multiple release to find the latest valid one.
 	// When IgnoreInvalidVersions is off, fetch only the latest release for performance.
 	if autoVersion.IgnoreInvalidVersions {


### PR DESCRIPTION
In case of updating nodejs/node v17 - the last v17 tag is more than 100 tags behind the latest, causing the existing auto-version logic to fail.

We will fix this further by supporting to update auto-version of a specific version (instead of today's logic to go through all the auto-versioned packages).