### PR TITLE
fix: Sanitise environment basename in shell prompt

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -101,6 +101,26 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 		{
+			// Regression test for VULN-78225: command injection via the environment basename.
+			name: "MaliciousEnvBasenameDoesNotExecute",
+			script: `
+				cat > "$HERMIT_USER_CONFIG" <<EOF
+prompt = "env"
+EOF
+				EVIL='$(printf PWNED>RCE.txt)'
+				mkdir -p "$EVIL"
+				hermit init --no-git "$EVIL"
+				# Non-interactive bash unsets PS1.
+				PS1=baseline
+				. "$EVIL/bin/activate-hermit"
+				# zsh defers the prompt update to precmd.
+				if [ -n "${ZSH_VERSION-}" ]; then update_hermit_ps1; fi
+				assert test ! -e RCE.txt
+				echo "prompt is: $PS1"
+			`,
+			expectations: exp{outputContains("__printf PWNED_RCE.txt_🐚")},
+		},
+		{
 			name: "InitBasicDefaultsToTrue",
 			script: `
 				# Remove the user config file created by test framework to test "no config" path

--- a/shell/activate_template_test.go
+++ b/shell/activate_template_test.go
@@ -60,6 +60,45 @@ func TestActivateHermitRejectsMaliciousEnvKey(t *testing.T) {
 	}
 }
 
+func TestActivationScriptNeutralisesMaliciousEnvBasename(t *testing.T) {
+	// Regression test for VULN-78225: command injection via the environment basename.
+	payload := `$(id>RCE_ID.txt;whoami>RCE_WHOAMI.txt;printf PWNED>RCE_WRITE.txt)`
+	for _, sh := range []Shell{&Bash{}, &Zsh{}, &Fish{}} {
+		t.Run(sh.Name(), func(t *testing.T) {
+			var out bytes.Buffer
+			err := ActivateHermit(&out, sh, ActivationConfig{
+				Root:   "/tmp/" + payload,
+				Prompt: "env",
+				Env:    envars.Envars{"HERMIT_BIN": "/tmp/" + payload + "/bin"},
+			})
+			assert.NoError(t, err)
+
+			script := out.String()
+			checked := 0
+			for line := range strings.SplitSeq(script, "\n") {
+				_, assignment, ok := strings.Cut(line, `PS1="`)
+				if !ok {
+					continue
+				}
+				name, _, ok := strings.Cut(assignment, "🐚")
+				if !ok {
+					continue
+				}
+				for _, metachar := range []string{"$", "`", `"`, `\`, "%", "!", ";", ">"} {
+					assert.NotContains(t, name, metachar, "%s", line)
+				}
+				checked++
+			}
+			// Fish does not interpolate the environment name into its prompt.
+			if sh.Name() != "fish" {
+				assert.True(t, checked > 0, "no prompt assignment found in:\n%s", script)
+			}
+			assert.NotContains(t, script, `PS1="$(`)
+			assert.Contains(t, script, "'/tmp/"+payload+"'")
+		})
+	}
+}
+
 func TestFishActivationScriptQuotesPathsWithSpaces(t *testing.T) {
 	root := "/tmp/Application Support/hermit env"
 

--- a/shell/bash.go
+++ b/shell/bash.go
@@ -2,7 +2,6 @@ package shell
 
 import (
 	"io"
-	"path/filepath"
 
 	"github.com/cashapp/hermit/errors"
 )
@@ -27,7 +26,7 @@ func (sh *Bash) Name() string { return "bash" }
 func (sh *Bash) ActivationScript(w io.Writer, config ActivationConfig) error {
 	err := posixActivationScriptTmpl.Execute(w, &posixActivationContext{
 		ActivationConfig: config,
-		EnvName:          filepath.Base(config.Root),
+		EnvName:          envName(config.Root),
 		Shell:            "bash",
 	})
 	return errors.WithStack(err)

--- a/shell/fish.go
+++ b/shell/fish.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 	"fmt"
 	"io"
-	"path/filepath"
 	"text/template"
 
 	"github.com/cashapp/hermit/envars"
@@ -34,7 +33,7 @@ func (sh *Fish) Name() string { return "fish" }
 func (sh *Fish) ActivationScript(w io.Writer, config ActivationConfig) error {
 	err := fishActivationScriptTmpl.Execute(w, &fishActivationContext{
 		ActivationConfig: config,
-		EnvName:          filepath.Base(config.Root),
+		EnvName:          envName(config.Root),
 		Shell:            "fish",
 	})
 	return errors.WithStack(err)

--- a/shell/quote.go
+++ b/shell/quote.go
@@ -2,8 +2,31 @@ package shell
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
+	"unicode"
 )
+
+const envNameSafePunctuation = " -_.,+=:@~"
+
+// envName sanitises the environment basename for use in the shell prompt.
+//
+// Quoting into a variable is not enough: zsh expands "%" after substitution,
+// and renders the reference literally unless PROMPT_SUBST is set.
+func envName(root string) string {
+	base := filepath.Base(root)
+	var name strings.Builder
+	name.Grow(len(base))
+	for _, r := range base {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsMark(r) ||
+			strings.ContainsRune(envNameSafePunctuation, r) {
+			name.WriteRune(r)
+		} else {
+			name.WriteRune('_')
+		}
+	}
+	return name.String()
+}
 
 // Quote returns a word quoted with single-quotes for consumption by shells.
 //

--- a/shell/quote_test.go
+++ b/shell/quote_test.go
@@ -23,3 +23,34 @@ func TestShellQuote(t *testing.T) {
 		assert.Equal(t, []string{test.original}, original)
 	}
 }
+
+func TestEnvName(t *testing.T) {
+	tests := []struct {
+		name     string
+		root     string
+		expected string
+	}{
+		{"Plain", "/tmp/hermit-env", "hermit-env"},
+		{"Spaces", "/tmp/Application Support/hermit env", "hermit env"},
+		{"SafePunctuation", "/tmp/a-b_c.d,e+f=g:h@i~j", "a-b_c.d,e+f=g:h@i~j"},
+		{"Unicode", "/tmp/héllo-wörld-日本語", "héllo-wörld-日本語"},
+		{"CommandSubstitution", "/tmp/$(id)", "__id_"},
+		{"Backticks", "/tmp/`id`", "_id_"},
+		{"ParameterExpansion", "/tmp/${HOME}", "__HOME_"},
+		{"Quotes", `/tmp/a"b'c`, "a_b_c"},
+		{"Backslash", `/tmp/a\b\`, "a_b_"},
+		{"BashPromptEscape", `/tmp/\u\h\$`, "_u_h__"},
+		{"ZshPromptEscape", "/tmp/%n%m%(e)", "_n_m__e_"},
+		{"ZshHistoryExpansion", "/tmp/a!b", "a_b"},
+		{"Control", "/tmp/a\nb\rc\td\x00e", "a_b_c_d_e"},
+		{"Semicolons", "/tmp/a;b&c|d", "a_b_c_d"},
+		{"InvalidUTF8", "/tmp/a\xff\xfeb", "a__b"},
+		{"Root", "/", "_"},
+		{"Empty", "", "."},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, envName(test.root))
+		})
+	}
+}

--- a/shell/zsh.go
+++ b/shell/zsh.go
@@ -2,7 +2,6 @@ package shell
 
 import (
 	"io"
-	"path/filepath"
 
 	"github.com/cashapp/hermit/errors"
 )
@@ -41,7 +40,7 @@ func (sh *Zsh) Name() string { return "zsh" }
 
 func (sh *Zsh) ActivationScript(w io.Writer, config ActivationConfig) error {
 	err := posixActivationScriptTmpl.Execute(w, &posixActivationContext{
-		EnvName:          filepath.Base(config.Root),
+		EnvName:          envName(config.Root),
 		ActivationConfig: config,
 		Shell:            "zsh",
 	})


### PR DESCRIPTION
The environment root's basename was interpolated raw into the generated
PS1 assignment, so a directory named $(...) or containing backticks
executed as the user on activation (bash) or at the first prompt (zsh).
This is reachable by default: prompt = "env" resolves as the default for
both absent and empty user config files.

Replace runes outside a conservative allowlist rather than quoting the
name into a shell variable, because zsh expands "%" after substitution
and renders the reference literally unless PROMPT_SUBST is set.

VULN-78225

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
