### PR TITLE
fix: incomplete memory profile

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -307,9 +307,11 @@ func Main(config Config) {
 		f, err := os.Create(pprofPath)
 		fatalIfError(p, ctx, err)
 		defer f.Close() // nolint: gosec
-		runtime.GC()    // get up-to-date statistics
-		err = pprof.WriteHeapProfile(f)
-		fatalIfError(p, ctx, err)
+		defer func() {
+			runtime.GC() // get up-to-date statistics
+			err = pprof.Lookup("allocs").WriteTo(f, 0)
+			fatalIfError(p, ctx, err)
+		}()
 	}
 	err = ctx.Run(env, p, sta, config, cli.getGlobalState(), ghClient, defaultHTTPClient, cache, userConfig)
 	fatalIfError(p, ctx, err)


### PR DESCRIPTION
The memory profile was being created before the main program even started, so very little relevant data was recorded. Also update the default view to total allocations since the program started rather than the current heap.