### PR TITLE
Download installer archive before decompression

### DIFF
--- a/cmd/geninstaller/install.sh.tmpl
+++ b/cmd/geninstaller/install.sh.tmpl
@@ -61,9 +61,16 @@ function user_install() {
   fi
   URL="${HERMIT_DIST_URL}/hermit-${OS}-${ARCH}.gz"
   TMP_FILE="${HERMIT_EXE}.download.${RANDOM}"
+  TMP_ARCHIVE="${TMP_FILE}.gz"
   echo "Downloading ${URL} to ${HERMIT_EXE}"
   chmod -f u+w "${HERMIT_EXE}" 2> /dev/null || true
-  curl -fsSL "${URL}" | gzip -dc > "${TMP_FILE}"
+  curl --remove-on-error -fsSL -o "${TMP_ARCHIVE}" "${URL}"
+  if [ ! -f "${TMP_ARCHIVE}" ] || [ ! -s "${TMP_ARCHIVE}" ]; then
+    echo "Failed to download ${URL}" >&2
+    exit 1
+  fi
+  gzip -dc "${TMP_ARCHIVE}" > "${TMP_FILE}"
+  rm -f "${TMP_ARCHIVE}"
   chown "$ID_USER:$ID_GROUP" "${TMP_FILE}"
   chmod u+wx "${TMP_FILE}"
   mv "${TMP_FILE}" "${HERMIT_EXE}"

--- a/files/install.sh.tmpl
+++ b/files/install.sh.tmpl
@@ -61,9 +61,16 @@ function user_install() {
   fi
   URL="${HERMIT_DIST_URL}/hermit-${OS}-${ARCH}.gz"
   TMP_FILE="${HERMIT_EXE}.download.${RANDOM}"
+  TMP_ARCHIVE="${TMP_FILE}.gz"
   echo "Downloading ${URL} to ${HERMIT_EXE}"
   chmod -f u+w "${HERMIT_EXE}" 2> /dev/null || true
-  curl -fsSL "${URL}" | gzip -dc > "${TMP_FILE}"
+  curl --remove-on-error -fsSL -o "${TMP_ARCHIVE}" "${URL}"
+  if [ ! -f "${TMP_ARCHIVE}" ] || [ ! -s "${TMP_ARCHIVE}" ]; then
+    echo "Failed to download ${URL}" >&2
+    exit 1
+  fi
+  gzip -dc "${TMP_ARCHIVE}" > "${TMP_FILE}"
+  rm -f "${TMP_ARCHIVE}"
   chown "$ID_USER:$ID_GROUP" "${TMP_FILE}"
   chmod u+wx "${TMP_FILE}"
   mv "${TMP_FILE}" "${HERMIT_EXE}"


### PR DESCRIPTION
## Summary

- download the compressed Hermit binary to a temporary archive before decompressing it
- keep user curl configuration enabled without allowing `--write-out` diagnostics to corrupt the archive stream
- remove partial downloads on curl errors and reject missing or empty archives
- keep both embedded installer templates synchronized

## Why

The installer previously piped curl's stdout directly into gzip. If a user's curlrc configured diagnostic output with `--write-out`, those bytes were mixed into the archive stream and decompression failed. Disabling curlrc globally, as proposed in #603, avoids the symptom but also ignores every user's curl configuration. Downloading to a file isolates the response body while preserving curlrc behavior.

## Validation

- `./bin/go test ./...`
- generated-installer parity check
- Shellcheck on the generated installer
- regression harness with curlrc `--write-out` output
- rejection test for a zero-byte download
