### PR TITLE
fix: Ensure ManageGit defaults to true

### DIFF
--- a/app/init_cmd.go
+++ b/app/init_cmd.go
@@ -7,7 +7,7 @@ import (
 )
 
 type initCmd struct {
-	Git     bool     `negatable:"" help:"Enable Hermit's automatic management of Git'"`
+	Git     *bool    `negatable:"" help:"Enable Hermit's automatic management of Git'"`
 	Idea    bool     `negatable:"" help:"Enable Hermit's automatic addition of its IntelliJ IDEA plugin"`
 	Sources []string `help:"Sources to sync package manifests from."`
 	Dir     string   `arg:"" help:"Directory to create environment in (${default})." default:"${env}" predictor:"dir"`
@@ -34,8 +34,8 @@ func (i *initCmd) Run(w *ui.UI, config Config, userConfig UserConfig) error {
 	if i.Sources != nil {
 		hermitConfig.Sources = i.Sources
 	}
-	if !i.Git {
-		hermitConfig.ManageGit = false
+	if i.Git != nil {
+		hermitConfig.ManageGit = *i.Git
 	}
 	if i.Idea {
 		hermitConfig.AddIJPlugin = true

--- a/app/main.go
+++ b/app/main.go
@@ -253,7 +253,7 @@ func Main(config Config) {
 	parser.FatalIfErrorf(err)
 	configureLogging(cli, ctx, p)
 
-	var userConfig UserConfig
+	userConfig := NewUserConfigWithDefaults()
 	userConfigPath := cli.getUserConfigFile()
 
 	if IsUserConfigExists(userConfigPath) {

--- a/app/user_config.go
+++ b/app/user_config.go
@@ -31,6 +31,14 @@ type UserConfig struct {
 	Defaults    hermit.Config `hcl:"defaults,block,optional" help:"Default configuration values for new Hermit environments."`
 }
 
+func NewUserConfigWithDefaults() UserConfig {
+	return UserConfig{
+		Defaults: hermit.Config{
+			ManageGit: true,
+		},
+	}
+}
+
 // IsUserConfigExists checks if the user config file exists at the given path.
 func IsUserConfigExists(configPath string) bool {
 	_, err := os.Stat(kong.ExpandPath(configPath))
@@ -39,7 +47,7 @@ func IsUserConfigExists(configPath string) bool {
 
 // LoadUserConfig from disk.
 func LoadUserConfig(configPath string) (UserConfig, error) {
-	config := UserConfig{}
+	config := NewUserConfigWithDefaults()
 	// always return a valid config on error, with defaults set.
 	_ = hcl.Unmarshal([]byte{}, &config)
 	data, err := os.ReadFile(kong.ExpandPath(configPath))


### PR DESCRIPTION
There appears to be a regression introduced by https://github.com/cashapp/hermit/pull/436

`ManageGit` should be defaulting to true, but the default defined `hermit.Config` only applies when parsing from HCL.

So if you have either
- No `~/.hermit.hcl` file.
- An `~/.hermit.hcl` file without a value set for `defaults.manage-git` 

The repo will be `init`ed with `manage-git = false`

This change sets the default to true (as a starting point) and switches the command line parsing to use a pointer to allow us to distinguish between "true", "false" and "not set".
