### PR TITLE
fix: broken shell completion

### DIFF
--- a/app/commands.go
+++ b/app/commands.go
@@ -42,7 +42,7 @@ type cliBase struct {
 	Info       infoCmd       `cmd:"" help:"Show information on packages." group:"global"`
 	ShellHooks shellHooksCmd `cmd:"" help:"Manage Hermit auto-activation hooks of a shell." group:"global" aliases:"install-hooks"`
 
-	Noop                 noopCmd              `cmd:"" help:"No-op, just exit." hidden:""`
+	Noop                 noopCmd              `cmd:"" help:"No-op, just exit." hidden:"" passthrough:""`
 	Activate             activateCmd          `cmd:"" help:"Activate an environment." hidden:""`
 	Exec                 execCmd              `cmd:"" help:"Directly execute a binary in a package." hidden:""`
 	Update               updateCmd            `cmd:"" aliases:"sync" help:"Update manifest sources." group:"global"`

--- a/app/noop_cmd.go
+++ b/app/noop_cmd.go
@@ -1,5 +1,7 @@
 package app
 
-type noopCmd struct{}
+type noopCmd struct {
+	Discard []string `arg:"" optional:""`
+}
 
 func (n *noopCmd) Run() error { return nil }

--- a/shell/bash.go
+++ b/shell/bash.go
@@ -14,7 +14,7 @@ else
   PROMPT_COMMAND="change_hermit_env"
 fi
 
-complete -o nospace -C "${HERMIT_ROOT_BIN:-"$HOME/bin/hermit"}" hermit
+complete -o nospace -C "${HERMIT_ROOT_BIN:-"$HOME/bin/hermit"} noop" hermit
 `
 
 // Bash represent the Bash shell

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -13,7 +13,7 @@ precmd_functions+=(change_hermit_env)
 # shellcheck disable=SC2154
 if [[ -n ${_comps+x} ]]; then
   autoload -U +X bashcompinit && bashcompinit
-  complete -o nospace -C "${HERMIT_ROOT_BIN:-"$HOME/bin/hermit"}" hermit
+  complete -o nospace -C "${HERMIT_ROOT_BIN:-"$HOME/bin/hermit"} noop" hermit
 fi
 `
 


### PR DESCRIPTION
Completion by default will pass the entire command to the completion program's Argv. Kong isn't able to handle this, so update the completion command to use the noop subcommand. The noop subcommand has to be updated to accept and discard any additional arguments.