### PR TITLE
Fix Fish activation quoting vulnerability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           mkdir build testenv
           ./bin/go build -o ./build/hermit ./cmd/hermit
       - name: Install shells
-        run: sudo apt-get install zsh
+        run: sudo apt-get install fish zsh
       - name: Run Go Integration Tests
         run: ./bin/go test -tags integration -v ./integration
       - name: Run Shellspec Integration Tests

--- a/integration/fish_test.go
+++ b/integration/fish_test.go
@@ -1,0 +1,75 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestFishActivationEscapesTrailingBackslash(t *testing.T) {
+	fish, err := exec.LookPath("fish")
+	assert.NoError(t, err)
+
+	environ := buildAndInjectHermit(t, buildEnviron(t))
+	stateDir := filepath.Join(t.TempDir(), "state")
+	userConfigFile := filepath.Join(t.TempDir(), ".hermit.hcl")
+	err = os.WriteFile(userConfigFile, nil, 0600)
+	assert.NoError(t, err)
+	environ = append(environ,
+		"HERMIT_USER_CONFIG="+userConfigFile,
+		"HERMIT_STATE_DIR="+stateDir,
+	)
+
+	var hermitExe string
+	for _, entry := range environ {
+		if strings.HasPrefix(entry, "HERMIT_EXE=") {
+			hermitExe = strings.TrimPrefix(entry, "HERMIT_EXE=")
+			break
+		}
+	}
+	if hermitExe == "" {
+		t.Fatal("HERMIT_EXE not found in integration test environment")
+	}
+
+	dir := t.TempDir()
+	cmd := exec.Command(hermitExe, "init", "--no-git", ".")
+	cmd.Dir = dir
+	cmd.Env = environ
+	output, err := cmd.CombinedOutput()
+	assert.NoError(t, err, "%s", output)
+
+	// Regression test for DX-30: a trailing backslash must not escape the
+	// closing quote and allow the following environment value to execute.
+	config := `env = {
+  "AAA": "\\",
+  "AAB": ";touch RCE.txt; #",
+}
+`
+	err = os.WriteFile(filepath.Join(dir, "bin", "hermit.hcl"), []byte(config), 0600)
+	assert.NoError(t, err)
+
+	cmd = exec.Command(fish, "--no-config", "-c", `
+bin/hermit activate . | source
+printf '%s' "$AAA" > AAA.txt
+printf '%s' "$AAB" > AAB.txt
+`)
+	cmd.Dir = dir
+	cmd.Env = environ
+	output, err = cmd.CombinedOutput()
+	assert.NoError(t, err, "%s", output)
+
+	aaa, err := os.ReadFile(filepath.Join(dir, "AAA.txt"))
+	assert.NoError(t, err)
+	assert.Equal(t, `\`, string(aaa))
+	aab, err := os.ReadFile(filepath.Join(dir, "AAB.txt"))
+	assert.NoError(t, err)
+	assert.Equal(t, `;touch RCE.txt; #`, string(aab))
+	_, err = os.Stat(filepath.Join(dir, "RCE.txt"))
+	assert.True(t, os.IsNotExist(err), "payload created RCE.txt")
+}

--- a/shell/activate_template_test.go
+++ b/shell/activate_template_test.go
@@ -122,3 +122,28 @@ func TestFishActivationScriptQuotesPathsWithSpaces(t *testing.T) {
 		t.Fatalf("generated fish script still contains unquoted HERMIT_ENV assignment:\n%s", script)
 	}
 }
