### PR TITLE
fix: confine archive extraction within the destination directory

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -411,7 +411,7 @@ func extractZip(b *ui.Task, f *os.File, info os.FileInfo, dest string, strip int
 			return errors.Wrap(err, destFile)
 		}
 	}
-	return nil
+	return validateSymlinks(root)
 }
 
 func extractZipFile(root *os.Root, zf *zip.File, destFile string, dest string) error {
@@ -530,7 +530,7 @@ func extractPackageTarball(b *ui.Task, r io.Reader, dest string, strip int) erro
 			_ = root.Chtimes(rel, hdr.AccessTime, hdr.ModTime) // Best effort.
 		}
 	}
-	return nil
+	return validateSymlinks(root)
 }
 
 func extractDebianPackage(b *ui.Task, r io.Reader, dest string, pkg *manifest.Package) error {
@@ -728,4 +728,29 @@ func createSymlink(root *os.Root, destFile, rel, linkTarget, dest string) error 
 		return errors.Errorf("%s: illegal symlink target %q (resolves outside %s)", destFile, linkTarget, dest)
 	}
 	return nil
+}
+
+// validateSymlinks re-checks every symlink in the extracted tree against the final
+// on-disk state. The per-link check in createSymlink treats a link with a missing
+// target component as a harmless dangling link, but a later archive entry can create
+// that component (e.g. as a symlink to ".") and turn the earlier link into one that
+// resolves outside the root. This pass runs once extraction is complete, so it sees
+// the final resolution of each link and rejects any that escapes the root.
+func validateSymlinks(root *os.Root) error {
+	return fs.WalkDir(root.FS(), ".", func(name string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Type()&fs.ModeSymlink == 0 {
+			return nil
+		}
+		// Stat follows the link with root-aware semantics: a target that escapes the
+		// root yields an error other than NotExist (a link that is still legitimately
+		// dangling within the root yields NotExist and is allowed).
+		if _, err := root.Stat(name); err != nil && !errors.Is(err, os.ErrNotExist) {
+			target, _ := root.Readlink(name)
+			return errors.Errorf("%s: illegal symlink target %q (resolves outside extraction root)", name, target)
+		}
+		return nil
+	})
 }

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	bufra "github.com/avvmoto/buf-readerat"
 	"github.com/blakesmith/ar"
@@ -723,7 +724,7 @@ func createSymlink(root *os.Root, destFile, rel, linkTarget, dest string) error 
 	if err := root.Symlink(linkTarget, rel); err != nil {
 		return errors.Wrapf(err, "%s: failed to create symlink to %s", destFile, linkTarget)
 	}
-	if _, err := root.Stat(rel); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if symlinkEscapesRoot(root, rel) {
 		_ = root.Remove(rel)
 		return errors.Errorf("%s: illegal symlink target %q (resolves outside %s)", destFile, linkTarget, dest)
 	}
@@ -744,13 +745,30 @@ func validateSymlinks(root *os.Root) error {
 		if d.Type()&fs.ModeSymlink == 0 {
 			return nil
 		}
-		// Stat follows the link with root-aware semantics: a target that escapes the
-		// root yields an error other than NotExist (a link that is still legitimately
-		// dangling within the root yields NotExist and is allowed).
-		if _, err := root.Stat(name); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if symlinkEscapesRoot(root, name) {
 			target, _ := root.Readlink(name)
 			return errors.Errorf("%s: illegal symlink target %q (resolves outside extraction root)", name, target)
 		}
 		return nil
 	})
+}
+
+// symlinkEscapesRoot reports whether the symlink at name (relative to root) resolves
+// to a location outside the root. os.Root.Stat refuses to traverse outside the root,
+// so a target that escapes yields a "path escapes from parent" error. Links that are
+// broken but contained — dangling targets, symlink loops, or a non-directory path
+// component — do not escape and are not flagged, preserving behaviour for the
+// (unusual but harmless) packages that contain them.
+func symlinkEscapesRoot(root *os.Root, name string) bool {
+	_, err := root.Stat(name)
+	switch {
+	case err == nil: // resolves to a real path within the root
+		return false
+	case errors.Is(err, os.ErrNotExist), // dangling within the root
+		errors.Is(err, syscall.ELOOP),   // symlink loop, contained
+		errors.Is(err, syscall.ENOTDIR): // non-directory component, contained
+		return false
+	default:
+		return true
+	}
 }

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -14,7 +14,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	bufra "github.com/avvmoto/buf-readerat"
 	"github.com/blakesmith/ar"
