### PR TITLE
chore: Remove docs exclusion from CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,8 @@
 on:
   push:
-    paths-ignore:
-      - 'docs/**'
     branches:
       - master
   pull_request:
-    paths-ignore:
-      - 'docs/**'
 name: CI
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
     branches:
       - master
   pull_request:


### PR DESCRIPTION
The docs exclusion saves a small amount of time for a doc-only change, but at the moment, the PR never runs the checks, so doesn't get marked as ready to merge!

We could update the checks, but feels simpler to just remove the doc exclusion.