### PR TITLE
Add conditional GIT_CREDENTIALS_TOKEN_NAME for Buildkite CI

### DIFF
--- a/files/hermit
+++ b/files/hermit
@@ -4,6 +4,10 @@
 
 set -eo pipefail
 
+# Set Github Token only in CI (Buildkite)
+if [ -n "${BUILDKITE}" ]; then
+  export GIT_CREDENTIALS_TOKEN_NAME=sq_hermit
+fi
 export HERMIT_USER_HOME=~
 
 if [ -z "${HERMIT_STATE_DIR}" ]; then


### PR DESCRIPTION
## Problem

When using Hermit in Buildkite CI with private package repositories (like `squareup/hermit-packages`), the build fails with:

```
error:org-49461806@github.com:squareup/hermit-packages.git: Cloning into '/root/.cache/hermit/sources/...'...
remote: Repository not found.
fatal: repository 'https://github.com/squareup/hermit-packages.git/' not found
```

This happens because:
1. Private repositories require authentication
2. Local development works with SSH keys
3. CI environments need GitHub tokens for HTTPS access

## Solution

This PR adds conditional logic to the `bin/hermit` script template to set `GIT_CREDENTIALS_TOKEN_NAME=sq_hermit` only when running in Buildkite CI.

### Changes
- Modified `files/hermit` template to include conditional check for `BUILDKITE` environment variable
- When `BUILDKITE` is set (automatically in Buildkite CI), exports `GIT_CREDENTIALS_TOKEN_NAME=sq_hermit`
- Local development remains unaffected (no token required, uses SSH)

### Benefits
- ✅ Local development works without token configuration
- ✅ CI works when `sq_hermit` environment variable contains valid GitHub token
- ✅ Clean separation between local and CI environments
- ✅ No breaking changes to existing workflows

### Testing
The logic has been verified:
- Local: `BUILDKITE` unset → no token configuration
- CI: `BUILDKITE=true` → `GIT_CREDENTIALS_TOKEN_NAME=sq_hermit` set

This allows CI environments to authenticate with private hermit package repositories while keeping local development simple.