### PR TITLE
chore: see if Go toolchain version check works

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -15,6 +15,11 @@
   ],
   packageRules: [
     {
+      matchManagers: ['hermit'],
+      "matchPackageNames": ['go'],
+      "versioning": 'regex:^v?1.(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?$'
+    },
+    {
       matchCategories: [
         'js',
       ],


### PR DESCRIPTION
Go versioning is actually in the form `1.<major>.<minor>`, but by default Renovate isn't aware of this. Try to write a custom version rule to define this.