### PR TITLE
fix: use HERMIT_GITHUB_TOKEN for git operations during exec

### DIFF
--- a/app/exec_cmd.go
+++ b/app/exec_cmd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cashapp/hermit/cache"
 	"github.com/cashapp/hermit/errors"
 	"github.com/cashapp/hermit/manifest"
+	"github.com/cashapp/hermit/sources"
 	"github.com/cashapp/hermit/state"
 	"github.com/cashapp/hermit/ui"
 	"github.com/cashapp/hermit/util/debug"
@@ -23,7 +24,7 @@ type execCmd struct {
 	Args   []string `arg:"" help:"Arguments to pass to executable (use -- to separate)." optional:""`
 }
 
-func (e *execCmd) Run(l *ui.UI, cache *cache.Cache, sta *state.State, globalState GlobalState, config Config, defaultHTTPClient *http.Client) error {
+func (e *execCmd) Run(l *ui.UI, cache *cache.Cache, sta *state.State, globalState GlobalState, config Config, defaultHTTPClient *http.Client, sourceRewriters []sources.URLRewriter) error {
 	envDir, err := hermit.FindEnvDir(e.Binary)
 	if err != nil {
 		return errors.WithStack(err)
@@ -34,7 +35,7 @@ func (e *execCmd) Run(l *ui.UI, cache *cache.Cache, sta *state.State, globalStat
 	}
 
 	// Pass config.SHA256Sums because OpenEnv uses the defaults cashapp/hermit; internal builds inject additional SHA256Sums.
-	env, err := hermit.OpenEnv(envInfo, sta, cache.GetSource, globalState.Env, defaultHTTPClient, config.SHA256Sums)
+	env, err := hermit.OpenEnv(envInfo, sta, cache.GetSource, globalState.Env, defaultHTTPClient, config.SHA256Sums, sourceRewriters...)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/app/main.go
+++ b/app/main.go
@@ -272,8 +272,8 @@ func Main(config Config) {
 		log.Fatalf("failed to open state: %s", err)
 	}
 
+	var sourceRewriters []sources.URLRewriter
 	if isActivated {
-		var sourceRewriters []sources.URLRewriter
 		if matcher != nil {
 			sourceRewriters = append(sourceRewriters, github.AuthenticatedURLRewriter(githubToken, matcher))
 		}
@@ -313,7 +313,7 @@ func Main(config Config) {
 			fatalIfError(p, ctx, err)
 		}()
 	}
-	err = ctx.Run(env, p, sta, config, cli.getGlobalState(), ghClient, defaultHTTPClient, cache, userConfig)
+	err = ctx.Run(env, p, sta, config, cli.getGlobalState(), ghClient, defaultHTTPClient, cache, userConfig, sourceRewriters)
 	fatalIfError(p, ctx, err)
 }
 


### PR DESCRIPTION
Since the hashed cached source path changes based on the rewritten URL, we can fail to run commands when relying on `HERMIT_GITHUB_TOKEN` for source authentication. This is a follow-up to cashapp/hermit#441 to use the same git source rewriting during exec.