### PR TITLE
[change_hermit_env] Gracefully handle set -u in change_hermit_env

### DIFF
--- a/shell/files/sh_common_hooks.sh
+++ b/shell/files/sh_common_hooks.sh
@@ -1,11 +1,13 @@
 change_hermit_env() {
   local CUR=${PWD}
   while [ "$CUR" != "/" ]; do
-    if [ "${CUR}" -ef "${HERMIT_ENV}" ]; then return; fi
+    if [ -n "${HERMIT_ENV+_}" ] && [ "${CUR}" -ef "${HERMIT_ENV}" ]; then
+      return
+    fi
     if [ -f "${CUR}/bin/activate-hermit" ]; then
       if [ -n "${HERMIT_ENV+_}"  ]; then type _hermit_deactivate &>/dev/null && _hermit_deactivate; fi
       # shellcheck source=files/activate-hermit
-      if ! [ "${CUR}" -ef "${DEACTIVATED_HERMIT}" ]; then
+      if [ -z "${DEACTIVATED_HERMIT+_}" ] || ! [ "${CUR}" -ef "${DEACTIVATED_HERMIT}" ]; then
         if "${HERMIT_ROOT_BIN:-"$HOME/bin/hermit"}" --quiet validate env "${CUR}"; then
           . "${CUR}/bin/activate-hermit"
         fi


### PR DESCRIPTION
For my own sanity's sake, I use `set -u` as part of my zsh config. However, hermit's `change_hermit_env` command fails when this is enabled; this PR fixes the hook so that when variables aren't set it won't emit the following error:

```sh
% cd ~/tmp/testing
change_hermit_env:3: HERMIT_ENV: parameter not set                                                                                                                                         
%
```