### PR TITLE
chore: Remove deprecated linters and fix usetesting lints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,6 @@ linters:
     - godox
     - wsl
     - dogsled
-    - gomnd
     - gocognit
     - gocyclo
     - godot
@@ -47,7 +46,7 @@ linters:
     - errchkjson
     - mnd      # overly sensitive to any number
     - tagalign # don't care about struct tag alignment (help:".." tends to be long)
-    - execinquery
+    - tenv     # deprecated, replaced by usetesting
 
 linters-settings:
   govet:

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -34,11 +34,7 @@ func TestExtract(t *testing.T) {
 		t.Run(test.file, func(t *testing.T) {
 			p, _ := ui.NewForTesting()
 
-			dest, err := os.MkdirTemp("", "")
-			assert.NoError(t, err)
-			defer os.RemoveAll(dest)
-
-			dest = filepath.Join(dest, "extracted")
+			dest := filepath.Join(t.TempDir(), "extracted")
 			finalise, err := Extract(
 				p.Task("extract"),
 				filepath.Join("testdata", test.file),

--- a/env_test.go
+++ b/env_test.go
@@ -155,9 +155,7 @@ func TestEnsureUpToDate(t *testing.T) {
 
 // Test that files referred in the Files map are copied correctly
 func TestCopyFiles(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	f, err := os.Create(filepath.Join(dir, "from"))
 	assert.NoError(t, err)
@@ -181,9 +179,7 @@ func TestCopyFiles(t *testing.T) {
 
 // Test that files referred in the Files map are copied correctly
 func TestCopyFilesAction(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	f, err := os.Create(filepath.Join(dir, "from"))
 	assert.NoError(t, err)
@@ -212,9 +208,7 @@ func TestCopyFilesAction(t *testing.T) {
 }
 
 func TestTriggers(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	file := filepath.Join(dir, "test.sh")
 	target := filepath.Join(dir, "success")

--- a/hermittest/envfixture.go
+++ b/hermittest/envfixture.go
@@ -35,15 +35,12 @@ type EnvTestFixture struct {
 // A test handler can be given to be used as an test http server for testing http interactions
 func NewEnvTestFixture(t *testing.T, handler http.Handler) *EnvTestFixture {
 	t.Helper()
-	envDir, err := os.MkdirTemp("", "")
-	assert.NoError(t, err)
-
-	stateDir, err := os.MkdirTemp("", "")
-	assert.NoError(t, err)
+	envDir := t.TempDir()
+	stateDir := t.TempDir()
 
 	log, buf := ui.NewForTesting()
 
-	err = hermit.Init(log, envDir, "", stateDir, hermit.Config{}, "BYPASS")
+	err := hermit.Init(log, envDir, "", stateDir, hermit.Config{}, "BYPASS")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(handler)
@@ -95,10 +92,9 @@ func (f *EnvTestFixture) Clean() {
 
 // NewEnv returns a new environment using the state directory from this fixture
 func (f *EnvTestFixture) NewEnv() *hermit.Env {
-	envDir, err := os.MkdirTemp("", "")
-	assert.NoError(f.t, err)
+	envDir := f.t.TempDir()
 	log, _ := ui.NewForTesting()
-	err = hermit.Init(log, envDir, "", f.State.Root(), hermit.Config{}, "BYPASS")
+	err := hermit.Init(log, envDir, "", f.State.Root(), hermit.Config{}, "BYPASS")
 	assert.NoError(f.t, err)
 	info, err := hermit.LoadEnvInfo(envDir)
 	assert.NoError(f.t, err)

--- a/manifest/autoversion/autoversion_test.go
+++ b/manifest/autoversion/autoversion_test.go
@@ -48,10 +48,9 @@ func TestAutoVersion(t *testing.T) {
 	for _, input := range inputs {
 		t.Run(strings.Title(strings.TrimSuffix(filepath.Base(input), ".input.hcl")), func(t *testing.T) {
 			// Copy input manifest to a temporary path.
-			tmpFile, err := os.CreateTemp("", "*.hcl")
+			tmpFile, err := os.CreateTemp(t.TempDir(), "*.hcl")
 			assert.NoError(t, err)
 			defer tmpFile.Close() // nolint
-			defer os.Remove(tmpFile.Name())
 
 			inputContent, err := os.ReadFile(input)
 			assert.NoError(t, err)

--- a/manifest/autoversion/git_tags_test.go
+++ b/manifest/autoversion/git_tags_test.go
@@ -13,11 +13,8 @@ import (
 )
 
 func Test_GitTagsAutoVersion(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "")
-	defer os.RemoveAll(tmpDir)
-	assert.NoError(t, err, "could not create temp dir")
-
-	err = runCommandInDir(tmpDir, "git", "init", ".")
+	tmpDir := t.TempDir()
+	err := runCommandInDir(tmpDir, "git", "init", ".")
 	assert.NoError(t, err)
 
 	err = os.WriteFile(path.Join(tmpDir, "README.md"), []byte("readme"), 0600)

--- a/util/filepatcher_test.go
+++ b/util/filepatcher_test.go
@@ -81,9 +81,7 @@ foobar
 `,
 	}}
 
-	dir, err := os.MkdirTemp("", "")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Replace os.MkdirTemp() with t.TempDir() in tests.

Also removes deprecated and removed linters `gomnd`, `execinquery` and `tenv`.