### PR TITLE
fix: Improve error message when binaries are missing

### DIFF
--- a/env.go
+++ b/env.go
@@ -833,7 +833,7 @@ func (e *Env) Exec(l *ui.UI, pkg *manifest.Package, binary string, args []string
 		err = syscall.Exec(bin, argsCopy, env)
 		return errors.Wrapf(err, "%s: failed to execute %q", pkg, bin)
 	}
-	return errors.Errorf("%s: could not find binary %q", pkg, binary)
+	return errors.Errorf("%s: failed to resolve binary %q in installed package - this may indicate a corrupted installation, try removing %s and hermit will reinstall it (may required sudo)", pkg, filepath.Base(binary), pkg.Dest)
 }
 
 func (e *Env) getPackageRuntimeEnvops(pkg *manifest.Package) (envars.Op, error) {

--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -127,10 +127,10 @@ func (p *Package) ResolveBinaries() ([]string, error) {
 		bin = path.Join(p.Root, bin)
 		bins, err := filepath.Glob(bin)
 		if err != nil {
-			return nil, errors.Wrapf(err, "%s: failed to resolve package binaries - this may indicate a corrupted installation, try removing %s and hermit will reinstall it (may require sudo)", p, p.Dest)
+			return nil, errors.Wrapf(err, "%s: failed to find the bin directory - this may indicate a corrupted installation, try removing %s and hermit will reinstall it (may require sudo)", p, p.Dest)
 		}
 		if len(bins) == 0 {
-			return nil, errors.Errorf("%s: failed to resolve package binaries - this may indicate a corrupted installation, try removing %s and hermit will reinstall it (may require sudo)", p, p.Dest)
+			return nil, errors.Errorf("%s: failed any binaries in the bin directory - this may indicate a corrupted installation, try removing %s and hermit will reinstall it (may require sudo)", p, p.Dest)
 		}
 		binaries = append(binaries, bins...)
 	}

--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -127,10 +127,10 @@ func (p *Package) ResolveBinaries() ([]string, error) {
 		bin = path.Join(p.Root, bin)
 		bins, err := filepath.Glob(bin)
 		if err != nil {
-			return nil, errors.Wrapf(err, "%s: failed to find binaries %q", p, bin)
+			return nil, errors.Wrapf(err, "%s: failed to resolve package binaries - this may indicate a corrupted installation, try removing %s and hermit will reinstall it (may require sudo)", p, p.Dest)
 		}
 		if len(bins) == 0 {
-			return nil, errors.Errorf("%s: failed to find binaries %q", p, bin)
+			return nil, errors.Errorf("%s: failed to resolve package binaries - this may indicate a corrupted installation, try removing %s and hermit will reinstall it (may require sudo)", p, p.Dest)
 		}
 		binaries = append(binaries, bins...)
 	}


### PR DESCRIPTION
If the required binaries are missing it indicates there was a problem with the installation of the package being used.  
Updates the error messages so that it's clearer how the user can potentially remedy the situation.

There are three scenarios that I manually tested:
- `bin` directory missing.
- `bin` directory empty.
>fatal:hermit: node-22.14.0: failed to resolve package binaries - this may indicate a corrupted installation, try removing /Users/jrobotham/Library/nodejs/nodejs-22.14.0-block-2024 and hermit will reinstall it (may require sudo)


- required binary missing.
>fatal:hermit: node-22.14.0: failed to resolve binary "node" in installed package - this may indicate a corrupted installation, try removing /Users/jrobotham/Library/nodejs/nodejs-22.14.0-block-2024 and hermit will reinstall it (may required sudo)
