### PR TITLE
perf(manifest): speed up ParseVersion

### DIFF
--- a/manifest/version.go
+++ b/manifest/version.go
@@ -8,10 +8,7 @@ import (
 	"unicode"
 )
 
-var (
-	versionRe      = regexp.MustCompile(`^([^-+a-zA-Z]+)(?:([-]?)([a-zA-Z][^+]*))?(?:(\+)(.+))?$`)
-	versionPartsRe = regexp.MustCompile(`[._]`)
-)
+var versionRe = regexp.MustCompile(`^([^-+a-zA-Z]+)(?:([-]?)([a-zA-Z][^+]*))?(?:(\+)(.+))?$`)
 
 // Version of a package.
 //
@@ -43,11 +40,14 @@ func ParseVersion(version string) Version {
 	if parts == nil {
 		parts = []string{version, version, "", ""}
 	}
+	isSep := func(r rune) bool {
+		return r == '.' || r == '_'
+	}
 	if parts[1] != "" {
-		components = versionPartsRe.Split(parts[1], -1)
+		components = strings.FieldsFunc(parts[1], isSep)
 	}
 	if parts[3] != "" {
-		prerelease = versionPartsRe.Split(parts[3], -1)
+		prerelease = strings.FieldsFunc(parts[3], isSep)
 	}
 	for len(parts) < 6 {
 		parts = append(parts, "")


### PR DESCRIPTION
ParseVersion was using regex to split strings into fields where strings.FieldsFunc will suffice. This regex split was taking a surprisingly large amount of CPU - changing to FieldsFunc reduces execution time of `hermit search go` by more than 10%:

Before change:

$ time hermit search go | wc
    202    4805   35460

real    0m1.840s
user    0m3.335s
sys     0m0.233s

With change:

$ time hermit search go | wc
    202    4805   35460

real    0m1.543s
user    0m2.897s
sys     0m0.258s