### PR TITLE
fix: Reject reserved HERMIT_ envars from manifests

### DIFF
--- a/env.go
+++ b/env.go
@@ -295,7 +295,7 @@ func readConfig(configFile string) (*Config, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, configFile)
 		}
-		if err := config.Envars.Validate(); err != nil {
+		if err := config.Envars.ValidateManifest(); err != nil {
 			return nil, errors.Wrap(err, configFile)
 		}
 	}

--- a/envars/util.go
+++ b/envars/util.go
@@ -18,6 +18,8 @@ import (
 // followed by any number of letters, digits, or underscores.
 var validEnvKey = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
+var reservedEnvKey = regexp.MustCompile(`^_?HERMIT_`)
+
 // ValidateKey returns an error if key is not a valid POSIX environment
 // variable name. Hermit emits keys verbatim into shell scripts, so anything
 // outside this pattern is rejected to prevent shell command injection.
@@ -28,11 +30,30 @@ func ValidateKey(key string) error {
 	return nil
 }
 
+func ValidateManifestKey(key string) error {
+	if err := ValidateKey(key); err != nil {
+		return err
+	}
+	if reservedEnvKey.MatchString(key) {
+		return errors.Errorf("environment variable name %q is reserved by Hermit (names prefixed with HERMIT_ or _HERMIT_ cannot be set from a manifest)", key)
+	}
+	return nil
+}
+
 // Validate returns an error if any key in e is not a valid POSIX environment
 // variable name. See [ValidateKey].
 func (e Envars) Validate() error {
 	for key := range e {
 		if err := ValidateKey(key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e Envars) ValidateManifest() error {
+	for key := range e {
+		if err := ValidateManifestKey(key); err != nil {
 			return err
 		}
 	}

--- a/envars/util_test.go
+++ b/envars/util_test.go
@@ -131,6 +131,42 @@ func TestValidateKey(t *testing.T) {
 func TestEnvarsValidate(t *testing.T) {
 	assert.NoError(t, Envars{"FOO": "1", "BAR_2": "2"}.Validate())
 	assert.Error(t, Envars{"FOO": "1", "EVIL; touch /tmp/x; X": "v"}.Validate())
+	assert.NoError(t, Envars{"HERMIT_EXE": "/tmp/evil"}.Validate())
+}
+
+func TestValidateManifestKey(t *testing.T) {
+	cases := []struct {
+		name    string
+		key     string
+		wantErr bool
+	}{
+		{name: "Simple", key: "FOO", wantErr: false},
+		{name: "MentionsHermit", key: "MY_HERMIT_THING", wantErr: false},
+		{name: "ActiveHermit", key: "ACTIVE_HERMIT", wantErr: false},
+		{name: "ReservedExe", key: "HERMIT_EXE", wantErr: true},
+		{name: "ReservedDistURL", key: "HERMIT_DIST_URL", wantErr: true},
+		{name: "ReservedStateDir", key: "HERMIT_STATE_DIR", wantErr: true},
+		{name: "ReservedRootBin", key: "HERMIT_ROOT_BIN", wantErr: true},
+		{name: "ReservedPrependPath", key: "HERMIT_PREPEND_PATH", wantErr: true},
+		{name: "ReservedUnderscore", key: "_HERMIT_OLD_FOO", wantErr: true},
+		{name: "InvalidPOSIX", key: "EVIL; touch /tmp/x; X", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateManifestKey(tc.key)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestEnvarsValidateManifest(t *testing.T) {
+	assert.NoError(t, Envars{"FOO": "1", "BAR_2": "2"}.ValidateManifest())
+	assert.Error(t, Envars{"FOO": "1", "HERMIT_EXE": "/tmp/evil"}.ValidateManifest())
+	assert.Error(t, Envars{"_HERMIT_OLD_PATH": "x"}.ValidateManifest())
 }
 
 func TestExpandDateTime(t *testing.T) {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -121,6 +121,20 @@ EOF
 			expectations: exp{outputContains("__printf PWNED_RCE.txt_🐚")},
 		},
 		{
+			name: "ManifestCannotSetReservedHermitEnvar",
+			script: `
+				hermit init .
+				cat > bin/hermit.hcl <<EOF
+env = {
+  "HERMIT_ROOT_BIN": "/tmp/evil",
+}
+EOF
+				assert test "$(hermit validate env . >/dev/null 2>&1; echo $?)" != "0"
+				. bin/activate-hermit >/dev/null 2>&1 || true
+				assert test -z "${HERMIT_ROOT_BIN:-}"
+			`,
+		},
+		{
 			name: "InitBasicDefaultsToTrue",
 			script: `
 				# Remove the user config file created by test framework to test "no config" path

--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -587,7 +587,7 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 	}
 
 	for _, env := range layerEnvars {
-		if err := env.Validate(); err != nil {
+		if err := env.ValidateManifest(); err != nil {
 			return nil, errors.Wrapf(err, "%s: %s", manifest.Path, found)
 		}
 		for k, v := range env {


### PR DESCRIPTION
A repository's bin/hermit.hcl (or a package manifest) env block is
exported verbatim into the developer's shell on activation. Nothing
excluded Hermit's own control variables, so a repo could set HERMIT_EXE,
HERMIT_DIST_URL, HERMIT_ROOT_BIN, HERMIT_PREPEND_PATH and others to
achieve code execution or PATH hijacking on cd, which hermit validate
env accepted (VULN-78245).

Reject any manifest-sourced key prefixed with HERMIT_ or _HERMIT_. This
breaks all reported attack chains at the root while leaving legitimate
uses intact: Hermit sets its own vars via Force ops, manifests may still
reference ${HERMIT_ENV} in values, and users may set HERMIT_PREPEND_PATH
in their own shell.

Co-authored-by: Claude Code <noreply@anthropic.com>