@@ -90,8 +89,14 @@ func Extract(b *ui.Task, source string, pkg *manifest.Package) (finalise func() 
 				if err != nil {
 					return err
 				}
+				// Never chmod through symlinks: os.Chmod follows them, which would
+				// let an extracted symlink alter the permissions of a file outside
+				// the destination.
+				if info.Mode()&os.ModeSymlink != 0 {
+					return nil
+				}
 				task.Tracef("chmod a-w %q", path)
-				err = os.Chmod(path, info.Mode()&^0222) //nolint:gosec // TODO: we separately validate symlink targets, though we should migrate to os.Root()
+				err = os.Chmod(path, info.Mode()&^0222) //nolint:gosec
 				if errors.Is(err, os.ErrNotExist) {
 					task.Debugf("file did not exist during finalisation %q", path)
 					return nil
@@ -384,6 +389,13 @@ func extractZip(b *ui.Task, f *os.File, info os.FileInfo, dest string, strip int
 	}
 	task := b.SubProgress("unpack", len(zr.File))
 	defer task.Done()
+	// Confine all filesystem operations to dest via os.Root so that symlinks in
+	// the archive cannot redirect writes outside the destination.
+	root, err := os.OpenRoot(dest)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer root.Close()
 	for _, zf := range zr.File {
 		b.Tracef("  %s", zf.Name)
 		task.Add(1)
@@ -394,7 +406,7 @@ func extractZip(b *ui.Task, f *os.File, info os.FileInfo, dest string, strip int
 		if destFile == "" {
 			continue
 		}
-		err = extractZipFile(zf, destFile, dest)
+		err = extractZipFile(root, zf, destFile, dest)
 		if err != nil {
 			return errors.Wrap(err, destFile)
 		}
@@ -402,14 +414,18 @@ func extractZip(b *ui.Task, f *os.File, info os.FileInfo, dest string, strip int
 	return nil
 }
 
-func extractZipFile(zf *zip.File, destFile string, dest string) error {
+func extractZipFile(root *os.Root, zf *zip.File, destFile string, dest string) error {
+	rel, err := filepath.Rel(dest, destFile)
+	if err != nil {
+		return errors.WithStack(err)
+	}
 	zfr, err := zf.Open()
 	if err != nil {
 		return errors.WithStack(err)
 	}
 	defer zfr.Close()
 	if zf.Mode().IsDir() {
-		return errors.WithStack(os.MkdirAll(destFile, 0700))
+		return errors.WithStack(root.MkdirAll(rel, 0700))
 	}
 	// Handle symlinks.
 	if zf.Mode()&os.ModeSymlink != 0 {
@@ -417,19 +433,15 @@ func extractZipFile(zf *zip.File, destFile string, dest string) error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		symlinkTarget := string(symlink)
-		if err := sanitizeSymlinkTarget(destFile, symlinkTarget, dest); err != nil {
-			return err
-		}
-		return errors.WithStack(os.Symlink(symlinkTarget, destFile))
+		return createSymlink(root, destFile, rel, string(symlink), dest)
 	}
 
-	err = os.MkdirAll(filepath.Dir(destFile), 0700)
+	err = root.MkdirAll(filepath.Dir(rel), 0700)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	w, err := os.OpenFile(destFile, os.O_CREATE|os.O_WRONLY, zf.Mode()&^0077)
+	w, err := root.OpenFile(rel, os.O_CREATE|os.O_WRONLY, zf.Mode()&^0077)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -441,12 +453,19 @@ func extractZipFile(zf *zip.File, destFile string, dest string) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	_ = os.Chtimes(destFile, zf.Modified, zf.Modified) // Best effort.
+	_ = root.Chtimes(rel, zf.Modified, zf.Modified) // Best effort.
 	return nil
 }
 
 func extractPackageTarball(b *ui.Task, r io.Reader, dest string, strip int) error {
 	tr := tar.NewReader(r)
+	// Confine all filesystem operations to dest via os.Root so that symlinks in
+	// the archive cannot redirect writes outside the destination.
+	root, err := os.OpenRoot(dest)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer root.Close()
 	for {
 		hdr, err := tr.Next()
 		if errors.Is(err, io.EOF) {
@@ -462,48 +481,44 @@ func extractPackageTarball(b *ui.Task, r io.Reader, dest string, strip int) erro
 		if destFile == "" {
 			continue
 		}
+		rel, err := filepath.Rel(dest, destFile)
+		if err != nil {
+			return errors.WithStack(err)
+		}
 		b.Tracef("  %s -> %s", hdr.Name, destFile)
-		err = os.MkdirAll(filepath.Dir(destFile), 0700)
+		err = root.MkdirAll(filepath.Dir(rel), 0700)
 		if err != nil {
 			return errors.WithStack(err)
 		}
 		switch {
 		case mode.IsDir():
-			err = os.MkdirAll(destFile, 0700)
+			err = root.MkdirAll(rel, 0700)
 			if err != nil {
 				return errors.Wrapf(err, "%s: failed to create directory", destFile)
 			}
 
 		case mode&os.ModeSymlink != 0:
-			if err := sanitizeSymlinkTarget(destFile, hdr.Linkname, dest); err != nil {
+			if err := createSymlink(root, destFile, rel, hdr.Linkname, dest); err != nil {
 				return err
-			}
-			err = syscall.Symlink(hdr.Linkname, destFile)
-			if err != nil {
-				return errors.Wrapf(err, "%s: failed to create symlink to %s", destFile, hdr.Linkname)
 			}
 
 		case hdr.Typeflag&(tar.TypeLink|tar.TypeGNULongLink) != 0 && hdr.Linkname != "":
 			// Convert hard links into symlinks so we don't have to track inodes later on during relocation.
 			src := filepath.Join(dest, hdr.Linkname) //nolint: gosec
-			if err := sanitizeSymlinkTarget(destFile, src, dest); err != nil {
-				return err
-			}
 			rp, err := filepath.Rel(filepath.Dir(destFile), src)
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			err = os.Symlink(rp, destFile)
-			if err != nil {
-				return errors.WithStack(err)
+			if err := createSymlink(root, destFile, rel, rp, dest); err != nil {
+				return err
 			}
 
 		default:
-			err := os.MkdirAll(filepath.Dir(destFile), 0700)
+			err = root.MkdirAll(filepath.Dir(rel), 0700)
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			w, err := os.OpenFile(destFile, os.O_CREATE|os.O_WRONLY, mode)
+			w, err := root.OpenFile(rel, os.O_CREATE|os.O_WRONLY, mode)
 			if err != nil {
 				return errors.WithStack(err)
 			}
@@ -512,7 +527,7 @@ func extractPackageTarball(b *ui.Task, r io.Reader, dest string, strip int) erro
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			_ = os.Chtimes(destFile, hdr.AccessTime, hdr.ModTime) // Best effort.
+			_ = root.Chtimes(rel, hdr.AccessTime, hdr.ModTime) // Best effort.
 		}
 	}
 	return nil
@@ -527,7 +542,10 @@ func extractDebianPackage(b *ui.Task, r io.Reader, dest string, pkg *manifest.Pa
 		}
 		if strings.HasPrefix(header.Name, "data.tar") {
 			limitReader := io.LimitReader(reader, header.Size)
-			filename := filepath.Join(dest, header.Name)
+			// Use a fixed name rather than the archive-controlled header.Name when
+			// writing the nested payload. The nested archive type is detected from
+			// content, so the extension is irrelevant.
+			filename := filepath.Join(dest, "data.tar")
 			w, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 			if err != nil {
 				return errors.WithStack(err)
@@ -681,6 +699,33 @@ func sanitizeSymlinkTarget(destFile, linkTarget, destination string) error {
 	cleanDest := filepath.Clean(destination)
 	if !strings.HasPrefix(resolvedTarget, cleanDest+string(filepath.Separator)) && resolvedTarget != cleanDest {
 		return errors.Errorf("%s: illegal symlink target %q (resolves to %s which is outside %s)", destFile, linkTarget, resolvedTarget, destination)
+	}
+	return nil
+}
+
+// createSymlink creates a symlink at rel (relative to root, which is rooted at dest)
+// pointing at linkTarget, refusing any link whose target escapes dest.
+//
+// sanitizeSymlinkTarget is a fast lexical reject for the obvious cases, but lexical
+// checks alone are not sufficient, so os.Root is the real containment boundary:
+// os.Root.Symlink keeps the link inside the root, and os.Root.Stat resolves it with
+// root-aware semantics so a target that escapes the root yields an error other than
+// NotExist (a legitimate dangling link within the root yields NotExist and is allowed).
+func createSymlink(root *os.Root, destFile, rel, linkTarget, dest string) error {
+	if err := sanitizeSymlinkTarget(destFile, linkTarget, dest); err != nil {
+		return err
+	}
+	if dir := filepath.Dir(rel); dir != "." {
+		if err := root.MkdirAll(dir, 0700); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	if err := root.Symlink(linkTarget, rel); err != nil {
+		return errors.Wrapf(err, "%s: failed to create symlink to %s", destFile, linkTarget)
+	}
+	if _, err := root.Stat(rel); err != nil && !errors.Is(err, os.ErrNotExist) {
+		_ = root.Remove(rel)
+		return errors.Errorf("%s: illegal symlink target %q (resolves outside %s)", destFile, linkTarget, dest)
 	}
 	return nil
 }

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -355,3 +355,94 @@ func TestZipEscapingSymlink(t *testing.T) {
 	assert.True(t, strings.Contains(err.Error(), "illegal symlink target"),
 		"expected error about illegal symlink target, got: %v", err)
 }
+
+// TestSymlinkChainEscape ensures that extraction cannot be tricked into writing
+// outside the destination via nested symlinks in the archive, and that any such
+// archive is rejected without modifying files outside the destination.
+func TestSymlinkChainEscape(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Extraction unpacks into a temp dir alongside dest, so "../canary.txt" from there
+	// lands in dest's parent.
+	dest := filepath.Join(tmpDir, "extracted")
+	canary := filepath.Join(tmpDir, "canary.txt")
+	assert.NoError(t, os.WriteFile(canary, []byte("ORIGINAL"), 0600))
+
+	tarball := filepath.Join(tmpDir, "chain.tar.gz")
+	f, err := os.Create(tarball)
+	assert.NoError(t, err)
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+
+	symlink := func(name, target string) {
+		assert.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: name, Typeflag: tar.TypeSymlink, Linkname: target, Mode: 0777,
+		}))
+	}
+	symlink("a", ".")
+	symlink("a/b", ".")
+	symlink("a/b/c", ".")
+	symlink("a/b/c/pwn", "../canary.txt")
+	assert.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "a/b/c/pwn", Typeflag: tar.TypeReg, Mode: 0600, Size: int64(len("PWNED")),
+	}))
+	_, err = tw.Write([]byte("PWNED"))
+	assert.NoError(t, err)
+	assert.NoError(t, tw.Close())
+	assert.NoError(t, gw.Close())
+	assert.NoError(t, f.Close())
+
+	p, _ := ui.NewForTesting()
+	t.Cleanup(func() { _ = makeWritable(tmpDir) })
+	_, err = Extract(
+		p.Task("extract"),
+		tarball,
+		&manifest.Package{Dest: dest, Source: "chain.tar.gz"},
+	)
+	assert.Error(t, err)
+
+	got, _ := os.ReadFile(canary)
+	assert.Equal(t, "ORIGINAL", string(got), "canary outside dest must not be modified")
+}
+
+// TestSymlinkTargetComponentEscape covers the variant where a symlinked component
+// appears in the symlink target itself rather than only in the parent path.
+func TestSymlinkTargetComponentEscape(t *testing.T) {
+	tmpDir := t.TempDir()
+	dest := filepath.Join(tmpDir, "extracted")
+	canary := filepath.Join(tmpDir, "canary.txt")
+	assert.NoError(t, os.WriteFile(canary, []byte("ORIGINAL"), 0600))
+
+	tarball := filepath.Join(tmpDir, "component.tar.gz")
+	f, err := os.Create(tarball)
+	assert.NoError(t, err)
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+
+	symlink := func(name, target string) {
+		assert.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: name, Typeflag: tar.TypeSymlink, Linkname: target, Mode: 0777,
+		}))
+	}
+	symlink("x", ".")
+	symlink("pwn", "x/../canary.txt")
+	assert.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "pwn", Typeflag: tar.TypeReg, Mode: 0600, Size: int64(len("PWNED")),
+	}))
+	_, err = tw.Write([]byte("PWNED"))
+	assert.NoError(t, err)
+	assert.NoError(t, tw.Close())
+	assert.NoError(t, gw.Close())
+	assert.NoError(t, f.Close())
+
+	p, _ := ui.NewForTesting()
+	t.Cleanup(func() { _ = makeWritable(tmpDir) })
+	_, err = Extract(
+		p.Task("extract"),
+		tarball,
+		&manifest.Package{Dest: dest, Source: "component.tar.gz"},
+	)
+	assert.Error(t, err)
+
+	got, _ := os.ReadFile(canary)
+	assert.Equal(t, "ORIGINAL", string(got), "canary outside dest must not be modified")
+}

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -446,3 +446,44 @@ func TestSymlinkTargetComponentEscape(t *testing.T) {
 	got, _ := os.ReadFile(canary)
 	assert.Equal(t, "ORIGINAL", string(got), "canary outside dest must not be modified")
 }
