### PR TITLE
fix: hermit test validates only specified version when fully qualified

### DIFF
--- a/app/test_cmd.go
+++ b/app/test_cmd.go
@@ -17,7 +17,7 @@ func (t *testCmd) Run(l *ui.UI, env *hermit.Env) error {
 		options := &hermit.ValidationOptions{
 			CheckSources: t.CheckSources,
 		}
-		warnings, err := env.ValidateManifest(l, selector.Name(), options)
+		warnings, err := env.ValidateSelector(l, &selector, options)
 		if err != nil {
 			return errors.WithStack(err)
 		}


### PR DESCRIPTION
When running 'hermit test ${pkg}-{version}', only validate that specific version instead of all versions in the manifest. This dramatically improves performance for packages with many versions (e.g., flyctl with 400+ versions).

- Add ValidateSelector method that filters references when selector is fully qualified
- Update test_cmd to use ValidateSelector instead of ValidateManifest

Before: `hermit test flyctl-0.4.0` validated all 400+ versions (~20s with --no-check-sources)
After: `hermit test flyctl-0.4.0` validates only version 0.4.0 (~0.5s)

Running 'hermit test flyctl' (no version) still validates all versions as before.