### PR TITLE
fix: progress bar crash

### DIFF
--- a/cache/http.go
+++ b/cache/http.go
@@ -107,7 +107,7 @@ func downloadHTTP(b *ui.Task, response *http.Response, checksum string, uri stri
 		return "", "", "", errors.WithStack(err)
 	}
 	resumed := info.Size()
-	task.Size(int(max(response.ContentLength + resumed, 0)))
+	task.Size(int(max(response.ContentLength+resumed, 1)))
 	task.Add(int(resumed))
 	defer task.Done()
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -272,7 +272,7 @@ func (w *UI) writeProgress(width int) {
 	columns := int(float64(width-15) * float64(barsn) * percent)
 	nofm := fmt.Sprintf("%d/%d", complete, len(liveOperations))
 	percentstr := fmt.Sprintf("%.1f%%", percent*100)
-	spaces := max(width - columns/barsn - 15, 0)
+	spaces := max(width-columns/barsn-15, 0)
 	fmt.Fprintf(w.stdout, "%s%s%s %-7s%6s\n", strings.Repeat(theme.fill, max(columns/barsn, 0)), theme.bars[columns%barsn], strings.Repeat(theme.blank, spaces), nofm, percentstr)
 	// Write operations bar.
 	for _, op := range liveOperations {


### PR DESCRIPTION
Ensure strings.Repeat is not given a negative number when drawing the progress bar.

I also noticed that if the Content-Length header isn't set by the remote server in cache.downloadHttp, the task size will be set to -1, so I fixed that here.

Hopefully fixes #517