### PR TITLE
chore: add integration test for missing activate-hermit.fish

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -289,6 +289,13 @@ func TestIntegration(t *testing.T) {
 			assert test "$(binary.sh)" = "Running from child"
 			`,
 		},
+		{
+			name:         "MissingActivateFishShellFileIsValidEnv",
+			preparations: prep{fixture("testenv1"), activate(".")},
+			script: `
+            hermit validate env .
+`,
+		},
 	}
 
 	checkForShells(t)


### PR DESCRIPTION
Follow up test for https://github.com/cashapp/hermit/pull/427. Verifies that an otherwise valid hermit environment missing an `activate-hermit.fish` is still considered valid.