### PR TITLE
fix: use filepath.EvalSymlinks to detect symlink chain escapes in archive extraction

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -668,7 +668,9 @@ func sanitizeExtractPath(filePath string, destination string) error {
 // linkTarget is the symlink target (can be relative or absolute).
 // destination is the root extraction directory that must contain the resolved symlink target.
 func sanitizeSymlinkTarget(destFile, linkTarget, destination string) error {
-	// Resolve the symlink target relative to the directory containing the symlink
+	cleanDest := filepath.Clean(destination)
+
+	// Compute the nominal target path lexically.
 	var resolvedTarget string
 	if filepath.IsAbs(linkTarget) {
 		resolvedTarget = linkTarget
@@ -677,10 +679,26 @@ func sanitizeSymlinkTarget(destFile, linkTarget, destination string) error {
 	}
 	resolvedTarget = filepath.Clean(resolvedTarget)
 
-	// Ensure the resolved target is within the destination directory
-	cleanDest := filepath.Clean(destination)
+	// Lexical check: catch obvious direct escapes early.
 	if !strings.HasPrefix(resolvedTarget, cleanDest+string(filepath.Separator)) && resolvedTarget != cleanDest {
 		return errors.Errorf("%s: illegal symlink target %q (resolves to %s which is outside %s)", destFile, linkTarget, resolvedTarget, destination)
 	}
+
+	// Chain escape check: resolve any previously-extracted symlinks in the parent
+	// directory of destFile using filepath.EvalSymlinks. filepath.Clean is purely
+	// lexical and cannot detect a chain where each individual hop looks safe (e.g.
+	// A->B, B->../../) but the resolved on-disk path escapes the extraction root.
+	if resolvedParent, err := filepath.EvalSymlinks(filepath.Dir(destFile)); err == nil {
+		var realTarget string
+		if filepath.IsAbs(linkTarget) {
+			realTarget = filepath.Clean(linkTarget)
+		} else {
+			realTarget = filepath.Clean(filepath.Join(resolvedParent, linkTarget))
+		}
+		if !strings.HasPrefix(realTarget, cleanDest+string(filepath.Separator)) && realTarget != cleanDest {
+			return errors.Errorf("%s: illegal symlink target %q escapes destination via symlink chain (real path %s is outside %s)", destFile, linkTarget, realTarget, destination)
+		}
+	}
+
 	return nil
 }

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -355,3 +355,60 @@ func TestZipEscapingSymlink(t *testing.T) {
 	assert.True(t, strings.Contains(err.Error(), "illegal symlink target"),
 		"expected error about illegal symlink target, got: %v", err)
 }
+
+// TestSymlinkChainEscape tests that a chain of symlinks where each individual hop
+// appears safe lexically cannot be used to escape the extraction root.
+// This is a bypass of the filepath.Clean-based check in PR #540: a chain like
+// A->B (within dest) followed by B->../../ (within dest relative to B's lexical path)
+// looks safe per filepath.Clean but escapes when on-disk symlinks are followed.
+func TestSymlinkChainEscape(t *testing.T) {
+	tmpDir := t.TempDir()
+	dest := filepath.Join(tmpDir, "extracted")
+	err := os.MkdirAll(dest, 0750)
+	assert.NoError(t, err)
+
+	// Build a tarball with a two-hop symlink chain:
+	//   hop1 -> hop2          (lexically within dest — passes individual check)
+	//   hop2 -> ../../escape  (lexically: dest/hop2/../../escape = tmpDir/escape — outside dest)
+	// The chain bypass: hop1/hop2 together resolve outside dest even though hop1 alone looks safe.
+	tarPath := filepath.Join(tmpDir, "chain_escape.tar.gz")
+	f, err := os.Create(tarPath)
+	assert.NoError(t, err)
+
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+
+	// First hop: hop1 -> hop2 (within dest, passes lexical check)
+	err = tw.WriteHeader(&tar.Header{
+		Name:     "hop1",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "hop2",
+	})
+	assert.NoError(t, err)
+
+	// Second hop: hop2 -> ../../escape (escapes dest via two levels)
+	err = tw.WriteHeader(&tar.Header{
+		Name:     "hop2",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "../../escape",
+	})
+	assert.NoError(t, err)
+
+	assert.NoError(t, tw.Close())
+	assert.NoError(t, gw.Close())
+	assert.NoError(t, f.Close())
+
+	p, _ := ui.NewForTesting()
+	_, err = Extract(
+		p.Task("extract"),
+		tarPath,
+		&manifest.Package{Dest: dest, Source: "chain_escape.tar.gz"},
+	)
+	assert.Error(t, err, "expected extraction to fail due to symlink chain escape")
+	assert.True(t, strings.Contains(err.Error(), "illegal symlink target"),
+		"expected error about illegal symlink target, got: %v", err)
+
+	// Verify no files were written outside dest
+	_, statErr := os.Stat(filepath.Join(tmpDir, "escape"))
+	assert.True(t, os.IsNotExist(statErr), "escape file should not exist outside dest")
+}

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -364,8 +364,6 @@ func TestZipEscapingSymlink(t *testing.T) {
 func TestSymlinkChainEscape(t *testing.T) {
 	tmpDir := t.TempDir()
 	dest := filepath.Join(tmpDir, "extracted")
-	err := os.MkdirAll(dest, 0750)
-	assert.NoError(t, err)
 
 	// Build a tarball with a two-hop symlink chain:
 	//   hop1 -> hop2          (lexically within dest — passes individual check)


### PR DESCRIPTION
## Summary

PR #540 introduced `sanitizeSymlinkTarget()` to prevent symlinks from escaping the extraction root during archive extraction. That check uses `filepath.Clean`, which is **purely lexical** — it normalizes path strings but does not follow symlinks on disk.

This leaves a chain escape bypass: a tarball can contain multiple symlinks where each individual hop looks safe under `filepath.Clean`, but the full on-disk resolution escapes the extraction root.

**Example chain:**
```
hop1 -> hop2         # filepath.Clean(dest/hop2) = dest/hop2 ✓ passes
hop2 -> ../../escape # filepath.Clean(dest/../../escape) = ../escape ✓ passes
```
When `hop1` is on disk and the OS follows both hops, a subsequent write through `hop1` escapes `dest`.

## Fix

After the existing lexical check, resolve the **parent directory of `destFile`** using `filepath.EvalSymlinks` (which follows actual on-disk symlinks) and re-validate the target against the extraction root. If `EvalSymlinks` fails (parent doesn't exist yet during extraction), the lexical check alone applies — no regression for valid archives.

## Testing

Adds `TestSymlinkChainEscape` to `archive_test.go`: builds a two-hop tarball in-memory and asserts that extraction fails with an `illegal symlink target` error and that no file is written outside the destination directory.

Existing `TestLinkTraversal` and `TestLinkTraversalWithStrip` tests continue to pass unchanged.

---
*Reported via Block's vulnerability management program (VULN-78098). Bypass of #540.*