### PR TITLE
fix: Renames if source and destination are on different filesystems

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -294,7 +294,7 @@ func (s *State) renameRecursive(b *ui.Task, src, dest string) error {
 			if rerr != nil {
 				return errors.WithStack(rerr)
 			}
-			if werr := os.WriteFile(dest, input, 0o755); werr != nil {
+			if werr := os.WriteFile(dest, input, 0o600); werr != nil {
 				return errors.WithStack(werr)
 			}
 			return errors.WithStack(os.Remove(src))


### PR DESCRIPTION
# What?

Has a fallback strategy for moving files when it's unable to perform an `os.Rename()`

# Why?

If the source and destination are on different mount locations then the Rename will fail with an error like...

`rename /root/.cache/hermit/pkg/hermit@square /root/.cache/hermit/pkg/.hermit@square.old: invalid cross-device link`

This has a fallback to copy the file if it fails to perform the rename.