### PR TITLE
fix: valid but empty variables in manifests were resulting in errors

### DIFF
--- a/envars/util_test.go
+++ b/envars/util_test.go
@@ -11,11 +11,11 @@ import (
 func TestExpandMapping(t *testing.T) {
 	cases := []struct {
 		name       string
-		mapping    func(string) string
+		mapping    func(string) (string, bool)
 		wantExpand map[string]string
 	}{
 		{
-			name: "basic expansion",
+			name: "BasicExpansion",
 			mapping: Mapping("hermit/env", "home/user", platform.Platform{
 				OS:   platform.Linux,
 				Arch: platform.Amd64,
@@ -28,11 +28,10 @@ func TestExpandMapping(t *testing.T) {
 				"${os}":         platform.Linux,
 				"${arch}":       platform.Amd64,
 				"${xarch}":      platform.ArchToXArch(platform.Amd64),
-				"${NOT_A_VAR}":  "",
 			},
 		},
 		{
-			name: "nested expansion",
+			name: "NestedExpansion",
 			mapping: Mapping("${HOME}/env", "home/${os}-user", platform.Platform{
 				OS:   platform.Darwin,
 				Arch: platform.Arm64,
@@ -47,7 +46,7 @@ func TestExpandMapping(t *testing.T) {
 			},
 		},
 		{
-			name: "unknown OS and Arch",
+			name: "UnknownOSAndArch",
 			mapping: Mapping("", "", platform.Platform{
 				OS:   "foo",
 				Arch: "bar",
@@ -57,15 +56,15 @@ func TestExpandMapping(t *testing.T) {
 			},
 		},
 		{
-			name: "escaped vars",
-			mapping: func(s string) string {
+			name: "EscapedVars",
+			mapping: func(s string) (string, bool) {
 				switch s {
 				case "$":
-					return "$$"
+					return "$$", true
 				case "foo":
-					return "bar"
+					return "bar", true
 				default:
-					return ""
+					return "", false
 				}
 			},
 			wantExpand: map[string]string{
@@ -86,14 +85,14 @@ func TestExpandMapping(t *testing.T) {
 }
 
 func TestExpandNoEscape(t *testing.T) {
-	assert.Equal(t, "$$foo", ExpandNoEscape("$$foo", func(s string) string {
+	assert.Equal(t, "$$foo", ExpandNoEscape("$$foo", func(s string) (string, bool) {
 		switch s {
 		case "$":
-			return "$$"
+			return "$$", true
 		case "foo":
-			return "bar"
+			return "bar", true
 		default:
-			return ""
+			return "", false
 		}
 	}))
 }

--- a/manifest/resolver_test.go
+++ b/manifest/resolver_test.go
@@ -197,7 +197,7 @@ func TestResolver_Resolve(t *testing.T) {
 				version "1.1.0" { source = "www.example.com/11" }
 				channel "testc" {
 				  update = "5h"
-				  version = "1.0.*"	
+				  version = "1.0.*"
 				}
             `,
 		},
@@ -222,7 +222,7 @@ func TestResolver_Resolve(t *testing.T) {
 				version "1.1.0" { source = "www.example.com/${version}" }
 				channel "testc" {
 				  update = "5h"
-				  version = "*"	
+				  version = "*"
 				}
             `,
 		},
@@ -246,7 +246,7 @@ func TestResolver_Resolve(t *testing.T) {
 				version "1.1.0" { source = "www.example.com/${version}" }
 				channel "testc" {
 				  update = "5h"
-				  version = "2.0"	
+				  version = "2.0"
 				}
             `,
 		},
@@ -349,9 +349,7 @@ func TestResolver_Resolve(t *testing.T) {
 			assert.NoError(t, err)
 			if tt.reference != "" {
 				gotPkg, err := l.Resolve(logger, PrefixSelector(ParseReference(tt.reference)))
-				if err != nil || tt.wantErr != "" {
-					assert.Equal(t, tt.wantErr, err.Error())
-				}
+				assert.EqualError(t, err, tt.wantErr)
 				if gotPkg != nil {
 					gotPkg.FS = nil
 				}


### PR DESCRIPTION
eg. in `swc.hcl` this:

```hcl
vars = {
  "arch_": "${arch}",
  "suffix": "",
}
```

Results in many errors like this:

```
warn: invalid manifest reference swc-1.10.16 in swc.hcl: unknown variable $suffix
```