### PR TITLE
Use kong exit

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -249,7 +249,7 @@ func Main(config Config) {
 
 	ctx, err := parser.Parse(os.Args[1:])
 	parser.FatalIfErrorf(err)
-	configureLogging(cli, ctx.Command(), p)
+	configureLogging(cli, ctx, p)
 
 	var userConfig UserConfig
 	userConfigPath := cli.getUserConfigFile()
@@ -317,7 +317,11 @@ func Main(config Config) {
 	}
 }
 
-func configureLogging(cli cliInterface, cmd string, p *ui.UI) {
+func configureLogging(cli cliInterface, ctx *kong.Context, p *ui.UI) {
+	cmd := ctx.Command()
+
+	p.SetExit(ctx.Exit)
+
 	// This is set to avoid logging in environments where quiet flag is not used
 	// in the "hermit" script. This is fragile, and should be removed when we know that all the
 	// environments are using a script with executions done with --quiet

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -59,14 +59,6 @@ func (w *UI) SetExit(f func(int)) {
 	w.exit = f
 }
 
-func (w *UI) Exit(c int) {
-	if w.exit == nil {
-		os.Exit(c)
-	} else {
-		w.exit(c)
-	}
-}
-
 var _ Logger = &UI{}
 
 // NewForTesting returns a new UI that writes all output to the returned bytes.Buffer.
@@ -87,6 +79,7 @@ func New(level Level, stdout, stderr SyncWriter, stdoutIsTTY, stderrIsTTY bool) 
 		stderrIsTTY:        stderrIsTTY,
 		minlevel:           level,
 		progressBarEnabled: true,
+		exit:               os.Exit,
 	}
 	w.loggingMixin = &loggingMixin{
 		logWriter: logWriter{
@@ -224,7 +217,7 @@ func (w *UI) logf(level Level, label string, format string, args ...interface{})
 	if level == LevelFatal {
 		defer func() {
 			_ = w.stderr.Sync()
-			w.Exit(1)
+			w.exit(1)
 		}()
 	} else {
 		w.writeProgress(w.width)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -52,6 +52,19 @@ type UI struct {
 	state              uint64
 	minlevel           Level
 	progressBarEnabled bool
+	exit               func(int)
+}
+
+func (w *UI) SetExit(f func(int)) {
+	w.exit = f
+}
+
+func (w *UI) Exit(c int) {
+	if w.exit == nil {
+		os.Exit(c)
+	} else {
+		w.exit(c)
+	}
 }
 
 var _ Logger = &UI{}
@@ -211,7 +224,7 @@ func (w *UI) logf(level Level, label string, format string, args ...interface{})
 	if level == LevelFatal {
 		defer func() {
 			_ = w.stderr.Sync()
-			os.Exit(1)
+			w.Exit(1)
 		}()
 	} else {
 		w.writeProgress(w.width)


### PR DESCRIPTION
## Description

Replace direct calls to `os.Exit` with `Kong.Exit` to ensure proper Kong exit handling
