### PR TITLE
fix: hermit chokes when global install dir is an env

### DIFF
--- a/env.go
+++ b/env.go
@@ -228,7 +228,9 @@ func EnvDirFromProxyLink(executable string) (string, error) {
 	if err != nil {
 		return "", errors.WithStack(err)
 	}
-	if filepath.Base(last) != "hermit" {
+	switch filepath.Base(last) {
+	case "hermit", "hermit-stable", "hermit-canary":
+	default:
 		return "", errors.Errorf("binary is not a Hermit symlink: %s", links[0])
 	}
 	last = filepath.Dir(last)


### PR DESCRIPTION
Hermit expects files in the bin folder of an environment to be symlinked to "hermit". This is not the case in the global install dir, where hermit itself is by default symlinked to "hermit-stable". Add "hermit-stable" and "hermit-canary" to the allow-list.

Fixes: #401