### PR TITLE
fix: Keep GitHub token out of git source URLs

### DIFF
--- a/app/exec_cmd.go
+++ b/app/exec_cmd.go
@@ -32,7 +32,7 @@ func (e *execCmd) Run(
 	globalState GlobalState,
 	config Config,
 	defaultHTTPClient *http.Client,
-	sourceRewriters []sources.URLRewriter,
+	gitCredentials []sources.GitCredentials,
 ) error {
 	envDir, err := hermit.FindEnvDir(e.Binary)
 	if err != nil {
@@ -44,7 +44,7 @@ func (e *execCmd) Run(
 	}
 
 	// Pass config.SHA256Sums because OpenEnv uses the defaults cashapp/hermit; internal builds inject additional SHA256Sums.
-	env, err := hermit.OpenEnv(envInfo, sta, cache.GetSource, globalState.Env, defaultHTTPClient, config.SHA256Sums, sourceRewriters...)
+	env, err := hermit.OpenEnv(envInfo, sta, cache.GetSource, globalState.Env, defaultHTTPClient, config.SHA256Sums, gitCredentials...)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/app/main.go
+++ b/app/main.go
@@ -279,13 +279,13 @@ func Main(config Config) {
 		log.Fatalf("failed to open state: %s", err)
 	}
 
-	var sourceRewriters []sources.URLRewriter
+	var gitCredentials []sources.GitCredentials
 	if isActivated {
 		if matcher != nil {
-			sourceRewriters = append(sourceRewriters, github.AuthenticatedURLRewriter(githubToken, matcher))
+			gitCredentials = append(gitCredentials, github.GitCredentialEnv(githubToken, matcher))
 		}
 
-		env, err = hermit.OpenEnv(envInfo, sta, cache.GetSource, cli.getGlobalState().Env, defaultHTTPClient, config.SHA256Sums, sourceRewriters...)
+		env, err = hermit.OpenEnv(envInfo, sta, cache.GetSource, cli.getGlobalState().Env, defaultHTTPClient, config.SHA256Sums, gitCredentials...)
 		if err != nil {
 			log.Fatalf("failed to open environment: %s", err)
 		}
@@ -320,7 +320,7 @@ func Main(config Config) {
 			fatalIfError(p, ctx, err)
 		}()
 	}
-	err = ctx.Run(env, p, sta, config, cli.getGlobalState(), ghClient, defaultHTTPClient, cache, userConfig, sourceRewriters)
+	err = ctx.Run(env, p, sta, config, cli.getGlobalState(), ghClient, defaultHTTPClient, cache, userConfig, gitCredentials)
 	fatalIfError(p, ctx, err)
 }
 

--- a/app/status_cmd.go
+++ b/app/status_cmd.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cashapp/hermit"
 	"github.com/cashapp/hermit/errors"
 	"github.com/cashapp/hermit/ui"
+	"github.com/cashapp/hermit/util"
 )
 
 type statusCmd struct{}
