### PR TITLE
Disable curlrc invocation for installation

### DIFF
--- a/cmd/geninstaller/install.sh.tmpl
+++ b/cmd/geninstaller/install.sh.tmpl
@@ -63,7 +63,7 @@ function user_install() {
   TMP_FILE="${HERMIT_EXE}.download.${RANDOM}"
   echo "Downloading ${URL} to ${HERMIT_EXE}"
   chmod -f u+w "${HERMIT_EXE}" 2> /dev/null || true
-  curl -fsSL "${URL}" | gzip -dc > "${TMP_FILE}"
+  curl -qfsSL "${URL}" | gzip -dc > "${TMP_FILE}"
   chown "$ID_USER:$ID_GROUP" "${TMP_FILE}"
   chmod u+wx "${TMP_FILE}"
   mv "${TMP_FILE}" "${HERMIT_EXE}"


### PR DESCRIPTION
 The installer runs `curl | bash` which is generally frowned upon for several reasons. One is that it takes the responses directly from curl to bash.
This fails if the user has any HTTP diagnostic output in their curlrc, as the output is interpreted by the gzip command. This PR disables curlrc
from being sourced, working around the issue. It's not as elegant as downloading the installer, then invoking bash, but it works.
