### PR TITLE
Avoid chmodding symlink targets during cleanup

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -771,6 +771,29 @@ EOF
 			`,
 		},
 		{
+			name:         "CleanPackagesDoesNotChmodSymlinkTargets",
+			preparations: prep{fixture("testenv1"), activate(".")},
+			script: `
+				target="$PWD/outside-target"
+				printf 'unchanged' > "$target"
+				chmod 600 "$target"
+
+				package_dir="$HERMIT_STATE_DIR/pkg/malicious-package"
+				mkdir -p "$package_dir"
+				ln -s "$target" "$package_dir/link"
+
+				hermit clean --packages
+
+				assert test ! -e "$package_dir"
+				assert test -e "$target"
+				case "$(uname -s)" in
+					Darwin) mode=$(stat -f '%Lp' "$target") ;;
+					*) mode=$(stat -c '%a' "$target") ;;
+				esac
+				assert test "$mode" = "600"
+			`,
+		},
+		{
 			name:         "InstallOnActivateEnsuresPackagesAreUnpacked",
 			preparations: prep{fixture("testenv-install-on-activate"), activate(".")},
 			script: `

--- a/state/state.go
+++ b/state/state.go
@@ -295,6 +295,11 @@ func (s *State) removeRecursive(b *ui.Task, dest string) error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
+		// Never chmod through symlinks: os.Chmod follows them, which would
+		// let a symlink alter the permissions of a file outside dest.
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
 		err = os.Chmod(path, info.Mode()|0o200) //nolint:gosec // TODO: Switch to use os.Root()
 
 		if errors.Is(err, os.ErrNotExist) {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -13,6 +13,28 @@ import (
 	"github.com/cashapp/hermit/ui"
 )
 
+func TestCleanPackagesDoesNotChmodSymlinkTargets(t *testing.T) {
+	fixture := NewStateTestFixture(t)
+	defer fixture.Clean()
+	state := fixture.State()
+
+	target := filepath.Join(t.TempDir(), "target")
+	assert.NoError(t, os.WriteFile(target, nil, 0600))
+
+	packageDir := filepath.Join(state.PkgDir(), "malicious-package")
+	assert.NoError(t, os.MkdirAll(packageDir, 0700))
+	assert.NoError(t, os.Symlink(target, filepath.Join(packageDir, "link")))
+
+	log, _ := ui.NewForTesting()
+	assert.NoError(t, state.CleanPackages(log))
+
+	_, err := os.Lstat(packageDir)
+	assert.True(t, os.IsNotExist(err), "package directory should be removed")
+	info, err := os.Stat(target)
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "symlink target permissions must not change")
+}
+
 func TestCacheAndUnpackDownloadsOnlyWhenNeeded(t *testing.T) {
 	calls := 0
 	fixture := NewStateTestFixture(t).


### PR DESCRIPTION
Prevents `removeRecursive` from following symlinks during its writable-permission walk. Without this guard, cleaning a package could widen permissions on a target outside the package tree.

Adds unit and CLI integration regression tests that verify cleanup removes the package while preserving the external target mode.

Fixes DX-31.