### PR TITLE
feat: Support reading default init sources from ~/.hermit.hcl

### DIFF
--- a/app/commands.go
+++ b/app/commands.go
@@ -11,7 +11,8 @@ import (
 
 // GlobalState configurable by user to be passed through to Hermit.
 type GlobalState struct {
-	Env envars.Envars `help:"Extra environment variables to apply to environments."`
+	Env        envars.Envars `help:"Extra environment variables to apply to environments."`
+	UserConfig string        `help:"Path to Hermit user configuration file." default:"~/.hermit.hcl" env:"HERMIT_USER_CONFIG"`
 }
 
 type cliInterface interface {

--- a/app/init_cmd.go
+++ b/app/init_cmd.go
@@ -13,13 +13,23 @@ type initCmd struct {
 	Dir     string   `arg:"" help:"Directory to create environment in (${default})." default:"${env}" predictor:"dir"`
 }
 
-func (i *initCmd) Run(w *ui.UI, config Config) error {
+func (i *initCmd) Run(w *ui.UI, config Config, userConfig UserConfig) error {
 	_, sum, err := GenInstaller(config)
 	if err != nil {
 		return errors.WithStack(err)
 	}
+
+	w.Tracef("Command line sources: %v", i.Sources)
+	w.Tracef("User config: %+v", userConfig)
+
+	sources := i.Sources
+	if len(sources) == 0 {
+		w.Tracef("Using init-sources from user config: %v", userConfig.InitSources)
+		sources = userConfig.InitSources
+	}
+
 	return hermit.Init(w, i.Dir, config.BaseDistURL, hermit.UserStateDir, hermit.Config{
-		Sources:     i.Sources,
+		Sources:     sources,
 		ManageGit:   !i.NoGit,
 		AddIJPlugin: i.Idea,
 	}, sum)

--- a/app/main.go
+++ b/app/main.go
@@ -156,7 +156,12 @@ func Main(config Config) {
 	if err != nil {
 		log.Fatalf("couldn't get working directory: %s", err) // nolint: gocritic
 	}
-	common := cliBase{Plugins: config.KongPlugins}
+	common := cliBase{
+		Plugins: config.KongPlugins,
+		GlobalState: GlobalState{
+			UserConfig: "~/.hermit.hcl",
+		},
+	}
 
 	// But we activate any environment we find
 	if envDir, err := hermit.FindEnvDir(os.Args[0]); err == nil {
@@ -167,10 +172,13 @@ func Main(config Config) {
 		cli = &unactivated{cliBase: common}
 	}
 
-	userConfig, err := LoadUserConfig()
+	userConfigPath := cli.getGlobalState().UserConfig
+	p.Tracef("Loading user config from: %s", userConfigPath)
+	userConfig, err := LoadUserConfig(userConfigPath)
 	if err != nil {
 		log.Printf("%s: %s", userConfigPath, err)
 	}
+	p.Tracef("Loaded user config: %+v", userConfig)
 
 	githubToken := os.Getenv("HERMIT_GITHUB_TOKEN")
 	if githubToken == "" {

--- a/app/user_config.go
+++ b/app/user_config.go
@@ -9,8 +9,6 @@ import (
 	"github.com/cashapp/hermit/errors"
 )
 
-const userConfigPath = "~/.hermit.hcl"
-
 var userConfigSchema = func() string {
 	schema, err := hcl.Schema(&UserConfig{})
 	if err != nil {
@@ -25,18 +23,19 @@ var userConfigSchema = func() string {
 
 // UserConfig is stored in ~/.hermit.hcl
 type UserConfig struct {
-	Prompt      string `hcl:"prompt,optional" default:"env" enum:"env,short,none" help:"Modify prompt to include hermit environment (env), just an icon (short) or nothing (none)"`
-	ShortPrompt bool   `hcl:"short-prompt,optional" help:"If true use a short prompt when an environment is activated."`
-	NoGit       bool   `hcl:"no-git,optional" help:"If true Hermit will never add/remove files from Git automatically."`
-	Idea        bool   `hcl:"idea,optional" help:"If true Hermit will try to add the IntelliJ IDEA plugin automatically."`
+	Prompt      string   `hcl:"prompt,optional" default:"env" enum:"env,short,none" help:"Modify prompt to include hermit environment (env), just an icon (short) or nothing (none)"`
+	ShortPrompt bool     `hcl:"short-prompt,optional" help:"If true use a short prompt when an environment is activated."`
+	NoGit       bool     `hcl:"no-git,optional" help:"If true Hermit will never add/remove files from Git automatically."`
+	Idea        bool     `hcl:"idea,optional" help:"If true Hermit will try to add the IntelliJ IDEA plugin automatically."`
+	InitSources []string `hcl:"init-sources,optional" help:"Default sources to use when initialising a new Hermit environment."`
 }
 
 // LoadUserConfig from disk.
-func LoadUserConfig() (UserConfig, error) {
+func LoadUserConfig(configPath string) (UserConfig, error) {
 	config := UserConfig{}
 	// always return a valid config on error, with defaults set.
 	_ = hcl.Unmarshal([]byte{}, &config)
-	data, err := os.ReadFile(kong.ExpandPath(userConfigPath))
+	data, err := os.ReadFile(kong.ExpandPath(configPath))
 	if os.IsNotExist(err) {
 		return config, nil
 	} else if err != nil {
@@ -70,6 +69,9 @@ func (u *userConfigResolver) Resolve(context *kong.Context, parent *kong.Path, f
 
 	case "idea":
 		return u.config.Idea, nil
+
+	case "init-sources":
+		return u.config.InitSources, nil
 
 	default:
 		return nil, nil

--- a/app/user_config_test.go
+++ b/app/user_config_test.go
@@ -1,0 +1,91 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestLoadUserConfig(t *testing.T) {
+	// Create a temporary directory for our test files
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name           string
+		configContents string
+		expected       UserConfig
+		expectError    bool
+	}{
+		{
+			name: "basic config with init-sources",
+			configContents: `
+init-sources = [
+	"source1",
+	"source2"
+]`,
+			expected: UserConfig{
+				Prompt:      "env", // Default value
+				InitSources: []string{"source1", "source2"},
+			},
+		},
+		{
+			name: "full config",
+			configContents: `
+prompt = "short"
+short-prompt = true
+no-git = true
+idea = true
+init-sources = [
+	"source1",
+	"source2"
+]`,
+			expected: UserConfig{
+				Prompt:      "short",
+				ShortPrompt: true,
+				NoGit:       true,
+				Idea:        true,
+				InitSources: []string{"source1", "source2"},
+			},
+		},
+		{
+			name:           "empty config",
+			configContents: "",
+			expected: UserConfig{
+				Prompt: "env", // Default value
+			},
+		},
+		{
+			name: "invalid HCL",
+			configContents: `
+init-sources = [
+	"unclosed array
+`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary config file
+			configPath := filepath.Join(tmpDir, "config.hcl")
+			err := os.WriteFile(configPath, []byte(tt.configContents), 0644)
+			assert.NoError(t, err)
+
+			// Load the config
+			config, err := LoadUserConfig(configPath)
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected.InitSources, config.InitSources)
+			assert.Equal(t, tt.expected.Prompt, config.Prompt)
+			assert.Equal(t, tt.expected.ShortPrompt, config.ShortPrompt)
+			assert.Equal(t, tt.expected.NoGit, config.NoGit)
+			assert.Equal(t, tt.expected.Idea, config.Idea)
+		})
+	}
+}

--- a/docs/docs/usage/user-config-schema.hcl
+++ b/docs/docs/usage/user-config-schema.hcl
@@ -8,3 +8,5 @@ short-prompt = boolean # (optional)
 no-git = boolean # (optional)
 # If true Hermit will try to add the IntelliJ IDEA plugin automatically.
 idea = boolean # (optional)
+# Default sources to use when initialising a new Hermit environment.
+init-sources = [string] # (optional)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -97,10 +97,12 @@ func TestIntegration(t *testing.T) {
 				outputContains("Creating new Hermit environment")}},
 		{name: "InitWithUserConfigSources",
 			script: `
-				cat > hermit.hcl <<EOF
+				cat > ~/.hermit.hcl <<EOF
 init-sources = ["source1", "source2"]
 EOF
-				hermit init --user-config hermit.hcl .
+				hermit init .
+				echo "Generated bin/hermit.hcl content:"
+				cat bin/hermit.hcl
 			`,
 			expectations: exp{
 				filesExist("bin/hermit.hcl"),
@@ -270,7 +272,7 @@ EOF
 			preparations: prep{fixture("testenv1"), activate(".")},
 			script: `
 			hermit manifest add-digests packages/testbin1.hcl
-			assert grep d4f8989a4a6bf56ccc768c094448aa5f42be3b9f0287adc2f4dfd2241f80d2c0 packages/testbin1.hcl 
+			assert grep d4f8989a4a6bf56ccc768c094448aa5f42be3b9f0287adc2f4dfd2241f80d2c0 packages/testbin1.hcl
 			`},
 		{name: "UpgradeTriggersInstallHook",
 			preparations: prep{fixture("testenv1"), activate(".")},
@@ -319,7 +321,7 @@ EOF
 			hermit install binary
 			. child_environment/bin/activate-hermit
 			assert test "$(binary.sh)" = "Running from parent"
-			
+
 			hermit install binary
 			assert test "$(binary.sh)" = "Running from child"
 			`,

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -95,6 +95,41 @@ func TestIntegration(t *testing.T) {
 					"bin/hermit", ".idea/externalDependencies.xml",
 					"bin/activate-hermit", "bin/hermit.hcl"),
 				outputContains("Creating new Hermit environment")}},
+		{name: "InitWithUserConfigSources",
+			script: `
+				cat > hermit.hcl <<EOF
+init-sources = ["source1", "source2"]
+EOF
+				hermit init --user-config hermit.hcl .
+			`,
+			expectations: exp{
+				filesExist("bin/hermit.hcl"),
+				fileContains("bin/hermit.hcl", `source1`),
+				fileContains("bin/hermit.hcl", `source2`)}},
+		{name: "InitWithCommandLineSources",
+			script: `
+				cat > hermit.hcl <<EOF
+init-sources = ["source1", "source2"]
+EOF
+				hermit init --user-config hermit.hcl --sources source3,source4 .
+			`,
+			expectations: exp{
+				filesExist("bin/hermit.hcl"),
+				fileContains("bin/hermit.hcl", `source3`),
+				fileContains("bin/hermit.hcl", `source4`)}},
+		{name: "InitSourcesCommandLineOverridesUserConfig",
+			script: `
+				cat > hermit.hcl <<EOF
+init-sources = ["source1", "source2"]
+EOF
+				hermit init --user-config hermit.hcl --sources source3,source4 .
+				assert test "$(grep -c source1 bin/hermit.hcl)" = "0"
+				assert test "$(grep -c source2 bin/hermit.hcl)" = "0"
+			`,
+			expectations: exp{
+				filesExist("bin/hermit.hcl"),
+				fileContains("bin/hermit.hcl", `source3`),
+				fileContains("bin/hermit.hcl", `source4`)}},
 		{name: "HermitEnvarIsSet",
 			script: `
 				hermit init .


### PR DESCRIPTION
This PR introduces a new `init_sources` field to the Hermit user configuration file (`~/.hermit.hcl`). This field allows users to specify a default set of sources to be used when initializing a new Hermit environment with the `hermit init` command.

**Example `~/.hermit.hcl`:**

```hcl
init_sources = [
  "https://github.com/lox/private-hermit-packages.git", 
  "https://github.com/cashapp/hermit-packages.git"
]
```

This means any call to `hermit init` will use these sources. 