### PR TITLE
fix: re-assert Hermit PATH precedence at first zsh prompt

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -683,6 +683,41 @@ EOF
 			`,
 		},
 		{
+			// Hermit hooks can activate an environment before the user's own
+			// startup files run (eg. from /etc/zshrc), letting anything they
+			// prepend to PATH afterwards (eg. RVM) shadow the environment. zsh
+			// re-asserts Hermit's PATH entries at the first prompt.
+			name:         "ZshReassertsPathPrecedenceAtFirstPrompt",
+			preparations: prep{fixture("testenv1")},
+			script: `
+				. bin/activate-hermit
+				if [ -n "${ZSH_VERSION-}" ]; then
+					assert test "${path[1]}" = "${HERMIT_ENV}/bin"
+					PATH="/rvm/bin:$PATH"
+					# Run the precmd hooks as an interactive shell would at the next prompt.
+					for f in $precmd_functions; do "$f"; done
+					assert test "${path[1]}" = "${HERMIT_ENV}/bin"
+					assert test "${path[2]}" = "/rvm/bin"
+				fi
+			`,
+		},
+		{
+			name:         "ZshKeepsHermitPrependPathFirstWhenReassertingPath",
+			preparations: prep{fixture("testenv1")},
+			script: `
+				export HERMIT_PREPEND_PATH="/prepend/first:/prepend/second"
+				. bin/activate-hermit
+				if [ -n "${ZSH_VERSION-}" ]; then
+					PATH="/rvm/bin:$PATH"
+					for f in $precmd_functions; do "$f"; done
+					assert test "${path[1]}" = "/prepend/first"
+					assert test "${path[2]}" = "/prepend/second"
+					assert test "${path[3]}" = "${HERMIT_ENV}/bin"
+					assert test "${path[4]}" = "/rvm/bin"
+				fi
+			`,
+		},
+		{
 			name:         "InstallOnActivateEnsuresPackagesAreUnpacked",
 			preparations: prep{fixture("testenv-install-on-activate"), activate(".")},
 			script: `

--- a/shell/files/activate.tmpl.sh
+++ b/shell/files/activate.tmpl.sh
@@ -37,7 +37,7 @@ _hermit_deactivate() {
 {{- end}}
 
 {{- if .Zsh }}
-  precmd_functions=(${precmd_functions:#(update_hermit_env|update_hermit_ps1)})
+  precmd_functions=(${precmd_functions:#(update_hermit_env|update_hermit_ps1|update_hermit_path)})
 {{- end}}
 
 {{- if ne .Prompt "none"}}
@@ -102,6 +102,18 @@ fi
 
 {{- if .Zsh }}
 precmd_functions+=(update_hermit_env)
+
+# Like the prompt above, Hermit may have been activated before the user's
+# startup files ran (eg. from hooks in /etc/zshrc), in which case anything
+# they prepend to PATH (eg. RVM) would shadow the environment. Re-assert
+# Hermit's PATH entries once, at the first prompt.
+precmd_functions+=(update_hermit_path)
+update_hermit_path() {
+  precmd_functions=(${precmd_functions:#update_hermit_path})
+  local -a hermit_path
+  hermit_path=(${(s.:.)${HERMIT_PREPEND_PATH-}} "${HERMIT_ENV}/bin")
+  path=($hermit_path ${path:|hermit_path})
+}
 {{- end}}
 
 if type hermit_on_activate >/dev/null 2>&1; then hermit_on_activate; fi


### PR DESCRIPTION
Since #554, zsh hooks activate Hermit eagerly, so when the hooks are installed early (eg. in /etc/zshrc) anything the user's startup files later prepend to PATH (eg. RVM) shadows the Hermit environment in any terminal opened inside it. This registers a one-shot precmd that moves Hermit's PATH entries back to the front at the first prompt — the same deferral `update_hermit_ps1` already does for the prompt prefix. `HERMIT_PREPEND_PATH` components stay ahead of the environment's bin, and later prepends are demoted rather than removed. zsh only; bash hooks already run at prompt time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)