### PR TITLE
fix: reserve Hermit execution environment variables

### DIFF
--- a/envars/util.go
+++ b/envars/util.go
@@ -20,6 +20,13 @@ var validEnvKey = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 var reservedEnvKey = regexp.MustCompile(`^_?HERMIT_`)
 
+var reservedManifestEnvKeys = map[string]bool{
+	// These variables do not use Hermit's prefix, but Hermit's shell scripts
+	// and bootstrap consume them to select the binary to execute.
+	"ACTIVE_HERMIT":  true,
+	"XDG_CACHE_HOME": true,
+}
+
 // ValidateKey returns an error if key is not a valid POSIX environment
 // variable name. Hermit emits keys verbatim into shell scripts, so anything
 // outside this pattern is rejected to prevent shell command injection.
@@ -34,8 +41,8 @@ func ValidateManifestKey(key string) error {
 	if err := ValidateKey(key); err != nil {
 		return err
 	}
-	if reservedEnvKey.MatchString(key) {
-		return errors.Errorf("environment variable name %q is reserved by Hermit (names prefixed with HERMIT_ or _HERMIT_ cannot be set from a manifest)", key)
+	if reservedEnvKey.MatchString(key) || reservedManifestEnvKeys[key] {
+		return errors.Errorf("environment variable name %q is reserved by Hermit and cannot be set from a manifest", key)
 	}
 	return nil
 }

--- a/envars/util_test.go
+++ b/envars/util_test.go
@@ -131,7 +131,11 @@ func TestValidateKey(t *testing.T) {
 func TestEnvarsValidate(t *testing.T) {
 	assert.NoError(t, Envars{"FOO": "1", "BAR_2": "2"}.Validate())
 	assert.Error(t, Envars{"FOO": "1", "EVIL; touch /tmp/x; X": "v"}.Validate())
-	assert.NoError(t, Envars{"HERMIT_EXE": "/tmp/evil"}.Validate())
+	assert.NoError(t, Envars{
+		"HERMIT_EXE":     "/tmp/evil",
+		"ACTIVE_HERMIT":  "/tmp/evil",
+		"XDG_CACHE_HOME": "/tmp/evil",
+	}.Validate())
 }
 
 func TestValidateManifestKey(t *testing.T) {
@@ -142,7 +146,8 @@ func TestValidateManifestKey(t *testing.T) {
 	}{
 		{name: "Simple", key: "FOO", wantErr: false},
 		{name: "MentionsHermit", key: "MY_HERMIT_THING", wantErr: false},
-		{name: "ActiveHermit", key: "ACTIVE_HERMIT", wantErr: false},
+		{name: "ReservedActiveHermit", key: "ACTIVE_HERMIT", wantErr: true},
+		{name: "ReservedXDGCacheHome", key: "XDG_CACHE_HOME", wantErr: true},
 		{name: "ReservedExe", key: "HERMIT_EXE", wantErr: true},
 		{name: "ReservedDistURL", key: "HERMIT_DIST_URL", wantErr: true},
 		{name: "ReservedStateDir", key: "HERMIT_STATE_DIR", wantErr: true},
@@ -167,6 +172,8 @@ func TestEnvarsValidateManifest(t *testing.T) {
 	assert.NoError(t, Envars{"FOO": "1", "BAR_2": "2"}.ValidateManifest())
 	assert.Error(t, Envars{"FOO": "1", "HERMIT_EXE": "/tmp/evil"}.ValidateManifest())
 	assert.Error(t, Envars{"_HERMIT_OLD_PATH": "x"}.ValidateManifest())
+	assert.Error(t, Envars{"ACTIVE_HERMIT": "/tmp/evil"}.ValidateManifest())
+	assert.Error(t, Envars{"XDG_CACHE_HOME": "/tmp/evil"}.ValidateManifest())
 }
 
 func TestExpandDateTime(t *testing.T) {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -135,6 +135,24 @@ EOF
 			`,
 		},
 		{
+			// Regression test for DX-28: unprefixed variables consumed by
+			// Hermit's shell scripts and bootstrap must be reserved too.
+			name: "ManifestCannotSetHermitExecutionEnvars",
+			script: `
+				hermit init .
+				for name in ACTIVE_HERMIT XDG_CACHE_HOME; do
+				cat > bin/hermit.hcl <<EOF
+env = {
+  "$name": "/tmp/evil",
+}
+EOF
+					assert test "$(hermit validate env . >/dev/null 2>&1; echo $?)" != "0"
+				done
+				. bin/activate-hermit >/dev/null 2>&1 || true
+				assert test "${XDG_CACHE_HOME:-}" != "/tmp/evil"
+			`,
+		},
+		{
 			// Regression test for VULN-78247: RCE via an unvalidated git transport scheme.
 			name: "MaliciousGitSourceSchemeDoesNotExecute",
 			script: `


### PR DESCRIPTION
Manifest-controlled ACTIVE_HERMIT and XDG_CACHE_HOME can redirect Hermit to attacker-selected binaries, bypassing script verification. Reject both variables from manifests and cover the behavior in unit and shell integration tests.

Co-authored-by: Codex <noreply@openai.com>
