### PR TITLE
fix(app): unsafe stdout buffer management

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -122,20 +122,15 @@ func Main(config Config) {
 		// This is necessary because stdout/stderr are unbuffered and thus _very_ slow.
 		stdout := bufio.NewWriter(os.Stdout)
 		stderr := bufio.NewWriter(os.Stderr)
+		p = ui.New(config.LogLevel, &bufioSyncer{stdout}, &bufioSyncer{stderr}, stdoutIsTTY, stderrIsTTY)
 		go func() {
 			for {
 				time.Sleep(time.Millisecond * 100)
-				err = stdout.Flush()
-				if err != nil {
-					break
-				}
-				err = stderr.Flush()
-				if err != nil {
+				if err := p.Sync(); err != nil {
 					break
 				}
 			}
 		}()
-		p = ui.New(config.LogLevel, &bufioSyncer{stdout}, &bufioSyncer{stderr}, stdoutIsTTY, stderrIsTTY)
 		defer stdout.Flush()
 		defer stderr.Flush()
 	} else {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -343,3 +343,10 @@ func (w *UI) Confirmation(message string, args ...interface{}) (bool, error) {
 	s = strings.ToLower(s)
 	return s == "y" || s == "yes", nil
 }
+
+// Sync flushes IO to stdout and stderr.
+func (w *UI) Sync() error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	return errors.Join(w.stdout.Sync(), w.stderr.Sync())
+}


### PR DESCRIPTION
app.Main spawns a goroutine to periodically flush output buffers to stdout and stderr. However, it does so without acquiring the log writer's lock. Add a Sync method to UI so that we can ensure that the mutex is acquired before flushing the buffers.

This change is more theoretical than anything. I discovered it by using `go build -race` rather than after having observed any real symptoms. It may or may not be related to #333.