### PR TITLE
Harden source URL and archive parsing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Repository Instructions
+
+- Add integration tests for security fixes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -503,7 +503,7 @@ func extractPackageTarball(b *ui.Task, r io.Reader, dest string, strip int) erro
 				return err
 			}
 
-		case hdr.Typeflag&(tar.TypeLink|tar.TypeGNULongLink) != 0 && hdr.Linkname != "":
+		case (hdr.Typeflag == tar.TypeLink || hdr.Typeflag == tar.TypeGNULongLink) && hdr.Linkname != "":
 			// Convert hard links into symlinks so we don't have to track inodes later on during relocation.
 			src := filepath.Join(dest, hdr.Linkname) //nolint: gosec
 			rp, err := filepath.Rel(filepath.Dir(destFile), src)

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"archive/tar"
 	"archive/zip"
+	"bytes"
 	"compress/gzip"
 	"os"
 	"path/filepath"
@@ -15,6 +16,98 @@ import (
 	"github.com/cashapp/hermit/manifest"
 	"github.com/cashapp/hermit/ui"
 )
+
+func TestRegularTarEntryWithLinkname(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+
+	target := []byte("target content")
+	assert.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "target",
+		Mode:     0644,
+		Typeflag: tar.TypeReg,
+		Size:     int64(len(target)),
+	}))
+	_, err := tw.Write(target)
+	assert.NoError(t, err)
+
+	payload := []byte("regular file content")
+	assert.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "regular",
+		Mode:     0644,
+		Typeflag: tar.TypeReg,
+		Linkname: "target",
+		Size:     int64(len(payload)),
+	}))
+	_, err = tw.Write(payload)
+	assert.NoError(t, err)
+	assert.NoError(t, tw.Close())
+
+	p, _ := ui.NewForTesting()
+	dest := t.TempDir()
+	assert.NoError(t, extractPackageTarball(p.Task("extract"), bytes.NewReader(buf.Bytes()), dest, 0))
+
+	info, err := os.Lstat(filepath.Join(dest, "regular"))
+	assert.NoError(t, err)
+	assert.True(t, info.Mode().IsRegular())
+	contents, err := os.ReadFile(filepath.Join(dest, "regular"))
+	assert.NoError(t, err)
+	assert.Equal(t, payload, contents)
+}
+
+func TestExtractRegularTarEntryWithLinkname(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Cleanup(func() {
+		_ = makeWritable(tmpDir)
+	})
+
+	archivePath := filepath.Join(tmpDir, "regular-with-linkname.tar.gz")
+	f, err := os.Create(archivePath)
+	assert.NoError(t, err)
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+
+	target := []byte("target content")
+	assert.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "target",
+		Mode:     0644,
+		Typeflag: tar.TypeReg,
+		Size:     int64(len(target)),
+	}))
+	_, err = tw.Write(target)
+	assert.NoError(t, err)
+
+	payload := []byte("regular file content")
+	assert.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "regular",
+		Mode:     0644,
+		Typeflag: tar.TypeReg,
+		Linkname: "target",
+		Size:     int64(len(payload)),
+	}))
+	_, err = tw.Write(payload)
+	assert.NoError(t, err)
+	assert.NoError(t, tw.Close())
+	assert.NoError(t, gw.Close())
+	assert.NoError(t, f.Close())
+
+	p, _ := ui.NewForTesting()
+	dest := filepath.Join(tmpDir, "extracted")
+	finalise, err := Extract(
+		p.Task("extract"),
+		archivePath,
+		&manifest.Package{Dest: dest, Source: filepath.Base(archivePath)},
+	)
+	assert.NoError(t, err)
+	assert.NoError(t, finalise())
+
+	info, err := os.Lstat(filepath.Join(dest, "regular"))
+	assert.NoError(t, err)
+	assert.True(t, info.Mode().IsRegular())
+	contents, err := os.ReadFile(filepath.Join(dest, "regular"))
+	assert.NoError(t, err)
+	assert.Equal(t, payload, contents)
+}
 
 func makeWritable(path string) error {
 	return filepath.Walk(path, func(path string, info os.FileInfo, err error) error {

--- a/cache/github.go
+++ b/cache/github.go
@@ -14,7 +14,7 @@ import (
 )
 
 // matches: https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{ASSET}
-var githubRe = regexp.MustCompile(`^https\://github.com/([^/]+)/([^/]+)/releases/download/([^/]+)/([^/]+)$`)
+var githubRe = regexp.MustCompile(`^https\://github\.com/([^/]+)/([^/]+)/releases/download/([^/]+)/([^/]+)$`)
 
 // GitHubSourceSelector can download private release assets from GitHub using an authenticated GitHub client.
 func GitHubSourceSelector(getSource PackageSourceSelector, ghclient *github.Client, match github.RepoMatcher) PackageSourceSelector {

--- a/cache/github_test.go
+++ b/cache/github_test.go
@@ -1,0 +1,15 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestGetGitHubReleaseInfoRequiresGitHubHost(t *testing.T) {
+	_, ok := getGitHubReleaseInfo("https://github.com/owner/repo/releases/download/v1.0.0/tool.tar.gz")
+	assert.True(t, ok)
+
+	_, ok = getGitHubReleaseInfo("https://githubXcom/owner/repo/releases/download/v1.0.0/tool.tar.gz")
+	assert.False(t, ok)
+}

--- a/sources/sources.go
+++ b/sources/sources.go
@@ -142,7 +142,11 @@ func getSource(b *ui.UI, source, dir, env string) (Source, error) {
 			task.Warnf("%s does not contain a path", uri)
 			return nil, nil
 		}
-		checkDir = filepath.Join(env, uri.Path)
+		cleanPath := filepath.Clean(strings.TrimLeft(uri.Path, "/\\"))
+		if cleanPath == ".." || strings.HasPrefix(cleanPath, ".."+string(filepath.Separator)) {
+			return nil, errors.Errorf("env source %q escapes the environment root", source)
+		}
+		checkDir = filepath.Join(env, cleanPath)
 		candidate = os.DirFS(checkDir)
 
 	case "file":

--- a/sources/sources_test.go
+++ b/sources/sources_test.go
@@ -1,6 +1,8 @@
 package sources
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
@@ -8,6 +10,25 @@ import (
 	"github.com/cashapp/hermit/github"
 	"github.com/cashapp/hermit/ui"
 )
+
+func TestEnvSourceRejectsPathTraversal(t *testing.T) {
+	root := t.TempDir()
+	env := filepath.Join(root, "env")
+	outside := filepath.Join(root, "outside")
+	assert.NoError(t, os.MkdirAll(env, 0750))
+	assert.NoError(t, os.MkdirAll(outside, 0750))
+
+	for _, uri := range []string{
+		"env:///../outside",
+		"env:///%2e%2e/outside",
+	} {
+		t.Run(uri, func(t *testing.T) {
+			ui, _ := ui.NewForTesting()
+			_, err := ForURIs(ui, filepath.Join(root, "state"), env, []string{uri})
+			assert.Error(t, err)
+		})
+	}
+}
 
 func TestGitHubTokenRewriter(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Fixes DX-35.

Rejects `env://` paths that escape the environment root, prevents regular tar entries with stray link names from being converted into symlinks, and restricts private GitHub release detection to the real `github.com` host. These checks prevent out-of-root manifest loading and preserve archive contents and source-selection behavior.

Adds focused regressions plus an end-to-end archive extraction test for the security-sensitive behavior, and documents that security fixes require integration coverage.