### PR TITLE
refactor: move common variable expansion to envars package

### DIFF
--- a/envars/util.go
+++ b/envars/util.go
@@ -1,7 +1,13 @@
 package envars
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
+	"time"
+
+	"github.com/cashapp/hermit/platform"
 )
 
 // Parse a KEY=VALUE list of environment variables into an Envars map.
@@ -12,4 +18,55 @@ func Parse(envars []string) Envars {
 		env[parts[0]] = parts[1]
 	}
 	return env
+}
+
+// Expand repeatedly expands s until the mapping function stops making
+// substitutions. This is useful for variables that reference other variables.
+func Expand(s string, mapping func(string) string) string {
+	last := ""
+	for last != s {
+		last = s
+		s = os.Expand(s, mapping)
+	}
+	return s
+}
+
+// Mapping returns a function that expands hermit variables. The function can
+// be passed to Expand.
+func Mapping(env, home string, p platform.Platform) func(s string) string {
+	return func(key string) string {
+		switch key {
+		case "HERMIT_ENV", "env":
+			return env
+
+		case "HERMIT_BIN":
+			return filepath.Join(env, "bin")
+
+		case "os":
+			return p.OS
+
+		case "arch":
+			return p.Arch
+
+		case "xarch":
+			if xarch := platform.ArchToXArch(p.Arch); xarch != "" {
+				return xarch
+			}
+			return p.Arch
+
+		case "HOME":
+			return home
+
+		case "YYYY":
+			return fmt.Sprintf("%04d", time.Now().Year())
+
+		case "MM":
+			return fmt.Sprintf("%02d", time.Now().Month())
+
+		case "DD":
+			return fmt.Sprintf("%02d", time.Now().Day())
+		default:
+			return ""
+		}
+	}
 }

--- a/envars/util_test.go
+++ b/envars/util_test.go
@@ -1,0 +1,81 @@
+package envars
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/cashapp/hermit/platform"
+)
+
+func TestExpandMapping(t *testing.T) {
+	cases := []struct {
+		name       string
+		mapping    func(string) string
+		wantExpand map[string]string
+	}{
+		{
+			name: "basic expansion",
+			mapping: Mapping("hermit/env", "home/user", platform.Platform{
+				OS:   platform.Linux,
+				Arch: platform.Amd64,
+			}),
+			wantExpand: map[string]string{
+				"${HOME}":       "home/user",
+				"${HERMIT_ENV}": "hermit/env",
+				"${env}":        "hermit/env",
+				"${HERMIT_BIN}": "hermit/env/bin",
+				"${os}":         platform.Linux,
+				"${arch}":       platform.Amd64,
+				"${xarch}":      platform.ArchToXArch(platform.Amd64),
+				"${NOT_A_VAR}":  "",
+			},
+		},
+		{
+			name: "nested expansion",
+			mapping: Mapping("${HOME}/env", "home/${os}-user", platform.Platform{
+				OS:   platform.Darwin,
+				Arch: platform.Arm64,
+			}),
+			wantExpand: map[string]string{
+				"You live at $HOME!":         "You live at home/darwin-user!",
+				"${HERMIT_ENV}":              "home/darwin-user/env",
+				"${env}":                     "home/darwin-user/env",
+				"${HERMIT_BIN}":              "home/darwin-user/env/bin",
+				"$HERMIT_BIN/foo-$arch/$env": "home/darwin-user/env/bin/foo-arm64/home/darwin-user/env",
+				"$xarch":                     platform.ArchToXArch(platform.Arm64),
+			},
+		},
+		{
+			name: "unknown OS and Arch",
+			mapping: Mapping("", "", platform.Platform{
+				OS:   "foo",
+				Arch: "bar",
+			}),
+			wantExpand: map[string]string{
+				"${os}-${arch}-${xarch}": "foo-bar-bar",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for str, wantExpand := range tc.wantExpand {
+				assert.Equal(t, wantExpand, Expand(str, tc.mapping))
+			}
+		})
+	}
+}
+
+func TestExpandDateTime(t *testing.T) {
+	mapping := Mapping("foo", "foo", platform.Platform{})
+
+	// Testing time expansion is complicated, so we simply make sure
+	// that year, month, and day are each expanded to positive integers.
+	for _, pattern := range []string{"$DD", "$MM", "$YYYY"} {
+		gotExpand := Expand(pattern, mapping)
+		gotInt, err := strconv.Atoi(gotExpand)
+		assert.NoError(t, err, "could not convert datetime expansion of %v (%v) to int", pattern, gotExpand)
+		assert.NotZero(t, gotInt, "expected nonzero date")
+	}
+}


### PR DESCRIPTION
While working on an implementation for #312, I found that it was necessary to factor variable expansion logic out of the manifest package so that it can be used elsewhere, such as when parsing hermit.hcl. This does not necessarily make the existing code cleaner, but it will facilitate future changes.

Also fixes an issue where variable references without {} (e.g., $FOO) were in some cases left unexpanded.