### PR TITLE
test(integration): fix flaky test

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -368,7 +368,8 @@ func TestIntegration(t *testing.T) {
 					assert.NoError(t, err)
 					defer f.Close()
 
-					go io.Copy(tee, f)
+					//nolint: errcheck // an io error is always returned, ignore it: read /dev/ptmx: input/output error
+					io.Copy(tee, f)
 
 					err = cmd.Wait()
 


### PR DESCRIPTION
The output of shell commands was being read in a goroutine, but the test wasn't waiting for the IO to finish. This caused the expectations to sometimes fail. Fix by reading the output synchronously. This does not have a significant effect on the test execution time.