### PR TITLE
perf(manifest): speed up newPackage

### DIFF
--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -3,18 +3,19 @@ package manifest
 import (
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/alecthomas/participle/v2"
 	"github.com/gobwas/glob"
-	"github.com/qdm12/reprint"
 
 	"github.com/cashapp/hermit/envars"
 	"github.com/cashapp/hermit/errors"
@@ -350,8 +351,6 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 		}
 	}
 
-	// Clone the entire manifest, as we mutate stuff.
-	manifest = reprint.This(manifest).(*AnnotatedManifest)
 	// Resolve version in manifest from ref.
 	var foundUpdateInterval time.Duration
 	// Search versions first.
@@ -384,11 +383,9 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 		sort.Strings(knownChannels)
 		if strings.Contains(selector.String(), "@") {
 			tryVersion := strings.ReplaceAll(selector.String(), "@", "-")
-			for _, ver := range knownVersions {
-				if ver == tryVersion {
-					return nil, errors.Wrapf(ErrUnknownPackage, "%s: no channel %s found, did you mean version %s?",
-						manifest.Path, selector, tryVersion)
-				}
+			if slices.Contains(knownVersions, tryVersion) {
+				return nil, errors.Wrapf(ErrUnknownPackage, "%s: no channel %s found, did you mean version %s?",
+					manifest.Path, selector, tryVersion)
 			}
 			return nil, errors.Wrapf(ErrUnknownPackage, "%s: no channel %s found in channels (%s) or versions (%s)",
 				manifest.Path, selector, strings.Join(knownChannels, ", "), strings.Join(knownVersions, ", "))
@@ -437,13 +434,13 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 
 	vars := map[string]string{}
 	layerEnvars := make([]envars.Envars, 0, len(layers))
+	// Because the layers are pointers belonging to the manifest, any data
+	// that may be modified (i.e. environment expansion) must be copied.
 	for _, layer := range layers {
 		if len(layer.Env) > 0 {
-			layerEnvars = append(layerEnvars, layer.Env)
+			layerEnvars = append(layerEnvars, layer.Env.Clone())
 		}
-		for k, v := range layer.Vars {
-			vars[k] = v
-		}
+		maps.Copy(vars, layer.Vars)
 		if layer.Arch != "" {
 			p.Arch = layer.Arch
 		}
@@ -463,7 +460,7 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 			p.DontExtract = layer.DontExtract
 		}
 		if len(layer.Mirrors) > 0 {
-			p.Mirrors = layer.Mirrors
+			p.Mirrors = append(p.Mirrors, layer.Mirrors...)
 		}
 		if layer.Root != "" {
 			p.Root = layer.Root
@@ -494,9 +491,7 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 				p.RuntimeDeps = append(p.RuntimeDeps, ref)
 			}
 		}
-		for k, v := range layer.Files {
-			files[k] = v
-		}
+		maps.Copy(files, layer.Files)
 	}
 	// Verify.
 	if len(p.Binaries) == 0 && len(p.Apps) == 0 {
@@ -574,7 +569,7 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 		}
 	}
 
-	// Expand envars in "s". If "ignoreMissing is true then unknown variable references will be
+	// Expand envars in "s". If "ignoreMissing" is true then unknown variable references will be
 	// passed through unaltered.
 	expand := func(s string, ignoreMissing bool) string {
 		last := ""
@@ -598,6 +593,7 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 		sort.Slice(ops, func(i, j int) bool { return ops[i].Envar() < ops[j].Envar() })
 		p.Env = append(p.Env, ops...)
 	}
+
 	p.Strip = layers.field("Strip", 0).(int)
 	p.Dest = expand(p.Dest, false)
 	p.Root = expand(p.Root, false)
@@ -616,6 +612,7 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 	for i, mirror := range p.Mirrors {
 		p.Mirrors[i] = expand(mirror, false)
 	}
+
 	// Get sha256 checksum after variable expansion for source, taking care of
 	// autoversion
 	for _, layer := range layers {
@@ -626,6 +623,7 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 		}
 	}
 	inferPackageRepository(p, manifest.Manifest)
