### PR TITLE
fix: show Fish activation script after init

### DIFF
--- a/env.go
+++ b/env.go
@@ -201,13 +201,14 @@ func Init(l *ui.UI, env string, distURL string, stateDir string, config Config, 
 			}
 		}
 	}
+	detectedShell, _ := shell.Detect()
 	l.Infof(`
 
 Hermit environment initialised in %s
 
 To activate the environment run:
 
-  . %s/bin/activate-hermit
+  %s
 
 Then run the following to list available commands:
 
@@ -218,8 +219,15 @@ To deactivate the environment run:
   deactivate-hermit
 
 For more information please refer to https://github.com/cashapp/hermit
-`, env, env)
+`, env, activationCommand(env, detectedShell))
 	return nil
+}
+
+func activationCommand(env string, detectedShell shell.Shell) string {
+	if detectedShell != nil && detectedShell.Name() == "fish" {
+		return fmt.Sprintf(". %s/bin/activate-hermit.fish", env)
+	}
+	return fmt.Sprintf(". %s/bin/activate-hermit", env)
 }
 
 // EnvDirFromProxyLink finds a Hermit environment given a proxy symlink.

--- a/env_internal_test.go
+++ b/env_internal_test.go
@@ -1,0 +1,45 @@
+package hermit
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/cashapp/hermit/shell"
+)
+
+func TestActivationCommand(t *testing.T) {
+	const env = "/path/to/env"
+
+	tests := []struct {
+		name     string
+		shell    shell.Shell
+		expected string
+	}{
+		{
+			name:     "fish",
+			shell:    &shell.Fish{},
+			expected: ". /path/to/env/bin/activate-hermit.fish",
+		},
+		{
+			name:     "bash",
+			shell:    &shell.Bash{},
+			expected: ". /path/to/env/bin/activate-hermit",
+		},
+		{
+			name:     "zsh",
+			shell:    &shell.Zsh{},
+			expected: ". /path/to/env/bin/activate-hermit",
+		},
+		{
+			name:     "detection failure",
+			shell:    nil,
+			expected: ". /path/to/env/bin/activate-hermit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, activationCommand(env, tt.shell))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- detect the current shell when a Hermit environment is initialized
- recommend `activate-hermit.fish` when Fish is detected
- preserve the existing activation command for Bash, Zsh, and detection failures

## Why

Hermit generates both `activate-hermit` and `activate-hermit.fish`, but the
post-`init` message always recommended the Bash/Zsh script. Following that
instruction from Fish causes Fish to parse an incompatible shell script.

The change reuses Hermit's existing shell detection and only changes the
recommended script when Fish is detected.

## Testing

- `go test ./...`
- `git diff --check`
