### PR TITLE
fix(fish): activate hermit env on shell startup

### DIFF
--- a/shell/files/fish_hooks.fish
+++ b/shell/files/fish_hooks.fish
@@ -35,3 +35,5 @@ function __complete_hermit
 end
 
 complete -f -c hermit -a "(__complete_hermit)"
+
+activate_hermit


### PR DESCRIPTION
## Problem

The `activate_hermit` handler in the fish hooks is registered only with `--on-variable PWD`. In fish, that fires on *subsequent changes* to `$PWD`, not on the value already set when the shell starts. Opening a terminal directly into a hermit directory therefore never activates the environment — you have to `cd` out and back in.

## Fix

Call `activate_hermit` once at the end of `fish_hooks.fish`. The hook file is sourced from `~/.config/fish/conf.d/hermit.fish` on every shell startup, so this handles the initial directory while `--on-variable PWD` continues to handle `cd`.

This mirrors the existing shell hooks:
- **zsh** (`shell/zsh.go`): calls `change_hermit_env` immediately after registering the `chpwd` hook.
- **bash** (`shell/bash.go`): runs `change_hermit_env` via `PROMPT_COMMAND`, which fires before the first prompt too.

Fish was the only shell not activating on startup.