### PR TITLE
chore: Always run all the integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test: ## run tests
 	./bin/go test -v ./...
 
 test-integration: ## run integration tests
-	./bin/go test -tags integration -v ./integration
+	./bin/go test -count=1 -tags integration -v ./integration
 
 build: ## builds binary and gzips it
 	mkdir -p $(BUILD_DIR)


### PR DESCRIPTION
Recently, I made a change, ran `make test-integration` locally, got cached results, pushed the change and it failed.

So I thought maybe the integration tests shouldn't be cached. I found this solution https://stackoverflow.com/a/48882892