@@ -25,7 +26,7 @@ func (s *statusCmd) Run(l *ui.UI, env *hermit.Env) error {
 		return errors.WithStack(err)
 	}
 	for _, source := range sources {
-		fmt.Printf("  %s\n", source)
+		fmt.Printf("  %s\n", util.RedactCredentials(source))
 	}
 	fmt.Println("Packages:")
 	for _, pkg := range pkgs {

--- a/env.go
+++ b/env.go
@@ -117,7 +117,7 @@ type Env struct {
 	configFile      string
 	httpClient      *http.Client
 	scriptSums      []string
-	sourceRewriters []sources.URLRewriter
+	gitCredentials  []sources.GitCredentials
 	activated       bool
 
 	// Lazily initialized fields
@@ -269,13 +269,13 @@ func FindEnvDir(binary string) (envDir string, err error) {
 	return
 }
 
-func getSources(l *ui.UI, envDir string, config *Config, state *state.State, defaultSources []string, sourceRewriters ...sources.URLRewriter) (*sources.Sources, error) {
+func getSources(l *ui.UI, envDir string, config *Config, state *state.State, defaultSources []string, gitCredentials ...sources.GitCredentials) (*sources.Sources, error) {
 	configuredSources := config.Sources
 	if config.Sources == nil {
 		configuredSources = defaultSources
 	}
 
-	ss, err := sources.ForURIs(l, state.SourcesDir(), envDir, configuredSources, sourceRewriters...)
+	ss, err := sources.ForURIs(l, state.SourcesDir(), envDir, configuredSources, gitCredentials...)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -349,7 +349,7 @@ func OpenEnv(
 	ephemeral envars.Envars,
 	httpClient *http.Client,
 	scriptSums []string,
-	sourceRewriters ...sources.URLRewriter,
+	gitCredentials ...sources.GitCredentials,
 ) (*Env, error) {
 	if err := ephemeral.Validate(); err != nil {
 		return nil, errors.WithStack(err)
@@ -370,7 +370,7 @@ func OpenEnv(
 		ephemeralEnvars: envars.Infer(ephemeral.System()),
 		httpClient:      httpClient,
 		scriptSums:      scriptSums,
-		sourceRewriters: sourceRewriters,
+		gitCredentials:  gitCredentials,
 		activated:       os.Getenv("ACTIVE_HERMIT") == info.Root,
 	}, nil
 }
@@ -921,7 +921,7 @@ func (e *Env) getPackageRuntimeEnvops(pkg *manifest.Package) (envars.Op, error) 
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	pkgEnv, err := OpenEnv(pkgEnvInfo, e.state, e.packageSource, nil, e.httpClient, e.scriptSums, e.sourceRewriters...)
+	pkgEnv, err := OpenEnv(pkgEnvInfo, e.state, e.packageSource, nil, e.httpClient, e.scriptSums, e.gitCredentials...)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -1668,7 +1668,7 @@ func (e *Env) sources(l *ui.UI) (*sources.Sources, error) {
 	if e.lazySources != nil {
 		return e.lazySources, nil
 	}
-	sources, err := getSources(l, e.envDir, e.config, e.state, e.state.Config().Sources, e.sourceRewriters...)
+	sources, err := getSources(l, e.envDir, e.config, e.state, e.state.Config().Sources, e.gitCredentials...)
 	if err != nil {
 		return nil, errors.Wrap(err, e.configFile)
 	}
@@ -1718,7 +1718,7 @@ func (e *Env) openParent() (*Env, error) {
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
-			return OpenEnv(parentEnvInfo, e.state, e.packageSource, nil, e.httpClient, e.scriptSums, e.sourceRewriters...)
+			return OpenEnv(parentEnvInfo, e.state, e.packageSource, nil, e.httpClient, e.scriptSums, e.gitCredentials...)
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return nil, err
 		}

--- a/github/url.go
+++ b/github/url.go
@@ -1,10 +1,11 @@
 package github
 
 import (
+	"encoding/base64"
 	"net/url"
 	"strings"
 
-	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/util"
 )
 
 // isGitHubHTTPSURL checks if a URL is a GitHub HTTPS URL and returns owner/repo if it is
@@ -26,27 +27,23 @@ func isGitHubSSHURL(uri string) bool {
 	return strings.HasPrefix(uri, "git@github.com:")
 }
 
-// AuthenticatedURLRewriter rewrites GitHub URLs to include an auth token if they match the provided pattern
-func AuthenticatedURLRewriter(token string, matcher RepoMatcher) func(uri string) (string, error) {
-	return func(repo string) (string, error) {
-		// Pass through SSH URLs unchanged
-		if isGitHubSSHURL(repo) {
-			return repo, nil
+// GitCredentialEnv authenticates matching GitHub repositories out of band: a token
+// embedded in the URL leaks into logs, the source directory name and .git/config.
+func GitCredentialEnv(token string, matcher RepoMatcher) func(uri string) []string {
+	return func(uri string) []string {
+		if token == "" || isGitHubSSHURL(uri) {
+			return nil
 		}
-
-		u, err := url.Parse(repo)
+		u, err := url.Parse(uri)
 		if err != nil {
-			return "", errors.WithStack(err)
+			return nil
 		}
-
 		owner, repoName, ok := isGitHubHTTPSURL(u)
-		if !ok || token == "" {
-			return repo, nil
+		if !ok || !matcher(owner, repoName) {
+			return nil
 		}
-		if matcher(owner, repoName) {
-			u.User = url.UserPassword("x-access-token", token)
-			return u.String(), nil
-		}
-		return repo, nil
+		auth := base64.StdEncoding.EncodeToString([]byte("x-access-token:" + token))
+		return util.GitConfigEnv(
+			"http.https://"+gitHubHost+"/.extraheader", "Authorization: Basic "+auth)
 	}
 }

--- a/github/url_test.go
+++ b/github/url_test.go
@@ -1,0 +1,53 @@
+package github
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func matchAll(_, _ string) bool { return true }
+
+func expectedHeaderEnv(token string) []string {
+	auth := base64.StdEncoding.EncodeToString([]byte("x-access-token:" + token))
+	return []string{
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=http.https://github.com/.extraheader",
+		"GIT_CONFIG_VALUE_0=Authorization: Basic " + auth,
+	}
+}
+
+func TestGitCredentialEnv(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		token    string
+		matcher  RepoMatcher
+		uri      string
+		expected []string
+	}{
+		{"MatchingRepo", "tok", matchAll, "https://github.com/cashapp/hermit.git", expectedHeaderEnv("tok")},
+		{"NonMatchingRepo", "tok", func(_, _ string) bool { return false },
+			"https://github.com/cashapp/hermit.git", nil},
+		{"NoToken", "", matchAll, "https://github.com/cashapp/hermit.git", nil},
+		{"SSHURL", "tok", matchAll, "git@github.com:cashapp/hermit.git", nil},
+		{"NonGitHubHost", "tok", matchAll, "https://example.com/cashapp/hermit.git", nil},
+		{"HostSpoofViaUserinfo", "tok", matchAll, "https://github.com@evil.com/o/r.git", nil},
+		{"PlainHTTP", "tok", matchAll, "http://github.com/cashapp/hermit.git", nil},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, GitCredentialEnv(test.token, test.matcher)(test.uri))
+		})
+	}
+}
+
+func TestGitCredentialEnvDoesNotLeakTokenIntoURI(t *testing.T) {
+	uri := "https://github.com/cashapp/hermit.git"
+	env := GitCredentialEnv("ghp_supersecret", matchAll)(uri)
+	assert.NotZero(t, env)
+	for _, v := range env {
+		assert.False(t, strings.Contains(v, "ghp_supersecret"),
+			"raw token must be base64 encoded, not embedded verbatim: %s", v)
+	}
+}

--- a/sources/git.go
+++ b/sources/git.go
@@ -17,28 +17,30 @@ type GitSource struct {
 	sourceDir string
 	path      string
 	runner    util.CommandRunner
+	env       []string
 }
 
-// NewGitSource returns a new GitSource
-func NewGitSource(uri, sourceDir string, runner util.CommandRunner) *GitSource {
+// NewGitSource returns a new GitSource. env carries any credentials required to
+// authenticate against uri.
+func NewGitSource(uri, sourceDir string, runner util.CommandRunner, env []string) *GitSource {
 	key := util.Hash(uri)
 	path := filepath.Join(sourceDir, key)
 	return &GitSource{&uriFS{
 		uri: uri,
 		FS:  os.DirFS(path),
-	}, sourceDir, path, runner}
+	}, sourceDir, path, runner, env}
 }
 
 func (s *GitSource) Sync(p *ui.UI, force bool) (bool, error) {
 	info, _ := os.Stat(s.path)
-	task := p.Task(s.fs.uri)
+	task := p.Task(util.RedactCredentials(s.fs.uri))
 	if info == nil || force || time.Since(info.ModTime()) >= SyncFrequency {
 		err := s.ensureSourcesDirExists()
 		if err != nil {
 			return false, errors.WithStack(err)
 		}
 
-		err = syncGit(task, s.sourceDir, s.fs.uri, s.path, s.runner)
+		err = syncGit(task, s.sourceDir, s.fs.uri, s.path, s.runner, s.env)
 		// If the sync failed while the repo had already been cloned, log a warning
 		// If the repo has not yet been cloned, fail.
 		if err != nil {
@@ -70,7 +72,7 @@ func (s *GitSource) ensureSourcesDirExists() error {
 }
 
 // Atomically clone git repo.
-func syncGit(b *ui.Task, dir, source, finalDest string, runner util.CommandRunner) (err error) {
+func syncGit(b *ui.Task, dir, source, finalDest string, runner util.CommandRunner, env []string) (err error) {
 	task := b.SubProgress("sync", 1)
 	defer func() {
 		task.Done()
@@ -82,7 +84,7 @@ func syncGit(b *ui.Task, dir, source, finalDest string, runner util.CommandRunne
 	// First, if a git repo exists, just pull.
 	info, _ := os.Stat(filepath.Join(finalDest, ".git"))
 	if info != nil {
-		err = runner.RunInDir(b, finalDest, util.GitArgs("pull")...)
+		err = runner.RunInDir(b, finalDest, env, util.GitArgs("pull")...)
 		if err == nil {
 			return nil
 		}
@@ -94,7 +96,7 @@ func syncGit(b *ui.Task, dir, source, finalDest string, runner util.CommandRunne
 		return errors.WithStack(err)
 	}
 	defer os.RemoveAll(dest)
-	if err = runner.RunInDir(b, dest, util.GitArgs("clone", "--depth=1", "--", source, dest)...); err != nil {
+	if err = runner.RunInDir(b, dest, env, util.GitArgs("clone", "--depth=1", "--", source, dest)...); err != nil {
 		return errors.WithStack(err)
 	}
 	_ = os.RemoveAll(finalDest)

--- a/sources/git_test.go
+++ b/sources/git_test.go
@@ -14,14 +14,14 @@ type FailingGit struct {
 	err error
 }
 
-func (f *FailingGit) RunInDir(_ *ui.Task, _ string, _ ...string) error {
+func (f *FailingGit) RunInDir(_ *ui.Task, _ string, _ []string, _ ...string) error {
 	return f.err
 }
 
 func TestGitDoesNotRemoveSourceAfterSyncFailure(t *testing.T) {
 	git := &FailingGit{}
 	sourceDir := t.TempDir()
-	source := sources.NewGitSource("git://test", sourceDir, git)
+	source := sources.NewGitSource("git://test", sourceDir, git, nil)
 
 	// Create the initial directory for sources by successfully syncing
 	u, _ := ui.NewForTesting()

--- a/sources/sources.go
+++ b/sources/sources.go
@@ -85,24 +85,15 @@ func (s *Sources) Sync(p *ui.UI, force bool) error {
 	return nil
 }
 
-// URLRewriter is a function that can transform a source URI
-type URLRewriter func(uri string) (string, error)
+// GitCredentials returns environment variables authenticating git operations
+// against uri, or nil if no credentials apply to it.
+type GitCredentials func(uri string) []string
 
 // ForURIs returns Source instances for given uri strings
-func ForURIs(b *ui.UI, dir, env string, uris []string, rewriters ...URLRewriter) (*Sources, error) {
+func ForURIs(b *ui.UI, dir, env string, uris []string, credentials ...GitCredentials) (*Sources, error) {
 	sources := make([]Source, 0, len(uris))
 	for _, uri := range uris {
-		// Apply each rewriter in sequence
-		transformedURI := uri
-		for _, rewrite := range rewriters {
-			rewritten, err := rewrite(transformedURI)
-			if err != nil {
-				return nil, errors.WithStack(err)
-			}
-			transformedURI = rewritten
-		}
-
-		s, err := getSource(b, transformedURI, dir, env)
+		s, err := getSource(b, uri, dir, env, credentials)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
@@ -116,15 +107,21 @@ func ForURIs(b *ui.UI, dir, env string, uris []string, rewriters ...URLRewriter)
 	}, nil
 }
 
-func getSource(b *ui.UI, source, dir, env string) (Source, error) {
-	task := b.Task(source)
+func getSource(b *ui.UI, source, dir, env string, credentials []GitCredentials) (Source, error) {
+	task := b.Task(util.RedactCredentials(source))
 	defer task.Done()
 
 	if strings.HasSuffix(source, ".git") {
 		if err := util.ValidateGitURL(source); err != nil {
 			return nil, errors.WithStack(err)
 		}
-		return NewGitSource(source, dir, &util.RealCommandRunner{}), nil
+		var gitEnv []string
+		for _, creds := range credentials {
+			if gitEnv = creds(source); len(gitEnv) > 0 {
+				break
+			}
+		}
+		return NewGitSource(source, dir, &util.RealCommandRunner{}, gitEnv), nil
 	}
 
 	uri, err := url.Parse(source)

--- a/sources/sources_test.go
+++ b/sources/sources_test.go
@@ -1,127 +1,75 @@
 package sources
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
-	"github.com/cashapp/hermit/errors"
 	"github.com/cashapp/hermit/github"
 	"github.com/cashapp/hermit/ui"
 )
 
-func TestGitHubTokenRewriter(t *testing.T) {
-	tests := []struct {
-		name    string
-		uri     string
-		token   string
-		pattern string
-		want    string
-	}{
-		{
-			name:    "matching github repo",
-			uri:     "https://github.com/owner/repo.git",
-			token:   "secret-token",
-			pattern: "owner/*",
-			want:    "https://x-access-token:secret-token@github.com/owner/repo.git",
-		},
-		{
-			name:    "non-matching github repo",
-			uri:     "https://github.com/other/repo.git",
-			token:   "secret-token",
-			pattern: "owner/*",
-			want:    "https://github.com/other/repo.git",
-		},
-		{
-			name:    "non-github url",
-			uri:     "https://example.com/repo.git",
-			token:   "secret-token",
-			pattern: "*/*",
-			want:    "https://example.com/repo.git",
-		},
-		{
-			name:    "git protocol url",
-			uri:     "git@github.com:owner/repo.git",
-			token:   "secret-token",
-			pattern: "owner/*",
-			want:    "git@github.com:owner/repo.git",
-		},
-		{
-			name:    "git protocol url with matching pattern",
-			uri:     "git@github.com:owner/repo.git",
-			token:   "secret-token",
-			pattern: "*/*",
-			want:    "git@github.com:owner/repo.git",
-		},
+func TestForURIsAttachesCredentialsWithoutRewritingURIs(t *testing.T) {
+	l, _ := ui.NewForTesting()
+
+	matcher, err := github.GlobRepoMatcher([]string{"owner/*"})
+	assert.NoError(t, err)
+	credentials := github.GitCredentialEnv("secret-token", matcher)
+
+	uris := []string{
+		"https://github.com/owner/repo1.git",
+		"https://github.com/other/repo2.git",
+		"git@github.com:owner/repo3.git",
+	}
+	sources, err := ForURIs(l, "testdir", "testenv", uris, credentials)
+	assert.NoError(t, err)
+	assert.Equal(t, len(uris), len(sources.sources))
+
+	for i, uri := range uris {
+		assert.Equal(t, uri, sources.sources[i].URI(),
+			"source URI must be left untouched so the token cannot leak through it")
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			matcher, err := github.GlobRepoMatcher([]string{tt.pattern})
-			assert.NoError(t, err)
+	matched, ok := sources.sources[0].(*GitSource)
+	assert.True(t, ok)
+	assert.NotZero(t, matched.env, "matching repo should carry credentials out of band")
 
-			rewriter := github.AuthenticatedURLRewriter(tt.token, matcher)
-			result, err := rewriter(tt.uri)
+	unmatched, ok := sources.sources[1].(*GitSource)
+	assert.True(t, ok)
+	assert.Zero(t, unmatched.env, "non-matching repo should carry no credentials")
+}
 
-			assert.NoError(t, err)
-			assert.Equal(t, tt.want, result)
-		})
+func TestForURIsNeverPlacesTokenInSourceURI(t *testing.T) {
+	l, _ := ui.NewForTesting()
+
+	matcher, err := github.GlobRepoMatcher([]string{"*/*"})
+	assert.NoError(t, err)
+
+	sources, err := ForURIs(l, "testdir", "testenv",
+		[]string{"https://github.com/owner/repo.git"},
+		github.GitCredentialEnv("ghp_supersecret", matcher))
+	assert.NoError(t, err)
+
+	for _, source := range sources.Sources() {
+		assert.False(t, strings.Contains(source, "ghp_supersecret"),
+			"token leaked into source URI: %s", source)
 	}
 }
 
-// TestForURIsIntegration tests the integration of ForURIs with rewriters
-func TestForURIsIntegration(t *testing.T) {
+func TestForURIsRejectsGitRemoteHelperURI(t *testing.T) {
 	l, _ := ui.NewForTesting()
 
-	t.Run("successful rewriting", func(t *testing.T) {
-		matcher, err := github.GlobRepoMatcher([]string{"owner/*"})
-		assert.NoError(t, err)
-		rewriter := github.AuthenticatedURLRewriter("test-token", matcher)
+	_, err := ForURIs(l, "testdir", "testenv", []string{"zzq::x.git"})
 
-		uris := []string{
-			"https://github.com/owner/repo1.git",
-			"https://github.com/other/repo2.git",
-			"git@github.com:owner/repo3.git",
-		}
-		sources, err := ForURIs(l, "testdir", "testenv", uris, rewriter)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "remote helpers are not supported")
+}
 
-		assert.NoError(t, err)
-		assert.Equal(t, len(uris), len(sources.sources))
+func TestForURIsRejectsUnsupportedScheme(t *testing.T) {
+	l, _ := ui.NewForTesting()
 
-		// Verify the sources were created with appropriate URIs
-		// First URI should be rewritten with token, others should remain unchanged
-		assert.Contains(t, sources.sources[0].URI(), "x-access-token:test-token@github.com")
-		assert.Equal(t, uris[1], sources.sources[1].URI())
-		assert.Equal(t, uris[2], sources.sources[2].URI())
-	})
+	_, err := ForURIs(l, "testdir", "testenv", []string{"invalid://not-a-valid-source"})
 
-	t.Run("rewriter error", func(t *testing.T) {
-		errorRewriter := func(uri string) (string, error) {
-			return "", errors.New("rewriter error")
-		}
-
-		uris := []string{"https://github.com/owner/repo.git"}
-		_, err := ForURIs(l, "testdir", "testenv", uris, errorRewriter)
-
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "rewriter error")
-	})
-
-	t.Run("git remote helper uri", func(t *testing.T) {
-		_, err := ForURIs(l, "testdir", "testenv", []string{"zzq::x.git"})
-
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "remote helpers are not supported")
-	})
-
-	t.Run("invalid rewritten uri", func(t *testing.T) {
-		invalidRewriter := func(uri string) (string, error) {
-			return "invalid://not-a-valid-source", nil
-		}
-
-		uris := []string{"https://github.com/owner/repo.git"}
-		_, err := ForURIs(l, "testdir", "testenv", uris, invalidRewriter)
-
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "unsupported source")
-	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported source")
 }

--- a/util/git.go
+++ b/util/git.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"regexp"
 	"slices"
 	"strings"
@@ -22,6 +23,21 @@ func GitArgs(args ...string) []string {
 		out = append(out, "-c", "protocol."+scheme+".allow=always")
 	}
 	return append(out, args...)
+}
+
+// GitConfigEnv passes git config via the environment (git >= 2.31), keeping
+// secrets out of process arguments and out of the repository's .git/config.
+func GitConfigEnv(pairs ...string) []string {
+	if len(pairs)%2 != 0 {
+		panic("GitConfigEnv requires an even number of arguments")
+	}
+	env := []string{fmt.Sprintf("GIT_CONFIG_COUNT=%d", len(pairs)/2)}
+	for i := 0; i < len(pairs); i += 2 {
+		env = append(env,
+			fmt.Sprintf("GIT_CONFIG_KEY_%d=%s", i/2, pairs[i]),
+			fmt.Sprintf("GIT_CONFIG_VALUE_%d=%s", i/2, pairs[i+1]))
+	}
+	return env
 }
 
 // ValidateGitURL rejects URLs selecting a transport Hermit does not support, and

--- a/util/redact.go
+++ b/util/redact.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"regexp"
+	"strings"
+)
+
+const redactedPlaceholder = "****"
+
+var urlCredentialsRe = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.\-]*://)([^/?#@\s]+)@`)
+
+// RedactCredentials masks userinfo in any URL appearing in s, so that credentials
+// in hand-written source URLs are not written to logs, errors or the terminal.
+func RedactCredentials(s string) string {
+	return urlCredentialsRe.ReplaceAllStringFunc(s, func(match string) string {
+		groups := urlCredentialsRe.FindStringSubmatch(match)
+		scheme, userinfo := groups[1], groups[2]
+		if i := strings.IndexByte(userinfo, ':'); i >= 0 {
+			return scheme + userinfo[:i] + ":" + redactedPlaceholder + "@"
+		}
+		return scheme + redactedPlaceholder + "@"
+	})
+}

--- a/util/redact_test.go
+++ b/util/redact_test.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestRedactCredentials(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"NoCredentials", "https://github.com/cashapp/hermit.git", "https://github.com/cashapp/hermit.git"},
+		{"UserAndPassword",
+			"https://x-access-token:ghp_secret@github.com/cashapp/hermit.git",
+			"https://x-access-token:****@github.com/cashapp/hermit.git"},
+		{"TokenOnly", "https://ghp_secret@github.com/o/r.git", "https://****@github.com/o/r.git"},
+		{"EmptyPassword", "https://user:@github.com/o/r.git", "https://user:****@github.com/o/r.git"},
+		{"WithinCommandLine",
+			"git clone -- https://x-access-token:ghp_secret@github.com/o/r.git /tmp/x failed",
+			"git clone -- https://x-access-token:****@github.com/o/r.git /tmp/x failed"},
+		{"MultipleURLs",
+			"https://a:b@host/x https://c:d@host/y",
+			"https://a:****@host/x https://c:****@host/y"},
+		{"NonHTTPScheme", "ssh://git:secret@github.com/o/r.git", "ssh://git:****@github.com/o/r.git"},
+		{"SCPStyleUnchanged", "git@github.com:cashapp/hermit.git", "git@github.com:cashapp/hermit.git"},
+		{"EmailInMessageUnchanged", "contact user@example.com for access", "contact user@example.com for access"},
+		{"PathAfterHostUnchanged", "https://github.com/o/r@v1.git", "https://github.com/o/r@v1.git"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, RedactCredentials(test.input))
+		})
+	}
+}

--- a/util/run.go
+++ b/util/run.go
@@ -3,6 +3,7 @@ package util
 import (
 	"bytes"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -14,15 +15,16 @@ import (
 
 // CommandRunner abstracts how we run command in a given directory
 type CommandRunner interface {
-	// RunInDir runs a command in the given directory.
-	RunInDir(log *ui.Task, dir string, args ...string) error
+	// RunInDir runs a command in the given directory, with env appended to the
+	// inherited environment.
+	RunInDir(log *ui.Task, dir string, env []string, args ...string) error
 }
 
 // RealCommandRunner actually calls command
 type RealCommandRunner struct{}
 
-func (g *RealCommandRunner) RunInDir(task *ui.Task, dir string, commands ...string) error {
-	return errors.WithStack(RunInDir(task, dir, commands...))
+func (g *RealCommandRunner) RunInDir(task *ui.Task, dir string, env []string, commands ...string) error {
+	return errors.WithStack(RunInDirWithEnv(task, dir, env, commands...))
 }
 
 // Run a command, outputting to stdout and stderr.
@@ -32,14 +34,14 @@ func Run(log *ui.Task, args ...string) error {
 
 // Capture runs a command, returning combined stdout and stderr.
 func Capture(log ui.Logger, args ...string) ([]byte, error) {
-	log.Debugf("%s", shellquote.Join(args...))
+	log.Debugf("%s", RedactCredentials(shellquote.Join(args...)))
 	cmd := exec.Command(args[0], args[1:]...) //nolint:gosec,noctx
 	return captureOutput(log, cmd)
 }
 
 // CaptureInDir runs a command in the given dir, returning combined stdout and stderr.
 func CaptureInDir(log ui.Logger, dir string, args ...string) ([]byte, error) {
-	log.Debugf("%s", shellquote.Join(args...))
+	log.Debugf("%s", RedactCredentials(shellquote.Join(args...)))
 	cmd := exec.Command(args[0], args[1:]...) //nolint:gosec,noctx
 	cmd.Dir = dir
 	return captureOutput(log, cmd)
@@ -48,7 +50,9 @@ func CaptureInDir(log ui.Logger, dir string, args ...string) ([]byte, error) {
 func captureOutput(log ui.Logger, cmd *exec.Cmd) ([]byte, error) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return out, errors.Wrapf(err, "%s: %s", shellquote.Join(cmd.Args...), strings.TrimSpace(string(out)))
+		return out, errors.Wrapf(err, "%s: %s",
+			RedactCredentials(shellquote.Join(cmd.Args...)),
+			RedactCredentials(strings.TrimSpace(string(out))))
 	}
 	_, _ = log.Write(out)
 	return out, nil
@@ -56,15 +60,24 @@ func captureOutput(log ui.Logger, cmd *exec.Cmd) ([]byte, error) {
 
 // RunInDir runs a command in the given directory.
 func RunInDir(log *ui.Task, dir string, args ...string) error {
+	return RunInDirWithEnv(log, dir, nil, args...)
+}
+
+// RunInDirWithEnv runs a command in the given directory, with env appended to
+// the inherited environment.
+func RunInDirWithEnv(log *ui.Task, dir string, env []string, args ...string) error {
 	cmd, out := Command(log, args...)
 	cmd.Dir = dir
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
 	err := cmd.Run()
 	if err != nil {
 		// log.Write() goes to debug, so only dump the logs at error if we haven't already.
 		if !log.WillLog(ui.LevelDebug) {
-			log.Errorf("%s", out.String())
+			log.Errorf("%s", RedactCredentials(out.String()))
 		}
-		return errors.Wrapf(err, "%s failed", shellquote.Join(args...))
+		return errors.Wrapf(err, "%s failed", RedactCredentials(shellquote.Join(args...)))
 	}
 	return nil
 }
@@ -75,7 +88,7 @@ func RunInDir(log *ui.Task, dir string, args ...string) error {
 // of the execution
 func Command(log *ui.Task, args ...string) (*exec.Cmd, *bytes.Buffer) {
 	log = log.SubTask("exec")
-	log.Debugf("%s", shellquote.Join(args...))
+	log.Debugf("%s", RedactCredentials(shellquote.Join(args...)))
 	b := &bytes.Buffer{}
 	w := io.MultiWriter(b, log)
 	cmd := exec.Command(args[0], args[1:]...) //nolint:gosec,noctx


### PR DESCRIPTION
The token was embedded in the source URL, so it reached every consumer
that treats that URL as an identifier: command lines in logs and error
messages, the UI task label, hermit status output, the source directory
hash, and remote.origin.url in the cloned repository's .git/config,
where it persisted indefinitely and was reused on every pull.

Pass it to git as an http.extraheader via GIT_CONFIG_* environment
variables instead. The environment keeps it out of argv as well as out
of .git/config, so all of those sinks close at once. Redacting URL
userinfo where commands and sources are displayed covers the remaining
case of credentials a user hand-writes into sources.

DX-26

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
