### PR TITLE
fix: reject invalid env-var names from manifests

### DIFF
--- a/env.go
+++ b/env.go
@@ -287,6 +287,9 @@ func readConfig(configFile string) (*Config, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, configFile)
 		}
+		if err := config.Envars.Validate(); err != nil {
+			return nil, errors.Wrap(err, configFile)
+		}
 	}
 	return config, nil
 }
@@ -340,6 +343,9 @@ func OpenEnv(
 	scriptSums []string,
 	sourceRewriters ...sources.URLRewriter,
 ) (*Env, error) {
+	if err := ephemeral.Validate(); err != nil {
+		return nil, errors.WithStack(err)
+	}
 	useGit := info.Config.ManageGit && isEnvAGitRepo(info.Root)
 	if len(scriptSums) == 0 {
 		scriptSums = ScriptSHAs
@@ -1189,6 +1195,9 @@ func (e *Env) EnvOps(l *ui.UI) (envars.Ops, error) {
 
 // SetEnv sets an extra environment variable.
 func (e *Env) SetEnv(key, value string) error {
+	if err := envars.ValidateKey(key); err != nil {
+		return errors.WithStack(err)
+	}
 	e.config.Envars[key] = value
 	data, err := hcl.Marshal(e.config)
 	if err != nil {

--- a/envars/util.go
+++ b/envars/util.go
@@ -4,11 +4,40 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
+	"github.com/cashapp/hermit/errors"
 	"github.com/cashapp/hermit/platform"
 )
+
+// validEnvKey matches names that are safe to interpolate directly into POSIX
+// shell and fish scripts. The pattern is the standard POSIX identifier syntax
+// used for environment variable names: an initial letter or underscore
+// followed by any number of letters, digits, or underscores.
+var validEnvKey = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// ValidateKey returns an error if key is not a valid POSIX environment
+// variable name. Hermit emits keys verbatim into shell scripts, so anything
+// outside this pattern is rejected to prevent shell command injection.
+func ValidateKey(key string) error {
+	if !validEnvKey.MatchString(key) {
+		return errors.Errorf("invalid environment variable name %q (must match %s)", key, validEnvKey)
+	}
+	return nil
+}
+
+// Validate returns an error if any key in e is not a valid POSIX environment
+// variable name. See [ValidateKey].
+func (e Envars) Validate() error {
+	for key := range e {
+		if err := ValidateKey(key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 // Parse a KEY=VALUE list of environment variables into an [Envars] map.
 func Parse(envars []string) Envars {

--- a/envars/util_test.go
+++ b/envars/util_test.go
@@ -97,6 +97,42 @@ func TestExpandNoEscape(t *testing.T) {
 	}))
 }
 
+func TestValidateKey(t *testing.T) {
+	cases := []struct {
+		name    string
+		key     string
+		wantErr bool
+	}{
+		{name: "Simple", key: "FOO", wantErr: false},
+		{name: "Underscore", key: "_HERMIT", wantErr: false},
+		{name: "Mixed", key: "PATH_2", wantErr: false},
+		{name: "Lowercase", key: "abc", wantErr: false},
+		{name: "Empty", key: "", wantErr: true},
+		{name: "LeadingDigit", key: "1FOO", wantErr: true},
+		{name: "Hyphen", key: "FOO-BAR", wantErr: true},
+		{name: "Space", key: "FOO BAR", wantErr: true},
+		{name: "Semicolon", key: "EVIL; touch /tmp/x; X", wantErr: true},
+		{name: "Backtick", key: "FOO`id`", wantErr: true},
+		{name: "Dollar", key: "FOO$BAR", wantErr: true},
+		{name: "Newline", key: "FOO\nBAR", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateKey(tc.key)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestEnvarsValidate(t *testing.T) {
+	assert.NoError(t, Envars{"FOO": "1", "BAR_2": "2"}.Validate())
+	assert.Error(t, Envars{"FOO": "1", "EVIL; touch /tmp/x; X": "v"}.Validate())
+}
+
 func TestExpandDateTime(t *testing.T) {
 	mapping := Mapping("foo", "foo", platform.Platform{})
 

--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -587,6 +587,9 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 	}
 
 	for _, env := range layerEnvars {
+		if err := env.Validate(); err != nil {
+			return nil, errors.Wrapf(err, "%s: %s", manifest.Path, found)
+		}
 		for k, v := range env {
 			// Expand manifest variables but keep other variable references.
 			// Envars are expanded again while applying envar Ops, so we need to

--- a/manifest/resolver_test.go
+++ b/manifest/resolver_test.go
@@ -318,6 +318,23 @@ func TestResolver_Resolve(t *testing.T) {
 			WithSource("www.example.com/foo/bar").
 			Result(),
 	}, {
+		// Regression test for VULN-78160: shell command injection via env-var key.
+		name: "Rejects env keys that are not valid POSIX identifiers",
+		files: map[string]string{
+			`evil.hcl`: `
+			description = ""
+			binaries = ["bin/evil"]
+			version "1.0.0" {
+				source = "www.example.com"
+				env = {
+					"EVIL; touch /tmp/x; X": "innocent",
+				}
+			}
+			`,
+		},
+		reference: "evil-1.0.0",
+		wantErr:   `memory:///evil.hcl: evil-1.0.0: invalid environment variable name "EVIL; touch /tmp/x; X" (must match ^[A-Za-z_][A-Za-z0-9_]*$)`,
+	}, {
 		name: "Returns an error when expanding version if channel has no version range",
 		files: map[string]string{
 			`test.hcl`: `

--- a/shell/activate_template_test.go
+++ b/shell/activate_template_test.go
@@ -37,6 +37,29 @@ func TestPosixActivationScriptQuotesPathsWithSpaces(t *testing.T) {
 	}
 }
 
+func TestActivateHermitRejectsMaliciousEnvKey(t *testing.T) {
+	// Regression test for VULN-78160: shell command injection via env-var key.
+	maliciousEnv := envars.Envars{
+		"EVIL; touch /tmp/pwned; X": "innocent",
+	}
+	cases := []Shell{&Bash{}, &Zsh{}, &Fish{}}
+	for _, sh := range cases {
+		t.Run(sh.Name(), func(t *testing.T) {
+			var out bytes.Buffer
+			err := ActivateHermit(&out, sh, ActivationConfig{
+				Root:   "/tmp/env",
+				Prompt: "none",
+				Env:    maliciousEnv,
+			})
+			assert.Error(t, err)
+
+			out.Reset()
+			err = sh.ApplyEnvars(&out, maliciousEnv)
+			assert.Error(t, err)
+		})
+	}
+}
+
 func TestFishActivationScriptQuotesPathsWithSpaces(t *testing.T) {
 	root := "/tmp/Application Support/hermit env"
 

--- a/shell/fish.go
+++ b/shell/fish.go
@@ -48,6 +48,9 @@ func (sh *Fish) ActivationHooksCode() (script string, err error) { // nolint: go
 }
 
 func (sh *Fish) ApplyEnvars(w io.Writer, env envars.Envars) error {
+	if err := env.Validate(); err != nil {
+		return errors.WithStack(err)
+	}
 	for key, value := range env {
 		if value == "" {
 			fmt.Fprintf(w, "set -e %s\n", key)

--- a/shell/posix.go
+++ b/shell/posix.go
@@ -34,6 +34,9 @@ func (a posixActivationContext) Zsh() bool  { return a.Shell == "zsh" }
 type posixMixin struct{}
 
 func (sh *posixMixin) ApplyEnvars(w io.Writer, env envars.Envars) error {
+	if err := env.Validate(); err != nil {
+		return errors.WithStack(err)
+	}
 	for key, value := range env {
 		if value == "" {
 			fmt.Fprintf(w, "unset %s\n", key)

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -165,6 +165,9 @@ func (c Changes) Merge(o *Changes) *Changes {
 
 // ActivateHermit prints out the hermit activation script for the given shell.
 func ActivateHermit(w io.Writer, shell Shell, config ActivationConfig) error {
+	if err := config.Env.Validate(); err != nil {
+		return errors.WithStack(err)
+	}
 	if err := shell.ActivationScript(w, config); err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
Manifest env = { ... } keys were interpolated unquoted into the
activation scripts and ApplyEnvars output, allowing a malicious
package to inject shell commands that run on activation and re-fire
on every prompt redraw via update_hermit_env.

Validate keys against the POSIX identifier syntax
^[A-Za-z_][A-Za-z0-9_]*$ at every trust boundary (manifest resolve,
hermit.hcl load, --env CLI flag) and again at emit time in ApplyEnvars
and ActivateHermit as defence in depth.

Co-authored-by: Claude Code <noreply@anthropic.com>
