### PR TITLE
[activate.tmpl.sh] Gracefully handle when the bin dir disappears

### DIFF
--- a/shell/files/activate.tmpl.sh
+++ b/shell/files/activate.tmpl.sh
@@ -22,8 +22,10 @@ export {{ $ENV_NAME }}={{ $ENV_VALUE | Quote }}
 {{ end }}
 
 _hermit_deactivate() {
-  echo "Hermit environment $(${HERMIT_ENV}/bin/hermit env HERMIT_ENV) deactivated"
-  eval "$(${ACTIVE_HERMIT}/bin/hermit env --deactivate-from-ops="${HERMIT_ENV_OPS}")"
+  local hermit_exe=${HERMIT_ENV}/bin/hermit
+  test -e "${hermit_exe}" || hermit_exe=${HERMIT_EXE:-$HERMIT_ROOT_BIN}
+  echo "Hermit environment $("${hermit_exe}" env HERMIT_ENV) deactivated"
+  eval "$("${hermit_exe}" env --deactivate-from-ops="${HERMIT_ENV_OPS}")"
   unset -f deactivate-hermit >/dev/null 2>&1
   unset -f update_hermit_env >/dev/null 2>&1
   unset ACTIVE_HERMIT
@@ -62,6 +64,7 @@ if test -n "${PS1+_}"; then export _HERMIT_OLD_PS1="${PS1}"; export PS1="{{if eq
 {{- end}}
 
 update_hermit_env() {
+  if test ! -e "${HERMIT_ENV}/bin/hermit"; then deactivate-hermit; return; fi
   local CURRENT=$(date -r ${HERMIT_ENV}/bin +"%s")
   test "$CURRENT" = "$HERMIT_BIN_CHANGE" && return 0
   local CUR_HERMIT=${HERMIT_ENV}/bin/hermit


### PR DESCRIPTION
This PR updates `update_hermit_env` to handle the case when the `bin` directory disappears:

Before every command, hermit's `update_hermit_env` function interacts with `${HERMIT_ENV}/bin` a few times (eg checking to see if it was modified, executing the `${HERMIT_ENV}/bin/hermit` function, etc.) However, if either of these are missing, it causes noisy errors:
```
hm🐚 /tmp/hm % mv bin bin2
usage: date [-jnRu] [-I[date|hours|minutes|seconds]] [-f input_fmt]                                                                            
            [-r filename|seconds] [-v[+|-]val[y|m|w|d|H|M|S]]
            [[[[mm]dd]HH]MM[[cc]yy][.SS] | new_date] [+output_fmt]
update_hermit_env:4: no such file or directory: /tmp/hm/bin/hermit
update_hermit_env:5: no such file or directory: /tmp/hm/bin/hermit
update_hermit_env:6: no such file or directory: /tmp/hm/bin/hermit
hm🐚 /tmp/hm %
```
While during normal usage, the `bin` directory shouldn't disappear, I've encountered it multiple times personally (eg swapping between different git branches, before and after hermit as added to the repo, or even just accidentally moving the `bin` dir.)

This PR fixes this by checking to see if `${HERMIT_ENV}/bin/hermit` exists before running the rest of `update_hermit_env`; If it doesn't it calls `deactivate-hermit` to disable hermit. However, `_hermit_deactivate` (called by `deactivate-hermit`) _also_ uses `${HERMIT_ENV}/bin/hermit` as well. So this also had to be changed to default to the system-wide hermit if needed
