### PR TITLE
fix: skipping activation when already activated should exit cleanly

### DIFF
--- a/bin/lint-shell-exit-codes
+++ b/bin/lint-shell-exit-codes
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+reserved_exit_codes=(
+  34 # previously used for "already activated" hermit environments
+)
+
+fails=false
+
+for file in $@; do
+  for code in "${reserved_exit_codes[@]}"; do
+    if grep -Hn -E "^\s*(exit|return)\s+$code(\s|$)" "$file"; then
+      fails=true
+    fi
+  done
+done
+
+if $fails; then
+  echo -e "\n❌ Reserved exit codes found. Please update with alternative codes."
+  exit 1
+fi

--- a/bin/lint-shell-scripts
+++ b/bin/lint-shell-scripts
@@ -10,3 +10,5 @@ go run ./cmd/hermit shell-hooks --zsh --print > $tmpzsh
 go run ./cmd/hermit shell-hooks --bash --print > $tmpbash
 go run -ldflags "-X main.channel=stable" ./cmd/hermit gen-installer --dest=./build/install.sh >/dev/null
 shellcheck -e SC2296 -s bash ./build/install.sh ./files/hermit ./files/activate-hermit ./shell/files/sh_common_hooks.sh "$tmpzsh" "$tmpbash" ./it/check_script_sha.sh
+lint-shell-exit-codes ./build/install.sh ./files/hermit ./files/activate-hermit ./files/activate-hermit.fish ./shell/files/activate.tmpl.sh ./shell/files/activate.tmpl.fish ./shell/files/fish_hooks.fish ./shell/files/sh_common_hooks.sh
+

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -194,7 +194,6 @@ EOF
 				. bin/activate-hermit
 				. bin/activate-hermit
 			`,
-			fails:        true,
 			expectations: exp{outputContains("This Hermit environment has already been activated. Skipping")},
 		},
 		{

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -188,7 +188,7 @@ EOF
 			`,
 		},
 		{
-			name: "CannotBeActivatedTwice",
+			name: "ConsidersASecondActivationANoop",
 			script: `
 				hermit init .
 				. bin/activate-hermit

--- a/it/full/spec/it_spec.sh
+++ b/it/full/spec/it_spec.sh
@@ -27,10 +27,10 @@ Describe "Hermit"
         The stderr should not be blank
         The variable HERMIT_ENV should equal "$(pwd)"
       End
-      It "fails to activate twice"
+      It "cannot be activated twice"
         . ./bin/activate-hermit
         When call source ./bin/activate-hermit
-        The status should be failure
+        The status should be success
         The stderr should eq "This Hermit environment has already been activated. Skipping"
       End
       It "loads environment variables from the local hermit.hcl"

--- a/it/full/spec/it_spec.sh
+++ b/it/full/spec/it_spec.sh
@@ -27,7 +27,7 @@ Describe "Hermit"
         The stderr should not be blank
         The variable HERMIT_ENV should equal "$(pwd)"
       End
-      It "cannot be activated twice"
+      It "considers a second activation a noop"
         . ./bin/activate-hermit
         When call source ./bin/activate-hermit
         The status should be success

--- a/shell/files/activate.tmpl.fish
+++ b/shell/files/activate.tmpl.fish
@@ -5,7 +5,7 @@ set -gx HERMIT_ENV {{.Root}}
 if set -q ACTIVE_HERMIT
     if test "$ACTIVE_HERMIT" = "$HERMIT_ENV"
         echo "This Hermit environment has already been activated. Skipping" >&2
-        return 34
+        return 0
     else if functions -q deactivate-hermit
         set -lx HERMIT_CURRENT_ENV $HERMIT_ENV
         set -gx HERMIT_ENV $ACTIVE_HERMIT

--- a/shell/files/activate.tmpl.sh
+++ b/shell/files/activate.tmpl.sh
@@ -5,7 +5,7 @@ export HERMIT_ENV={{.Root}}
 if [ -n "${ACTIVE_HERMIT+_}" ]; then
   if [ "$ACTIVE_HERMIT" = "$HERMIT_ENV" ]; then
     echo "This Hermit environment has already been activated. Skipping" >&2
-    return 34
+    return 0
   elif type deactivate-hermit &>/dev/null; then
     export HERMIT_CURRENT_ENV=$HERMIT_ENV
     export HERMIT_ENV=$ACTIVE_HERMIT


### PR DESCRIPTION
We've had reports of some AI agents struggling when trying to activate an already activated environment because of the non-zero exit code. There reason for exiting with the 34 code seems to have been lost to the sands of time, and we now believe that there is not a significant reason not to exit cleanly in this case.