+
 	for _, actions := range p.Triggers {
 		for _, action := range actions {
 			switch action := action.(type) {
@@ -703,6 +701,7 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+
 	return p, err
 }
 

--- a/manifest/resolver_test.go
+++ b/manifest/resolver_test.go
@@ -433,3 +433,89 @@ func TestSearchVersionsAndChannelsCoexist(t *testing.T) {
 	}
 	assert.Equal(t, repr.String(expected, repr.Indent("  ")), repr.String(pkgs, repr.Indent("  ")))
 }
+
+func TestManifestImmutability(t *testing.T) {
+	// Some data from the manifest is copied to newly created Packages. Some
+	// of this data is modified (e.g., for environment variable expansion).
+	// This test ensures that the original manifest is not modified. It
+	// uses a smattering of expansions all over the place in different areas
+	// to try to catch corner cases.
+	files := map[string]string{
+		"test.hcl": `
+			description = "a package"
+			binaries = ["bin-${os}"]
+			env = { "FOO_ENV": "BAR_${version}" }
+			vars = { "FOO_VAR": "something" }
+			dest = "/tmp/foo/${version}"
+			root = "/tmp/foo/${os}"
+			source = "www.example.com/${version}/${os}/2"
+			provides = ["bar-${version}"]
+			on "unpack" {
+				delete {
+					files = ["/tmp/test-${os}"]
+				}
+			}
+
+			version "1.0.0" "1.0.5" {
+				source = "www.example.com/${version}/${os}"
+				requires = ["foo-${os}"]
+				on "activate" {
+					chmod {
+						file = "${root}/foo-${version}"
+						mode = 493
+					}
+				}
+			}
+
+			platform "Linux" {
+				mirrors = ["www.example.com/linux/${version}"]
+				on "install" {
+					mkdir {
+						dir = "${FOO_VAR}"
+					}
+				}
+			}
+			platform "darwin" {
+				mirrors = ["www.example.com/bsd/${version}"]
+			}
+
+			channel stable {
+				source = "www.example.com"
+				update = "24h"
+			}
+
+			channel canary {
+				source = "www.example.com/${os}-${arch}"
+				update = "24h"
+				on "unpack" {
+					rename {
+						from = "/tmp/bar-${os}"
+						to = "/tmp/test-canary-${version}"
+					}
+				}
+			}
+		`,
+	}
+	config := Config{
+		Env:   "/home/user/project",
+		State: "/home/user/.cache/hermit",
+		Platform: platform.Platform{
+			OS:   "Linux",
+			Arch: "x86_64",
+		},
+	}
+	ffs := vfs.InMemoryFS(files)
+	mft, err := LoadManifestFile(ffs, "test.hcl")
+	assert.NoError(t, err)
+
+	mftCopy, err := LoadManifestFile(ffs, "test.hcl")
+	assert.NoError(t, err)
+
+	refs := mft.References("test")
+
+	for _, ref := range refs {
+		_, err := Resolve(mft, config, ref)
+		assert.NoError(t, err)
+		assert.Equal(t, mft, mftCopy)
+	}
+}

--- a/manifest/triggers.go
+++ b/manifest/triggers.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 
 	"github.com/cashapp/hermit/errors"
+	"github.com/qdm12/reprint"
 )
 
 // Event in the lifecycle of a package.
@@ -57,28 +58,28 @@ type Trigger struct {
 func (a *Trigger) Ordered() []Action {
 	var out []Action
 	for _, action := range a.Run {
-		out = append(out, action)
+		out = append(out, reprint.This(action).(Action))
 	}
 	for _, action := range a.Copy {
-		out = append(out, action)
+		out = append(out, reprint.This(action).(Action))
 	}
 	for _, action := range a.Chmod {
-		out = append(out, action)
+		out = append(out, reprint.This(action).(Action))
 	}
 	for _, action := range a.Rename {
-		out = append(out, action)
+		out = append(out, reprint.This(action).(Action))
 	}
 	for _, action := range a.Delete {
-		out = append(out, action)
+		out = append(out, reprint.This(action).(Action))
 	}
 	for _, action := range a.Message {
-		out = append(out, action)
+		out = append(out, reprint.This(action).(Action))
 	}
 	for _, action := range a.Mkdir {
-		out = append(out, action)
+		out = append(out, reprint.This(action).(Action))
 	}
 	for _, action := range a.Symlink {
-		out = append(out, action)
+		out = append(out, reprint.This(action).(Action))
 	}
 	sort.Slice(out, func(i, j int) bool {
 		return out[i].position().Line < out[j].position().Line


### PR DESCRIPTION
Profiling indicated that the deep copy of the manifest in newPackage was taking >30% of CPU time when running `hermit search`. This copy was performed to ensure that the original manifest object is not modified when performing env var expansion. However, we can instead copy the limited number of fields that are modified, significantly speeding up package processing. The effect is most noticeable when using `hermit search` when a large number of packages match.

`hermit search` benchmarks (large gain)

Before:
real    0m7.825s
user    0m12.985s
sys     0m0.424s

After:
real    0m3.317s
user    0m5.890s
sys     0m0.389s

`hermit search sql` benchmarks (small gain)

Before:
real    0m0.623s
user    0m1.681s
sys     0m0.129s

After:
real    0m0.529s
user    0m1.521s
sys     0m0.104s

Add a test to attempt to catch possible modifications introduced by future changes.