### PR TITLE
fix: Explicitly disable GPG signing in git tags test

### DIFF
--- a/it/full/run.sh
+++ b/it/full/run.sh
@@ -16,6 +16,7 @@ beforeAll() {
   git add .
   git config user.email "you@example.com"
   git config user.name "Your Name"
+  git config commit.gpgsign false
   git commit -m 'test commit'
   popd
 }

--- a/manifest/autoversion/git_tags_test.go
+++ b/manifest/autoversion/git_tags_test.go
@@ -2,13 +2,14 @@ package autoversion
 
 import (
 	"fmt"
-	"github.com/alecthomas/assert/v2"
-	"github.com/cashapp/hermit/errors"
-	"github.com/cashapp/hermit/manifest"
 	"os"
 	"os/exec"
 	"path"
 	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/manifest"
 )
 
 func Test_GitTagsAutoVersion(t *testing.T) {
@@ -25,6 +26,8 @@ func Test_GitTagsAutoVersion(t *testing.T) {
 	err = runCommandInDir(tmpDir, "git", "config", "--local", "user.email", "test@example.com")
 	assert.NoError(t, err)
 	err = runCommandInDir(tmpDir, "git", "config", "--local", "user.name", "test")
+	assert.NoError(t, err)
+	err = runCommandInDir(tmpDir, "git", "config", "--local", "commit.gpgsign", "false")
 	assert.NoError(t, err)
 	err = runCommandInDir(tmpDir, "git", "add", ".")
 	assert.NoError(t, err)


### PR DESCRIPTION
Makes the test more robust by explicitly disabling GPG signing in the test repository. This ensures the tests works consistently in environments where commit signing is enabled globally (e.g., developers using 1Password or other GPG signing tools).