### PR TITLE
feat: support HERMIT_PREPEND_PATH to prepend entries to PATH

### DIFF
--- a/docs/docs/usage/envars.md
+++ b/docs/docs/usage/envars.md
@@ -17,6 +17,7 @@ present in an active environment are:
 |-----------|------|
 | `HERMIT_ENV` | Path to the active Hermit environment. |
 | `HERMIT_BIN` | Path to the active Hermit environment `bin` directory. |
+| `HERMIT_PREPEND_PATH` | If set, prepends its value to the front of `PATH` after all other environment operations are applied. Useful for ensuring specific directories always take precedence over Hermit-managed packages. |
 
 An empty environment might look something like the following:
 

--- a/env.go
+++ b/env.go
@@ -1429,6 +1429,9 @@ func (e *Env) allEnvarOpsForPackages(runtimeDeps []*manifest.Package, targetPkg 
 	}
 	ops = append(ops, e.localEnvarOps()...)
 	ops = append(ops, e.ephemeralEnvars...)
+	if prependPath := os.Getenv("HERMIT_PREPEND_PATH"); prependPath != "" {
+		ops = append(ops, &envars.Prepend{Name: "PATH", Value: prependPath})
+	}
 	return ops
 }
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -674,6 +674,15 @@ EOF
 			`,
 		},
 		{
+			name:         "HermitPrependPathIsRespected",
+			preparations: prep{fixture("testenv1")},
+			script: `
+				export HERMIT_PREPEND_PATH="/prepend/first:/prepend/second"
+				. bin/activate-hermit
+				assert echo "$PATH" | grep -q "^/prepend/first:/prepend/second:"
+			`,
+		},
+		{
 			name:         "InstallOnActivateEnsuresPackagesAreUnpacked",
 			preparations: prep{fixture("testenv-install-on-activate"), activate(".")},
 			script: `


### PR DESCRIPTION
When `HERMIT_PREPEND_PATH` is set, its value is always prepended to the front of `PATH` after all other environment operations are applied. This allows users to ensure specific directories take precedence over Hermit-managed packages.

## Changes
- In `allEnvarOpsForPackages`, after all other env ops are assembled, check `HERMIT_PREPEND_PATH` and append a final `Prepend` op so it ends up at the very front of PATH.