### PR TITLE
fix: Revert "perf(exec): improve performance"

### DIFF
--- a/env.go
+++ b/env.go
@@ -49,7 +49,7 @@ var (
 	//go:embed "files/install.sh.tmpl"
 	InstallerTemplateSource string
 
-	// UserStateDir should be passed to OpenEnv()/Init() in most cases.
+	// UserStateDir should be passed to Open()/Init() in most cases.
 	UserStateDir = func() string {
 		// Check if state dir is explicitly set
 		explicit := os.Getenv("HERMIT_STATE_DIR")
@@ -114,7 +114,6 @@ type Env struct {
 	configFile      string
 	httpClient      *http.Client
 	scriptSums      []string
-	activated       bool
 
 	// Lazily initialized fields
 	lazyResolver  *manifest.Resolver
@@ -350,7 +349,6 @@ func OpenEnv(
 		ephemeralEnvars: envars.Infer(ephemeral.System()),
 		httpClient:      httpClient,
 		scriptSums:      scriptSums,
-		activated:       os.Getenv("DEACTIVATED_HERMIT") == "",
 	}, nil
 }
 
@@ -785,21 +783,10 @@ func (e *Env) Exec(l *ui.UI, pkg *manifest.Package, binary string, args []string
 		return errors.WithStack(err)
 	}
 
-	var installed []*manifest.Package
-
-	// If we are activated, the parent shell already has
-	// already passed us all necessary environment variables.
-	// This may not be the case if the user manually ran
-	// e.g. ./bin/go
-	// We still need to call e.allEnvarOpsForPackages to ensure
-	// the selected package's env vars take precedence.
-	if !e.activated {
-		installed, err = e.ListInstalled(l)
-		if err != nil {
-			return errors.WithStack(err)
-		}
+	installed, err := e.ListInstalled(l)
+	if err != nil {
+		return errors.WithStack(err)
 	}
-
 	ops := e.allEnvarOpsForPackages(runtimeDeps, pkg, installed...)
 	packageHermitBin, err := e.getPackageRuntimeEnvops(pkg)
 	if err != nil {
@@ -810,6 +797,9 @@ func (e *Env) Exec(l *ui.UI, pkg *manifest.Package, binary string, args []string
 	}
 	env := e.envarsFromOps(true, ops)
 
+	if err != nil {
+		return errors.WithStack(err)
+	}
 	for _, bin := range binaries {
 		if filepath.Base(bin) != filepath.Base(binary) {
 			continue


### PR DESCRIPTION
## 📝 Description
In a nested environment, Hermit fails to set the correct environment for the target binary. For example, given the following directory structure:
```
repo-root/
├── bin/
│   ├── java@17
│   ├── gradle
├── foo/
│   ├── bin/
│   │   ├── java@21
```
When navigating to `repo-root/foo` and running `gradle`, Hermit installs Java 17 but sets `JAVA_HOME` to Java 21, resulting in the following error:
```
JAVA_HOME is set to an invalid directory: /root/.cache/hermit/pkg/openjdk@21
```
This issue leads to unexpected failures in internal builds.

## Revert Reason
This commit reverts cashapp/hermit#433 because it introduces a regression in environment resolution. Until a proper fix is found, reverting ensures stability for existing builds.
 