### PR TITLE
fix(zsh): stop ../-path completion stalling and double chpwd registration

### DIFF
--- a/shell/files/sh_common_hooks.sh
+++ b/shell/files/sh_common_hooks.sh
@@ -1,4 +1,10 @@
 change_hermit_env() {
+  # zsh sets `compstate` only while its completion system is running. The _cd
+  # completer canonicalises `../` paths by running `cd` in a $(...) subshell,
+  # which would otherwise trigger a full (and immediately discarded) env switch
+  # on every TAB. Skip activation in that case; real `cd` and `(cd ... && cmd)`
+  # leave `compstate` unset and are unaffected.
+  if [ -n "${compstate+_}" ]; then return 0; fi
   local CUR=${PWD}
   while [ "$CUR" != "/" ]; do
     if [ -n "${HERMIT_ENV+_}" ] && [ "${CUR}" -ef "${HERMIT_ENV}" ]; then

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -8,7 +8,13 @@ import (
 )
 
 var zshShellHooks = `
-chpwd_functions+=(change_hermit_env)
+# Use add-zsh-hook (not chpwd_functions+=) so re-sourcing this block - e.g. the
+# hooks appearing in both .zprofile and .zshrc, or a "source ~/.zshrc" reload -
+# does not register change_hermit_env more than once. add-zsh-hook is idempotent;
+# a bare += (or even typeset -gU) would accumulate duplicates and run the hook,
+# and its hermit shell-out, repeatedly on every cd.
+autoload -Uz add-zsh-hook
+add-zsh-hook chpwd change_hermit_env
 change_hermit_env
 
 # A child zsh can inherit HERMIT_ENV/ACTIVE_HERMIT from its parent without


### PR DESCRIPTION
Two zsh shell-hook issues that compound on machines where Hermit hooks
are evaluated more than once (e.g. a corporate-managed /etc/zshrc plus a
per-user ~/.zshrc install).

1. ../-path tab completion paused ~1s. zsh's _cd completer canonicalises
   a `../` prefix by running `cd` in a $(...) subshell, which fires
   chpwd_functions -> change_hermit_env and pays for a full Hermit env
   switch (validate + source activate-hermit) that is then discarded. Guard
   change_hermit_env with `${compstate+_}`, which zsh sets only while its
   completion system is running and which is inherited into the _cd
   subshell. Interactive `cd`, `(cd ... && cmd)` and `$(cd ... && cmd)` all
   leave compstate unset and are unaffected.

2. change_hermit_env was registered twice in chpwd_functions, doubling the
   cost of every real cd. The hook block is evaluated once per startup file
   that sources it (system-wide + per-user), and the old
   `chpwd_functions+=(change_hermit_env)` is not idempotent. Register via
   add-zsh-hook instead, which checks membership before appending. Note a
   plain `typeset -gU chpwd_functions` does not help: += bypasses the unique
   flag in zsh 5.9.
