### PR TITLE
Fix self-update for NFS

### DIFF
--- a/it/sanity/run.sh
+++ b/it/sanity/run.sh
@@ -46,7 +46,6 @@ trap afterAll EXIT
 beforeAll
 
 testSubset() {
-  ./bin/hermit update
   ./bin/hermit test openjdk --level=debug
   ./bin/hermit test hermit --level=debug
 }

--- a/it/sanity/run.sh
+++ b/it/sanity/run.sh
@@ -46,6 +46,7 @@ trap afterAll EXIT
 beforeAll
 
 testSubset() {
+  ./bin/hermit update
   ./bin/hermit test openjdk --level=debug
   ./bin/hermit test hermit --level=debug
 }

--- a/state/state.go
+++ b/state/state.go
@@ -544,10 +544,12 @@ func (s *State) removePackage(task *ui.Task, pkg *manifest.Package) error {
 	// Evicting the current executing package may cause issues on certain filesystems (ex: NFS)
 	// while the binary is in use. Instead of removing, we rename the package directory instead.
 	if strings.HasPrefix(filepath.Base(pkg.Dest), "hermit@") {
-		newPath := filepath.Join(s.pkgDir, fmt.Sprintf("%s.old", filepath.Base(pkg.Dest)))
+		newPath := filepath.Join(filepath.Dir(pkg.Dest), fmt.Sprintf(".%s.old", filepath.Base(pkg.Dest)))
 		// If new path exists, remove it first
 		if _, err := os.Stat(newPath); err == nil {
-			s.removeRecursive(task, newPath)
+			if err := s.removeRecursive(task, newPath); err != nil {
+				return errors.WithStack(err)
+			}
 		}
 		task.Debugf("mv %s %s", pkg.Dest, newPath)
 		return errors.WithStack(os.Rename(pkg.Dest, newPath))

--- a/state/state.go
+++ b/state/state.go
@@ -541,7 +541,17 @@ func (s *State) removePackage(task *ui.Task, pkg *manifest.Package) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-
+	// Evicting the current executing package may cause issues on certain filesystems (ex: NFS)
+	// while the binary is in use. Instead of removing, we rename the package directory instead.
+	if strings.HasPrefix(filepath.Base(pkg.Dest), "hermit@") {
+		newPath := filepath.Join(s.pkgDir, fmt.Sprintf("%s.old", filepath.Base(pkg.Dest)))
+		// If new path exists, remove it first
+		if _, err := os.Stat(newPath); err == nil {
+			s.removeRecursive(task, newPath)
+		}
+		task.Debugf("mv %s %s", pkg.Dest, newPath)
+		return errors.WithStack(os.Rename(pkg.Dest, newPath))
+	}
 	err = s.removeRecursive(task, pkg.Dest)
 	if err != nil {
 		return errors.WithStack(err)

--- a/state/state.go
+++ b/state/state.go
@@ -580,8 +580,10 @@ func (s *State) removePackage(task *ui.Task, pkg *manifest.Package) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	// Evicting the current executing package may cause issues on certain filesystems (ex: NFS)
-	// while the binary is in use. Instead of removing, we rename the package directory instead.
+	// When removing hermit itself, we avoid removing the package directory and instead rename it
+	// to avoid issues with the active hermit binary being in use. This is because in certain
+	// environments (like NFSv3), removing a directory that contains an open file
+	// can lead to undefined behavior, such as the directory not being removed until the file is closed.
 	if pkg.Reference.Name == "hermit" {
 		newPath := filepath.Join(filepath.Dir(pkg.Dest), fmt.Sprintf(".%s.old", filepath.Base(pkg.Dest)))
 		return errors.WithStack(s.renameRecursive(task, pkg.Dest, newPath))

--- a/state/state.go
+++ b/state/state.go
@@ -262,7 +262,6 @@ func (s *State) renameRecursive(b *ui.Task, src, dest string) error {
 		}
 	}
 
-	// Start our renaming task
 	task := b.SubTask("rename")
 	release, err := s.acquireLock(b, "recursively renaming %s to %s", src, dest)
 	if err != nil {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1,6 +1,7 @@
 package state_test
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -176,5 +177,71 @@ func TestUpdateSymlinks(t *testing.T) {
 	linuxLink, err := os.Readlink(linuxExec)
 	assert.NoError(t, err)
 	assert.Equal(t, filepath.Join(newPkg.Dest, "linux_exe"), linuxLink)
+
+}
+
+func TestUpgrade(t *testing.T) {
+	etagCounter := 0
+	fixture := NewStateTestFixture(t).
+		WithHTTPHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// always generate a new ETag to invalidate the cache
+			w.Header().Set("ETag", fmt.Sprintf("etag-%d", etagCounter))
+			etagCounter++
+			fr, err := os.Open("../archive/testdata/archive.tar.gz")
+			assert.NoError(t, err)
+			defer fr.Close() // nolint
+			_, err = io.Copy(w, fr)
+			assert.NoError(t, err)
+
+		}))
+	defer fixture.Clean()
+	state := fixture.State()
+	log, _ := ui.NewForTesting()
+	rootPkgDir := state.PkgDir()
+
+	packageNames := []string{"hermit", "dune"}
+
+	for _, name := range packageNames {
+		t.Run(name, func(t *testing.T) {
+			pkgDir := filepath.Join(rootPkgDir, name)
+			renamedDir := filepath.Join(rootPkgDir, fmt.Sprintf(".%s.old", name))
+			pkg := manifesttest.NewPkgBuilder(pkgDir).
+				WithSource(fixture.Server.URL).
+				WithName(name).
+				WithChannel("stable").
+				Result()
+			assert.NoError(t, state.CacheAndUnpack(log.Task("test"), pkg))
+
+			// Check package file exists
+			_, err := os.Stat(pkgDir)
+			assert.NoError(t, err)
+			_, err = os.Stat(renamedDir)
+			assert.Error(t, err)
+
+			// Update cache with new ETag
+			_, err = state.CacheAndDigest(log.Task("test"), pkg)
+			assert.NoError(t, err)
+
+			// Run upgrade
+			err = state.UpgradeChannel(log.Task("test"), pkg)
+			assert.NoError(t, err)
+
+			_, err = os.Stat(pkgDir)
+			assert.NoError(t, err)
+			// For hermit, we should have renamed the old directory
+			if name == "hermit" {
+				_, err = os.Stat(renamedDir)
+				assert.NoError(t, err)
+			} else {
+				// For dune, we should not have renamed the old directory
+				_, err = os.Stat(renamedDir)
+				assert.Error(t, err)
+			}
+
+			// Another upgrade to make sure we delete the old hermit directory
+			_, err = state.CacheAndDigest(log.Task("test"), pkg)
+			assert.NoError(t, err)
+		})
+	}
 
 }


### PR DESCRIPTION
When running hermit on an NFS mounted environment, it fails to update itself. This is due to NFS keeping a  file busy while a binary on a certain folder is executing. Reference similar issue: https://community.unix.com/t/unix-rm-rf-error-rm-cannot-remove-filename-device-or-resource-busy/288520/7


Solution: 
- If self-updating hermit, instead of removing all files, rename folder to allow for new installation to happen. This ensures we don't have issues on NFS-like file systems.


Run of sanity/run.sh showing error:
```
file:///home/gerardc_squareup_com/projects/hermit/it/sanity/release/canary
~/projects/hermit/it/sanity/testenv ~/projects/hermit/it/sanity
info: Creating new Hermit environment in /home/gerardc_squareup_com/projects/hermit/it/sanity/testenv
info:   -> /home/gerardc_squareup_com/projects/hermit/it/sanity/testenv/bin/activate-hermit.fish
info:   -> /home/gerardc_squareup_com/projects/hermit/it/sanity/testenv/bin/hermit
info:   -> /home/gerardc_squareup_com/projects/hermit/it/sanity/testenv/bin/README.hermit.md
info:   -> /home/gerardc_squareup_com/projects/hermit/it/sanity/testenv/bin/activate-hermit
info:   -> /home/gerardc_squareup_com/projects/hermit/it/sanity/testenv/bin/hermit.hcl
info:

Hermit environment initialised in /home/gerardc_squareup_com/projects/hermit/it/sanity/testenv

To activate the environment run:

  . /home/gerardc_squareup_com/projects/hermit/it/sanity/testenv/bin/activate-hermit

Then run the following to list available commands:

  hermit --help

To deactivate the environment run:

  deactivate-hermit

For more information please refer to https://github.com/cashapp/hermit

Bootstrapping /home/gerardc_squareup_com/projects/hermit/it/sanity/state/pkg/hermit@canary/hermit from file:///home/gerardc_squareup_com/projects/hermit/it/sanity/release/canary
Creating /home/gerardc_squareup_com/projects/hermit/it/sanity/state/pkg/hermit@canary
Downloading file:///home/gerardc_squareup_com/projects/hermit/it/sanity/release/canary/hermit-linux-amd64.gz to /home/gerardc_squareup_com/projects/hermit/it/sanity/state/pkg/hermit@canary/hermit
Hermit installed as /home/gerardc_squareup_com/projects/hermit/it/sanity/state/pkg/hermit@canary/hermit
Hermit is installed as /home/gerardc_squareup_com/projects/hermit/it/sanity/userbin/hermit

See https://cashapp.github.io/hermit/usage/get-started/ for more information.

info:hermit@canary: Fetching a new version for hermit@canary
█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▏ 1/1    100.0%

fatal:hermit: unlinkat /home/gerardc_squareup_com/projects/hermit/it/sanity/state/pkg/hermit@canary: directory not empty
~/projects/hermit/it/sanity
```