### PR TITLE
fix: Prevent duplicate source syncs per invocation

### DIFF
--- a/sources/builtin.go
+++ b/sources/builtin.go
@@ -16,8 +16,8 @@ func NewBuiltInSource(dir fs.FS) *BuiltInSource {
 	return &BuiltInSource{dir}
 }
 
-func (s *BuiltInSource) Sync(_ *ui.UI, _ bool) error { // nolint: golint
-	return nil
+func (s *BuiltInSource) Sync(_ *ui.UI, _ bool) (bool, error) { // nolint: golint
+	return true, nil
 }
 
 func (s *BuiltInSource) URI() string { // nolint: golint

--- a/sources/git.go
+++ b/sources/git.go
@@ -29,13 +29,13 @@ func NewGitSource(uri, sourceDir string, runner util.CommandRunner) *GitSource {
 	}, sourceDir, path, runner}
 }
 
-func (s *GitSource) Sync(p *ui.UI, force bool) error { // nolint: golint
+func (s *GitSource) Sync(p *ui.UI, force bool) (bool, error) { // nolint: golint
 	info, _ := os.Stat(s.path)
 	task := p.Task(s.fs.uri)
 	if info == nil || force || time.Since(info.ModTime()) >= SyncFrequency {
 		err := s.ensureSourcesDirExists()
 		if err != nil {
-			return errors.WithStack(err)
+			return false, errors.WithStack(err)
 		}
 
 		err = syncGit(task, s.sourceDir, s.fs.uri, s.path, s.runner)
@@ -44,14 +44,14 @@ func (s *GitSource) Sync(p *ui.UI, force bool) error { // nolint: golint
 		if err != nil {
 			if info != nil {
 				task.Warnf("git sync failed: %s", err)
-			} else {
-				return errors.Wrap(err, "git sync failed")
+				return false, nil
 			}
+			return false, errors.Wrap(err, "git sync failed")
 		}
-	} else {
-		task.Debugf("Update skipped, updated within the last %s", SyncFrequency)
+		return true, nil
 	}
-	return nil
+	task.Debugf("Update skipped, updated within the last %s", SyncFrequency)
+	return false, nil
 }
 
 func (s *GitSource) URI() string { // nolint: golint

--- a/sources/git_test.go
+++ b/sources/git_test.go
@@ -25,7 +25,7 @@ func TestGitDoesNotRemoveSourceAfterSyncFailure(t *testing.T) {
 
 	// Create the initial directory for sources by successfully syncing
 	u, _ := ui.NewForTesting()
-	err := source.Sync(u, true)
+	_, err := source.Sync(u, true)
 	assert.NoError(t, err)
 	files, err := os.ReadDir(sourceDir)
 	assert.NoError(t, err)
@@ -34,7 +34,7 @@ func TestGitDoesNotRemoveSourceAfterSyncFailure(t *testing.T) {
 
 	// Fail the sync
 	git.err = errors.New("failing git fails")
-	err = source.Sync(u, true)
+	_, err = source.Sync(u, true)
 
 	// no error as it was not an initial clone
 	assert.NoError(t, err)

--- a/sources/local.go
+++ b/sources/local.go
@@ -19,8 +19,8 @@ func NewLocalSource(uri string, f fs.FS) *LocalSource {
 	}}
 }
 
-func (s *LocalSource) Sync(_ *ui.UI, _ bool) error { // nolint: golint
-	return nil
+func (s *LocalSource) Sync(_ *ui.UI, _ bool) (bool, error) { // nolint: golint
+	return true, nil
 }
 
 func (s *LocalSource) URI() string { // nolint: golint

--- a/sources/memory.go
+++ b/sources/memory.go
@@ -18,8 +18,8 @@ func NewMemSource(name, content string) *MemSource {
 	return &MemSource{name, content}
 }
 
-func (s *MemSource) Sync(_ *ui.UI, _ bool) error { // nolint: golint
-	return nil
+func (s *MemSource) Sync(_ *ui.UI, _ bool) (bool, error) { // nolint: golint
+	return true, nil
 }
 
 func (s *MemSource) URI() string { // nolint: golint

--- a/sources/sources.go
+++ b/sources/sources.go
@@ -19,8 +19,9 @@ const SyncFrequency = time.Hour * 24
 
 // Source is a single source for manifest files
 type Source interface {
-	// Sync synchronises these sources from the possibly remote origin
-	Sync(p *ui.UI, force bool) error
+	// Sync synchronises these sources from the possibly remote origin.
+	// Returns true if the source was actually updated.
+	Sync(p *ui.UI, force bool) (bool, error)
 	// URI returns a URI for the source
 	URI() string
 	// Bundle returns a fs.FS for the manifests from this source
@@ -65,17 +66,21 @@ func (s *Sources) Add(source Source) {
 
 // Sync synchronises manifests from remote repos.
 // Will be synced at most every SyncFrequency unless "force" is true.
-// A Sources set can only be synchronised once. Following calls will not have any effect.
+// Sources will only be synchronised once per invocation. Following calls will not have any effect.
 func (s *Sources) Sync(p *ui.UI, force bool) error {
-	if s.isSynchronised && !force {
+	if s.isSynchronised {
 		return nil
 	}
-	s.isSynchronised = true
+	synced := false
 	for _, source := range s.sources {
-		err := source.Sync(p, force)
+		did, err := source.Sync(p, force)
 		if err != nil {
 			return errors.WithStack(err)
 		}
+		synced = synced || did
+	}
+	if synced {
+		s.isSynchronised = true
 	}
 	return nil
 }


### PR DESCRIPTION
Source.Sync now returns whether it actually synced. Sources.Sync only
marks itself as synchronised once a real sync has occurred, preventing
redundant git pulls while still allowing a force sync if the initial
non-force sync was skipped due to SyncFrequency.

```
🐚 ~/foo $ hermit install --trace termtosvg
trace: No user config found at: ~/.hermit.hcl
debug:https://github.com/cashapp/hermit-packages.git: Update skipped, updated within the last 24h0m0s
debug:https://github.com/cashapp/hermit-packages.git:exec: git pull
debug: Already up to date.
debug:https://github.com/cashapp/hermit-packages.git:exec: git pull
debug: Already up to date.
debug:https://github.com/cashapp/hermit-packages.git:exec: git pull
debug: Already up to date.
```

Co-authored-by: Claude Code <noreply@anthropic.com>
