### PR TITLE
feat: Allow defining defaults for hermit.hcl in user config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ lint: ## run golangci-lint
 test: ## run tests
 	./bin/go test -v ./...
 
+test-integration: ## run integration tests
+	./bin/go test -tags integration -v ./integration
+
 build: ## builds binary and gzips it
 	mkdir -p $(BUILD_DIR)
 	CGO_ENABLED=0 ./bin/go build -ldflags "-X main.version=$(VERSION) -X main.channel=$(CHANNEL)" -o $(BIN) $(ROOT)/cmd/hermit

--- a/app/activate_cmd.go
+++ b/app/activate_cmd.go
@@ -22,7 +22,7 @@ type activateCmd struct {
 	ShortPrompt bool   `help:"Use a minimal prompt in active environments." hidden:""`
 }
 
-func (a *activateCmd) Run(l *ui.UI, cache *cache.Cache, sta *state.State, globalState GlobalState, config Config, defaultClient *http.Client) error {
+func (a *activateCmd) Run(l *ui.UI, cache *cache.Cache, sta *state.State, globalState GlobalState, config Config, defaultClient *http.Client, userConfig UserConfig) error {
 	realdir, err := resolveActivationDir(a.Dir)
 	if err != nil {
 		return errors.WithStack(err)
@@ -58,7 +58,15 @@ func (a *activateCmd) Run(l *ui.UI, cache *cache.Cache, sta *state.State, global
 		return errors.WithStack(err)
 	}
 	environ := envars.Parse(os.Environ()).Apply(env.Root(), ops).Changed(true)
-	prompt := a.Prompt
+	// Apply user config settings
+	prompt := userConfig.Prompt
+	if userConfig.ShortPrompt {
+		prompt = "short"
+	}
+	// Apply command line overrides
+	if a.Prompt != "" {
+		prompt = a.Prompt
+	}
 	if a.ShortPrompt {
 		prompt = "short"
 	}

--- a/app/commands.go
+++ b/app/commands.go
@@ -23,17 +23,19 @@ type cliInterface interface {
 	getLevel() ui.Level
 	getGlobalState() GlobalState
 	getLockTimeout() time.Duration
+	getUserConfigFile() string
 }
 
 type cliBase struct {
-	VersionFlag kong.VersionFlag `help:"Show version." name:"version"`
-	CPUProfile  string           `placeholder:"PATH" name:"cpu-profile" help:"Enable CPU profiling to PATH." hidden:""`
-	MemProfile  string           `placeholder:"PATH" name:"mem-profile" help:"Enable memory profiling to PATH." hidden:""`
-	Debug       bool             `help:"Enable debug logging." short:"d"`
-	Trace       bool             `help:"Enable trace logging." short:"t"`
-	Quiet       bool             `help:"Disable logging and progress UI, except fatal errors." env:"HERMIT_QUIET" short:"q"`
-	Level       ui.Level         `help:"Set minimum log level (${enum})." env:"HERMIT_LOG" default:"auto" enum:"auto,trace,debug,info,warn,error,fatal"`
-	LockTimeout time.Duration    `help:"Timeout for waiting on the lock" default:"30s" env:"HERMIT_LOCK_TIMEOUT"`
+	VersionFlag    kong.VersionFlag `help:"Show version." name:"version"`
+	CPUProfile     string           `placeholder:"PATH" name:"cpu-profile" help:"Enable CPU profiling to PATH." hidden:""`
+	MemProfile     string           `placeholder:"PATH" name:"mem-profile" help:"Enable memory profiling to PATH." hidden:""`
+	Debug          bool             `help:"Enable debug logging." short:"d"`
+	Trace          bool             `help:"Enable trace logging." short:"t"`
+	Quiet          bool             `help:"Disable logging and progress UI, except fatal errors." env:"HERMIT_QUIET" short:"q"`
+	Level          ui.Level         `help:"Set minimum log level (${enum})." env:"HERMIT_LOG" default:"auto" enum:"auto,trace,debug,info,warn,error,fatal"`
+	LockTimeout    time.Duration    `help:"Timeout for waiting on the lock" default:"30s" env:"HERMIT_LOCK_TIMEOUT"`
+	UserConfigFile string           `help:"Path to Hermit user configuration file." name:"user-config" default:"~/.hermit.hcl" env:"HERMIT_USER_CONFIG"`
 	GlobalState
 
 	Init       initCmd       `cmd:"" help:"Initialise an environment (idempotent)." group:"env"`
@@ -63,6 +65,7 @@ func (u *cliBase) getQuiet() bool                { return u.Quiet }
 func (u *cliBase) getLevel() ui.Level            { return ui.AutoLevel(u.Level) }
 func (u *cliBase) getGlobalState() GlobalState   { return u.GlobalState }
 func (u *cliBase) getLockTimeout() time.Duration { return u.LockTimeout }
+func (u *cliBase) getUserConfigFile() string     { return u.UserConfigFile }
 
 // CLI structure.
 type unactivated struct {

--- a/app/main.go
+++ b/app/main.go
@@ -252,7 +252,7 @@ func Main(config Config) {
 	var userConfig UserConfig
 	userConfigPath := cli.getUserConfigFile()
 
-	if userConfigExists := IsUserConfigExists(userConfigPath); userConfigExists {
+	if IsUserConfigExists(userConfigPath) {
 		p.Tracef("Loading user config from: %s", userConfigPath)
 		userConfig, err = LoadUserConfig(userConfigPath)
 		if err != nil {

--- a/docs/docs/usage/user-config-schema.hcl
+++ b/docs/docs/usage/user-config-schema.hcl
@@ -8,3 +8,19 @@ short-prompt = boolean # (optional)
 no-git = boolean # (optional)
 # If true Hermit will try to add the IntelliJ IDEA plugin automatically.
 idea = boolean # (optional)
+# Default configuration values for new Hermit environments.
+defaults = {
+  # Package manifest sources.
+  sources = [string] # (optional)
+  # Whether Hermit should automatically 'git add' new packages.
+  manage-git = boolean # (optional)
+  # Whether this environment inherits a potential parent environment from one of the parent directories.
+  inherit-parent = boolean # (optional)
+  # Whether Hermit should automatically add the IntelliJ IDEA plugin.
+  idea = boolean # (optional)
+  # When to use GitHub token authentication.
+  github-token-auth = {
+    # One or more glob patterns. If any of these match the 'owner/repo' pair of a GitHub repository, the GitHub token from the current environment will be used to fetch their artifacts.
+    match = [string] # (optional)
+  } # (optional)
+} # (optional)


### PR DESCRIPTION
Adds support for user-level configuration defaults in Hermit. Users can now define default settings in their ~/.hermit.hcl file that will be applied to all new Hermit environments.

**Example ~/.hermit.hcl:**

```hcl
defaults {
  sources = [
    "https://github.com/lox/private-hermit-packages.git", 
    "https://github.com/cashapp/hermit-packages.git"
  ]
}
```

Also allows the user config file to be defined with `HERMIT_USER_CONFIG` or `--user-config`. 


This replaces the more narrowly scoped https://github.com/cashapp/hermit/pull/434. 