### PR TITLE
fix: env validation when missing fish script

### DIFF
--- a/docs/docs/usage/shell.md
+++ b/docs/docs/usage/shell.md
@@ -49,4 +49,4 @@ in order for the changes to take effect.
 
 ```shell
 hermit shell-hooks --fish
-````
+```

--- a/env.go
+++ b/env.go
@@ -359,12 +359,12 @@ func (e *Env) Root() string {
 // Verify contains valid Hermit scripts.
 func (e *Env) Verify() error {
 next:
-	for _, path := range []string{"activate-hermit", "activate-hermit.fish", "hermit"} {
-		path = filepath.Join(e.binDir, path)
+	for _, file := range []string{"activate-hermit", "activate-hermit.fish", "hermit"} {
+		path := filepath.Join(e.binDir, file)
 		hasher := sha256.New()
 		r, err := os.Open(path)
 		if os.IsNotExist(err) {
-			if path == "activate-hermit.fish" {
+			if file == "activate-hermit.fish" {
 				// Fish support was added later. Older hermit envs won't have it.
 				continue next
 			}


### PR DESCRIPTION
env validation was failing when the `activate-hermit.fish` script was missing due to matching on path instead of filename. Not sure why integration tests didn't catch it. Will follow up later with a test.