### PR TITLE
perf: speed up shell completion for install and info commands

### DIFF
--- a/env.go
+++ b/env.go
@@ -1148,6 +1148,19 @@ func (e *Env) Clean(l *ui.UI, level CleanMask) error {
 	return nil
 }
 
+// SearchLite for packages using the given regular expression.
+func (e *Env) SearchLite(l *ui.UI, pattern string) ([]string, error) {
+	resolver, err := e.resolver(l)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	matches, err := resolver.SearchLite(l, pattern)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return matches, nil
+}
+
 // Search for packages using the given regular expression.
 func (e *Env) Search(l *ui.UI, pattern string) (manifest.Packages, error) {
 	resolver, err := e.resolver(l)

--- a/manifest/loader.go
+++ b/manifest/loader.go
@@ -109,6 +109,14 @@ func (l *Loader) Load(u *ui.UI, name string) (*AnnotatedManifest, error) {
 // Non-critical errors will be made available in each AnnotatedManifest and
 // also via Errors().
 func (l *Loader) All() ([]*AnnotatedManifest, error) {
+	return l.Glob("*")
+}
+
+// Glob loads all package manifests based on the given glob and returns them.
+//
+// Non-critical errors will be made available in each AnnotatedManifest and
+// also via Errors().
+func (l *Loader) Glob(glob string) ([]*AnnotatedManifest, error) {
 	l.lock.Lock()
 	defer l.lock.Unlock()
 	var (
@@ -140,8 +148,10 @@ func (l *Loader) All() ([]*AnnotatedManifest, error) {
 	// Throttle concurrency to avoid being too resource-greedy.
 	wg.SetLimit(max(3, runtime.NumCPU()/4))
 
+	pattern := glob + ".hcl"
+
 	for _, bundle := range l.sources.Bundles() {
-		files, err := fs.Glob(bundle, "*.hcl")
+		files, err := fs.Glob(bundle, pattern)
 		if err != nil {
 			return nil, errors.Wrapf(err, "%s", bundle)
 		}

--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -218,6 +218,23 @@ func (r *Resolver) Sync(l *ui.UI, force bool) error {
 	return nil
 }
 
+// SearchLite returns package references matching the given pattern.
+func (r *Resolver) SearchLite(l ui.Logger, pattern string) ([]string, error) {
+	manifests, err := r.loader.Glob(pattern + "*")
+	var matches []string
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	for _, manifest := range manifests {
+		if strings.HasPrefix(manifest.Name, pattern) {
+			matches = append(matches, manifest.Name)
+		}
+	}
+
+	return matches, nil
+}
+
 // Search for packages using the given regular expression.
 func (r *Resolver) Search(l ui.Logger, pattern string) (Packages, error) {
 	re, err := regexp.Compile("(?i)" + pattern + "")

--- a/predictors.go
+++ b/predictors.go
@@ -3,7 +3,6 @@ package hermit
 import (
 	"github.com/posener/complete"
 
-	"github.com/cashapp/hermit/manifest"
 	"github.com/cashapp/hermit/state"
 	"github.com/cashapp/hermit/ui"
 )
@@ -23,20 +22,14 @@ func NewPackagePredictor(s *state.State, e *Env, l *ui.UI) *PackagePredictor {
 func (p *PackagePredictor) Predict(args complete.Args) []string { // nolint: golint
 	p.l.SetLevel(ui.LevelFatal)
 
-	var pkgs []*manifest.Package
+	var res []string
 	// if there is an error, just quietly return an empty list
 	if p.env == nil {
-		ps, _ := p.state.Search(p.l, ".*")
-		pkgs = ps
+		res, _ = p.state.SearchLite(p.l, args.Last)
 	} else {
-		ps, _ := p.env.Search(p.l, ".*")
-		pkgs = ps
+		res, _ = p.env.SearchLite(p.l, args.Last)
 	}
 
-	res := make([]string, len(pkgs))
-	for i, pkg := range pkgs {
-		res[i] = pkg.Reference.Name
-	}
 	return res
 }
 

--- a/state/state.go
+++ b/state/state.go
@@ -158,6 +158,18 @@ func (s *State) Resolve(l *ui.UI, matcher manifest.Selector) (*manifest.Package,
 	return resolver.Resolve(l, matcher)
 }
 
+func (s *State) SearchLite(l *ui.UI, glob string) ([]string, error) {
+	resolver, err := s.resolver(l)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	matches, err := resolver.SearchLite(l, glob)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return matches, nil
+}
+
 // Search for packages without an active environment.
 func (s *State) Search(l *ui.UI, glob string) (manifest.Packages, error) {
 	resolver, err := s.resolver(l)


### PR DESCRIPTION
Instead of loading every possible package, we can just load the ones that match what the user is completing.

This cuts tab completion time for `hermit install` from 10+ seconds to 0-1 seconds.