### PR TITLE
fix: stdout needs to be flushed when prompting the user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,12 @@ test: ## run tests
 test-integration: ## run integration tests
 	./bin/go test -count=1 -tags integration -v ./integration
 
-build: ## builds binary and gzips it
+build: build-binary ## builds binary and gzips it
+	gzip -9 $(BIN)
+
+build-binary: ## builds binary
 	mkdir -p $(BUILD_DIR)
 	CGO_ENABLED=0 ./bin/go build -ldflags "-X main.version=$(VERSION) -X main.channel=$(CHANNEL)" -o $(BIN) $(ROOT)/cmd/hermit
-	gzip -9 $(BIN)
 
 help: ## Display this help message
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_\/-]+:.*?## / {printf "\033[34m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | \

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -332,7 +332,10 @@ func (w *UI) Confirmation(message string, args ...interface{}) (bool, error) {
 	w.lock.Lock()
 	defer w.lock.Unlock()
 
-	fmt.Fprintf(w.stdout, "hermit: "+message+"\n", args...)
+	fmt.Fprintf(w.stdout, "hermit: "+message+" ", args...)
+	if err := w.stdout.Sync(); err != nil {
+		return false, errors.WithStack(err)
+	}
 	s := ""
 	if _, err := fmt.Scan(&s); err != nil {
 		return false, errors.WithStack(err)


### PR DESCRIPTION
If it isn't, the prompt doesn't display until the user hits enter, but they're not aware that they have to.

I'm not sure how this regression occurred, because it definitely used to work.