### PR TITLE
fix: improve error when version fails to expand

### DIFF
--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -557,7 +557,11 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 	mapping := func(key string) string {
 		val := pkgMapping(key)
 		if val == "" {
-			err = errors.Errorf("unknown variable $%s", key)
+			if key == "version" {
+				err = errors.Errorf("failed to expand ${%s} (hint: make sure all channels set a version range)", key)
+			} else {
+				err = errors.Errorf("unknown variable $%s", key)
+			}
 			return ""
 		}
 		return val

--- a/manifest/resolver_test.go
+++ b/manifest/resolver_test.go
@@ -317,6 +317,25 @@ func TestResolver_Resolve(t *testing.T) {
 			WithVersion("1.0.0").
 			WithSource("www.example.com/foo/bar").
 			Result(),
+	}, {
+		name: "Returns an error when expanding version if channel has no version range",
+		files: map[string]string{
+			`test.hcl`: `
+			description = "test package"
+			binaries = ["bin-${version}"]
+
+			version "1.0.0" {
+				source = "www.example.com"
+			}
+
+			channel "edge" {
+				update = "5h"
+				source = "www.example.com/channels/${version}/test"
+			}
+			`,
+		},
+		reference: "test@edge",
+		wantErr:   "failed to expand ${version} (hint: make sure all channels set a version range)",
 	},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This situation is easy to run into when a field contains the ${version} variable but a channel does not contain a specific version range.