### PR TITLE
Don't export PS1 in shell activations

### DIFF
--- a/shell/files/activate.tmpl.sh
+++ b/shell/files/activate.tmpl.sh
@@ -58,7 +58,7 @@ export HERMIT_ENV_OPS="$(${HERMIT_ENV}/bin/hermit env --ops)"
 export HERMIT_BIN_CHANGE=$(date -r ${HERMIT_ENV}/bin +"%s")
 
 {{- if ne .Prompt "none" }}
-if test -n "${PS1+_}"; then export _HERMIT_OLD_PS1="${PS1}"; export PS1="{{if eq .Prompt "env"}}{{ .EnvName }}{{end}}🐚 ${PS1}"; fi
+if test -n "${PS1+_}"; then export _HERMIT_OLD_PS1="${PS1}"; PS1="{{if eq .Prompt "env"}}{{ .EnvName }}{{end}}🐚 ${PS1}"; fi
 {{- end}}
 
 update_hermit_env() {


### PR DESCRIPTION
This PR removes the `export` in front of `export PS1` in `active.templ.sh`.

`export` in shells is used exclusively to mark a variable as an environment variable, and thus something that processes spawned from the shell should be able to view. However, `PS1` is quite explicitly _shell-specific_, as the escape sequences used in `PS1` vary wildly (e.g. bash uses `\w` for the current working directory, where ZSH uses `%~`).

This makes it quite annoying to try to launch new shells when hermit is active. For example, launching bash form ZSH
```
🐚 [16:57:42 32 ✔0] ~/hermit % bash --norc
bash: 🐚 %B%F{blue}[%b%F{cyan}%* ${${HISTFILE+%f}:-%F{red\}}%U%!%u %(?.%F{green}✔.%F{red}✘%B)%?%b%(2L. %F{red}SHLVL=%L.)%(1j.%F{166} (%j job%(2j.s.)).)%f%(9V. (%9v).)%B%F{blue}]%b %F{11}%(5~.%-1~/…/%3~.%~) %F{43}%-$((COLUMNS * 2 / 3))(l.%2v.%3v)%F{8}%#%f : bad substitution
🐚 %B%F{blue}[%b%F{cyan}%* ${${HISTFILE+%f}:-%F{red\}}%U%!%u %(?.%F{green}✔.%F{red}✘%B)%?%b%(2L. %F{red}SHLVL=%L.)%(1j.%F{166} (%j job%(2j.s.)).)%f%(9V. (%9v).)%B%F{blue}]%b %F{11}%(5~.%-1~/…/%3~.%~) %F{43}%-$((COLUMNS * 2 / 3))(l.%2v.%3v)%F{8}%#
```

The solution to this is to _not_ export `PS1`.