### PR TITLE
fix: don't rely on an environment when self updating

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 on:
   push:
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
     tags:
-      - 'v*'
+      - "v*"
 name: Release
 jobs:
   deployable:
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: '^1.16.3'
+          go-version: "^1.16.3"
       - name: Build Hermit
         run: |
           make GOOS=linux GOARCH=amd64 CHANNEL=stable build

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test-integration: ## run integration tests
 	./bin/go test -count=1 -tags integration -v ./integration
 
 build: build-binary ## builds binary and gzips it
-	gzip -9 $(BIN)
+	gzip -f9 $(BIN)
 
 build-binary: ## builds binary
 	mkdir -p $(BUILD_DIR)

--- a/app/update_cmd.go
+++ b/app/update_cmd.go
@@ -24,7 +24,7 @@ func (s *updateCmd) Run(l *ui.UI, env *hermit.Env, state *state.State, cli cliIn
 		return errors.WithStack(err)
 	}
 	// Upgrade hermit if necessary
-	err = maybeUpdateHermit(l, env, cli.getSelfUpdate(), true)
+	err = maybeUpdateHermit(l, state, cli.getSelfUpdate(), true)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/env.go
+++ b/env.go
@@ -1170,13 +1170,7 @@ func (e *Env) Search(l *ui.UI, pattern string) (manifest.Packages, error) {
 //
 // This should only be called for packages that have already been installed
 func (e *Env) EnsureChannelIsUpToDate(l *ui.UI, pkg *manifest.Package) error {
-	task := l.Task(pkg.Reference.String())
-	if pkg.UpdateInterval == 0 || pkg.UpdatedAt.After(time.Now().Add(-1*pkg.UpdateInterval)) {
-		task.Tracef("No updated required")
-		// No updates needed for this package
-		return nil
-	}
-	return errors.WithStack(e.state.UpgradeChannel(task, pkg))
+	return errors.WithStack(e.state.EnsureChannelIsUpToDate(l, pkg))
 }
 
 // AddSource adds a new source bundle and refreshes the packages from it


### PR DESCRIPTION
This was a regression I introduced in #507.