+
+func TestFishEscapesBackslashesInValues(t *testing.T) {
+	config := ActivationConfig{
+		Root:   `/tmp/hermit\`,
+		Prompt: "none",
+		Env: envars.Envars{
+			"AAA": `\`,
+			"AAB": `;touch /tmp/pwned; #`,
+		},
+	}
+
+	var out bytes.Buffer
+	err := (&Fish{}).ActivationScript(&out, config)
+	assert.NoError(t, err)
+	assert.Contains(t, out.String(), `set -gx HERMIT_ENV '/tmp/hermit\\'`)
+	assert.Contains(t, out.String(), `set -gx AAA '\\'`)
+	assert.Contains(t, out.String(), `set -gx AAB ';touch /tmp/pwned; #'`)
+	assert.NotContains(t, out.String(), `set -gx AAA '\'`)
+
+	out.Reset()
+	err = (&Fish{}).ApplyEnvars(&out, config.Env)
+	assert.NoError(t, err)
+	assert.Contains(t, out.String(), `set -gx AAA '\\'`)
+	assert.NotContains(t, out.String(), `set -gx AAA '\'`)
+}

--- a/shell/files/activate.tmpl.fish
+++ b/shell/files/activate.tmpl.fish
@@ -1,6 +1,6 @@
 # Hermit {{.Shell}} activation script
 
-set -gx HERMIT_ENV {{ .Root | Quote }}
+set -gx HERMIT_ENV {{ .Root | FishQuote }}
 
 if set -q ACTIVE_HERMIT
     if test "$ACTIVE_HERMIT" = "$HERMIT_ENV"
@@ -18,7 +18,7 @@ if set -q ACTIVE_HERMIT
 end
 
 {{ range $ENV_NAME, $ENV_VALUE := .Env }}
-set -gx {{ $ENV_NAME }} {{ $ENV_VALUE | Quote }}
+set -gx {{ $ENV_NAME }} {{ $ENV_VALUE | FishQuote }}
 {{- end }}
 
 function _hermit_deactivate

--- a/shell/fish.go
+++ b/shell/fish.go
@@ -18,7 +18,7 @@ var (
 	fishActivationScript     string
 	fishActivationScriptTmpl = template.Must(
 		template.New("activation").
-			Funcs(template.FuncMap{"Quote": Quote}).
+			Funcs(template.FuncMap{"FishQuote": FishQuote}).
 			Parse(fishActivationScript),
 	)
 )
@@ -55,7 +55,7 @@ func (sh *Fish) ApplyEnvars(w io.Writer, env envars.Envars) error {
 		if value == "" {
 			fmt.Fprintf(w, "set -e %s\n", key)
 		} else {
-			fmt.Fprintf(w, "set -gx %s %s\n", key, Quote(value))
+			fmt.Fprintf(w, "set -gx %s %s\n", key, FishQuote(value))
 		}
 	}
 	return nil

--- a/shell/quote.go
+++ b/shell/quote.go
@@ -71,3 +71,13 @@ func Quote(word string) string {
 	}
 	return buf.String()
 }
+
+// FishQuote returns a word quoted with single-quotes for consumption by Fish.
+//
+// Unlike POSIX shells, Fish treats backslash as an escape character inside
+// single-quotes, so both backslashes and single-quotes must be escaped.
+func FishQuote(word string) string {
+	word = strings.ReplaceAll(word, `\`, `\\`)
+	word = strings.ReplaceAll(word, `'`, `\'`)
+	return `'` + word + `'`
+}

--- a/shell/quote_test.go
+++ b/shell/quote_test.go
@@ -24,6 +24,22 @@ func TestShellQuote(t *testing.T) {
 	}
 }
 
+func TestFishQuote(t *testing.T) {
+	tests := []struct {
+		original string
+		quoted   string
+	}{
+		{``, `''`},
+		{`=test`, `'=test'`},
+		{`back\slash`, `'back\\slash'`},
+		{`trailing\`, `'trailing\\'`},
+		{`single'quote`, `'single\'quote'`},
+	}
+	for _, test := range tests {
+		assert.Equal(t, test.quoted, FishQuote(test.original))
+	}
+}
+
 func TestEnvName(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Fish treats backslashes as escapes inside single-quoted strings, unlike POSIX shells. A trailing backslash could therefore escape the closing quote and allow a following environment value to execute as Fish code. Use Fish-specific quoting and cover the exploit with unit and real-shell integration tests.

Co-authored-by: Codex <noreply@openai.com>