+
+// TestSymlinkChainEscapeOutOfOrder covers the ordering where the escaping link is
+// written before the symlinked component that makes it escape, so the link looks
+// harmlessly dangling at creation time and is only resolvable as an escape once the
+// later component exists.
+func TestSymlinkChainEscapeOutOfOrder(t *testing.T) {
+	tmpDir := t.TempDir()
+	dest := filepath.Join(tmpDir, "extracted")
+	canary := filepath.Join(tmpDir, "canary.txt")
+	assert.NoError(t, os.WriteFile(canary, []byte("ORIGINAL"), 0600))
+
+	tarball := filepath.Join(tmpDir, "ooo.tar.gz")
+	f, err := os.Create(tarball)
+	assert.NoError(t, err)
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+	symlink := func(name, target string) {
+		assert.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: name, Typeflag: tar.TypeSymlink, Linkname: target, Mode: 0777,
+		}))
+	}
+	// pwn is written first (x does not exist yet, so it looks dangling), then x -> .
+	// is created, which makes pwn resolve above dest.
+	symlink("pwn", "x/../canary.txt")
+	symlink("x", ".")
+	assert.NoError(t, tw.Close())
+	assert.NoError(t, gw.Close())
+	assert.NoError(t, f.Close())
+
+	p, _ := ui.NewForTesting()
+	t.Cleanup(func() { _ = makeWritable(tmpDir) })
+	_, err = Extract(
+		p.Task("extract"),
+		tarball,
+		&manifest.Package{Dest: dest, Source: "ooo.tar.gz"},
+	)
+	assert.Error(t, err)
+
+	got, _ := os.ReadFile(canary)
+	assert.Equal(t, "ORIGINAL", string(got), "canary outside dest must not be modified")
+}

