### PR TITLE
docs: Add github-token-auth documentation

### DIFF
--- a/docs/docs/packaging/private.md
+++ b/docs/docs/packaging/private.md
@@ -41,3 +41,15 @@ or a [GitHub App installation token](https://docs.github.com/en/developers/apps/
 This token must have the `repo` scope set at creation.
 
 The environment variable `HERMIT_GITHUB_TOKEN` must be set to this a token.
+
+You can configure a Hermit-initialized repository to use this token
+by adding a `github-token-auth` block to your `bin/hermit.hcl`.
+For example:
+
+```hcl
+# Use HERMIT_GITHUB_TOKEN to authenticate downloads from GitHub repositories
+# owned by the 'cashapp' organization.
+github-token-auth {
+  match = ["cashapp/*"]
+}
+```

--- a/docs/docs/usage/config.md
+++ b/docs/docs/usage/config.md
@@ -13,6 +13,13 @@ customise that Hermit environment.
 | `sources` | `[string]?` | Package manifest sources in order of preference.                                      |
 | `manage-git` | `bool?` | Whether Hermit should manage Git.                                                     |
 | `inherit-parent` | `bool?` | Whether this Hermit environment should inherit an environment from a parent diectory. | 
+| `github-token-auth` | `GitHubTokenAuthConfig?` | When to use GitHub token authentication. |
+
+### GitHubTokenAuthConfig
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| match | `[string]?` | One or more glob patterns. If any of these match the 'owner/repo' pair of a GitHub repository, the GitHub token from the current environment will be used to fetch their artifacts. |
 
 ## Per-environment Sources
 
@@ -21,5 +28,3 @@ Hermit supports three different manifest sources:
 1. Git repositories; any cloneable URI ending with `.git`, eg.<br/>`https://github.com/cashapp/hermit-packages.git`. An optional `#<tag>` suffix can be added to checkout a specific tag.
 2. Local filesystem, eg. `file:///home/user/my-packages`.<br/>This is mostly only useful for local development and testing.
 3. Environment relative, eg. `env:///my-packages`.<br/>This will search for package manifests in the directory `${HERMIT_ENV}/my-packages`. Useful for local overrides.
-
-	


### PR DESCRIPTION
PR #409 added support for opting packages into GitHub token
authentication with a `github-token-auth` block in `bin/hermit.hcl`.

This adds information about this feature to the private releases
documentation, and adds an entry to the config reference.

---

This should probably not be merged until the next release is tagged
to prevent incorrect documentation from being published.