--- a/archive/legit_test.go
+++ b/archive/legit_test.go
@@ -1,0 +1,97 @@
+package archive
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/cashapp/hermit/manifest"
+	"github.com/cashapp/hermit/ui"
+)
+
+func writeTar(t *testing.T, path string, write func(tw *tar.Writer)) {
+	f, err := os.Create(path)
+	assert.NoError(t, err)
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+	write(tw)
+	assert.NoError(t, tw.Close())
+	assert.NoError(t, gw.Close())
+	assert.NoError(t, f.Close())
+}
+
+// 1. Directory symlink with files written *through* it (common "current -> versions/x" layout).
+func TestLegitDirSymlinkWriteThrough(t *testing.T) {
+	tmpDir := t.TempDir()
+	dest := filepath.Join(tmpDir, "extracted")
+	tarball := filepath.Join(tmpDir, "p.tar.gz")
+	writeTar(t, tarball, func(tw *tar.Writer) {
+		_ = tw.WriteHeader(&tar.Header{Name: "versions/1.0/", Typeflag: tar.TypeDir, Mode: 0755})
+		_ = tw.WriteHeader(&tar.Header{Name: "current", Typeflag: tar.TypeSymlink, Linkname: "versions/1.0", Mode: 0777})
+		_ = tw.WriteHeader(&tar.Header{Name: "current/bin/tool", Typeflag: tar.TypeReg, Mode: 0755, Size: 2})
+		_, _ = tw.Write([]byte("hi"))
+	})
+
+	p, _ := ui.NewForTesting()
+	t.Cleanup(func() { _ = makeWritable(tmpDir) })
+	_, err := Extract(p.Task("x"), tarball, &manifest.Package{Dest: dest, Source: "p.tar.gz"})
+	assert.NoError(t, err)
+	b, err := os.ReadFile(filepath.Join(dest, "versions", "1.0", "bin", "tool"))
+	assert.NoError(t, err)
+	assert.Equal(t, "hi", string(b))
+}
+
+// 2. Legit relative symlink to a sibling file within the package.
+func TestLegitRelativeSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	dest := filepath.Join(tmpDir, "extracted")
+	tarball := filepath.Join(tmpDir, "p.tar.gz")
+	writeTar(t, tarball, func(tw *tar.Writer) {
+		_ = tw.WriteHeader(&tar.Header{Name: "lib/libfoo.so.1.2.3", Typeflag: tar.TypeReg, Mode: 0644, Size: 3})
+		_, _ = tw.Write([]byte("lib"))
+		_ = tw.WriteHeader(&tar.Header{Name: "lib/libfoo.so.1", Typeflag: tar.TypeSymlink, Linkname: "libfoo.so.1.2.3", Mode: 0777})
+	})
+
+	p, _ := ui.NewForTesting()
+	t.Cleanup(func() { _ = makeWritable(tmpDir) })
+	_, err := Extract(p.Task("x"), tarball, &manifest.Package{Dest: dest, Source: "p.tar.gz"})
+	assert.NoError(t, err)
+	target, err := os.Readlink(filepath.Join(dest, "lib", "libfoo.so.1"))
+	assert.NoError(t, err)
+	assert.Equal(t, "libfoo.so.1.2.3", target)
+}
+
+// 3. Legit dangling symlink whose target stays within the package (e.g. created at runtime).
+func TestLegitDanglingInRootSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	dest := filepath.Join(tmpDir, "extracted")
+	tarball := filepath.Join(tmpDir, "p.tar.gz")
+	writeTar(t, tarball, func(tw *tar.Writer) {
+		_ = tw.WriteHeader(&tar.Header{Name: "var/run", Typeflag: tar.TypeSymlink, Linkname: "state/run", Mode: 0777})
+	})
+
+	p, _ := ui.NewForTesting()
+	t.Cleanup(func() { _ = makeWritable(tmpDir) })
+	_, err := Extract(p.Task("x"), tarball, &manifest.Package{Dest: dest, Source: "p.tar.gz"})
+	assert.NoError(t, err, "dangling symlink within the package must be allowed")
+}
+
+// 4. Circular symlink (a -> b, b -> a): broken but contained within the package, so
+// it must not be rejected as an escape.
+func TestCircularSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	dest := filepath.Join(tmpDir, "extracted")
+	tarball := filepath.Join(tmpDir, "p.tar.gz")
+	writeTar(t, tarball, func(tw *tar.Writer) {
+		_ = tw.WriteHeader(&tar.Header{Name: "a", Typeflag: tar.TypeSymlink, Linkname: "b", Mode: 0777})
+		_ = tw.WriteHeader(&tar.Header{Name: "b", Typeflag: tar.TypeSymlink, Linkname: "a", Mode: 0777})
+	})
+
+	p, _ := ui.NewForTesting()
+	t.Cleanup(func() { _ = makeWritable(tmpDir) })
+	_, err := Extract(p.Task("x"), tarball, &manifest.Package{Dest: dest, Source: "p.tar.gz"})
+	assert.NoError(t, err, "contained circular symlinks must not be rejected")
+}


### PR DESCRIPTION
Extraction now performs all filesystem operations through `os.Root`, so symlinks contained in an archive can no longer cause files to be written outside the destination directory. Also avoids following symlinks during the read-only finalisation chmod, and uses a fixed name for the nested payload when unpacking `.deb` packages.

Adds regression tests for symlink handling during extraction.