### PR TITLE
fix: redact credentials from logs and errors

### DIFF
--- a/app/init_cmd.go
+++ b/app/init_cmd.go
@@ -3,14 +3,15 @@ package app
 import (
 	"github.com/cashapp/hermit"
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/ui"
 )
 
 type initCmd struct {
-	Git     *bool    `negatable:"" help:"Enable Hermit's automatic management of Git'"`
-	Idea    bool     `negatable:"" help:"Enable Hermit's automatic addition of its IntelliJ IDEA plugin"`
-	Sources []string `help:"Sources to sync package manifests from."`
-	Dir     string   `arg:"" help:"Directory to create environment in (${default})." default:"${env}" predictor:"dir"`
+	Git     *bool        `negatable:"" help:"Enable Hermit's automatic management of Git'"`
+	Idea    bool         `negatable:"" help:"Enable Hermit's automatic addition of its IntelliJ IDEA plugin"`
+	Sources []redact.URL `help:"Sources to sync package manifests from."`
+	Dir     string       `arg:"" help:"Directory to create environment in (${default})." default:"${env}" predictor:"dir"`
 }
 
 func (i *initCmd) Run(w *ui.UI, config Config, userConfig UserConfig) error {

--- a/app/log_test.go
+++ b/app/log_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cashapp/hermit/cache"
 	"github.com/cashapp/hermit/hermittest"
 	"github.com/cashapp/hermit/manifest"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/ui"
 )
 
@@ -125,7 +126,7 @@ func testLogsFor(
 	err = expected.Execute(&tbuf, state{
 		Source: uri,
 		State:  f.State.Root(),
-		Cache:  filepath.Join(f.State.Root(), "cache", cache.BasePath("", uri)),
+		Cache:  filepath.Join(f.State.Root(), "cache", cache.BasePath("", redact.URL(uri))),
 		Env:    f.Env.EnvDir(),
 		Bin:    f.Env.BinDir(),
 	})

--- a/app/main.go
+++ b/app/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cashapp/hermit"
 	"github.com/cashapp/hermit/cache"
 	"github.com/cashapp/hermit/github"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/sources"
 	"github.com/cashapp/hermit/state"
 	"github.com/cashapp/hermit/ui"
@@ -172,9 +173,9 @@ func Main(config Config) {
 		cli = &unactivated{cliBase: common}
 	}
 
-	githubToken := os.Getenv("HERMIT_GITHUB_TOKEN")
+	githubToken := redact.Secret(os.Getenv("HERMIT_GITHUB_TOKEN"))
 	if githubToken == "" {
-		githubToken = os.Getenv("GITHUB_TOKEN")
+		githubToken = redact.Secret(os.Getenv("GITHUB_TOKEN"))
 		p.Tracef("GitHub token set from GITHUB_TOKEN")
 	} else {
 		p.Tracef("GitHub token set from HERMIT_GITHUB_TOKEN")

--- a/app/validate_source_cmd.go
+++ b/app/validate_source_cmd.go
@@ -8,13 +8,14 @@ import (
 	"github.com/cashapp/hermit/errors"
 	"github.com/cashapp/hermit/manifest"
 	"github.com/cashapp/hermit/platform"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/sources"
 	"github.com/cashapp/hermit/state"
 	"github.com/cashapp/hermit/ui"
 )
 
 type validateSourceCmd struct {
-	Source string `arg:"" optional:"" name:"source" help:"The manifest source to validate."`
+	Source redact.URL `arg:"" optional:"" name:"source" help:"The manifest source to validate."`
 }
 
 func (g *validateSourceCmd) Run(l *ui.UI, env *hermit.Env, sta *state.State) error {
@@ -29,7 +30,7 @@ func (g *validateSourceCmd) Run(l *ui.UI, env *hermit.Env, sta *state.State) err
 			return errors.WithStack(err)
 		}
 	} else {
-		srcs, err = sources.ForURIs(l, sta.SourcesDir(), "", []string{g.Source})
+		srcs, err = sources.ForURIs(l, sta.SourcesDir(), "", []redact.URL{g.Source})
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -136,7 +136,7 @@ func Extract(b *ui.Task, source string, pkg *manifest.Package) (finalise func() 
 	r = io.NopCloser(io.TeeReader(r, task.ProgressWriter()))
 
 	if pkg.DontExtract {
-		return finalise, copyDirect(r, tmpDest, path.Base(pkg.Source))
+		return finalise, copyDirect(r, tmpDest, path.Base(pkg.Source.Reveal()))
 	}
 
 	// Archive is a single executable.
@@ -150,7 +150,7 @@ func Extract(b *ui.Task, source string, pkg *manifest.Package) (finalise func() 
 	case "application/x-mach-binary", "application/x-elf",
 		"application/x-executable", "application/x-sharedlib",
 		"text/x-shellscript":
-		return finalise, extractExecutable(r, tmpDest, path.Base(pkg.Source))
+		return finalise, extractExecutable(r, tmpDest, path.Base(pkg.Source.Reveal()))
 
 	case "application/x-tar":
 		return finalise, extractPackageTarball(task, r, tmpDest, pkg.Strip)

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/alecthomas/assert/v2"
 	"github.com/cashapp/hermit/manifest"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/ui"
 )
 
@@ -96,7 +97,7 @@ func TestExtractRegularTarEntryWithLinkname(t *testing.T) {
 	finalise, err := Extract(
 		p.Task("extract"),
 		archivePath,
-		&manifest.Package{Dest: dest, Source: filepath.Base(archivePath)},
+		&manifest.Package{Dest: dest, Source: redact.URL(filepath.Base(archivePath))},
 	)
 	assert.NoError(t, err)
 	assert.NoError(t, finalise())
@@ -149,7 +150,7 @@ func TestExtract(t *testing.T) {
 			finalise, err := Extract(
 				p.Task("extract"),
 				filepath.Join("testdata", test.file),
-				&manifest.Package{Dest: dest, Source: test.file},
+				&manifest.Package{Dest: dest, Source: redact.URL(test.file)},
 			)
 			assert.NoError(t, err)
 			assert.NoError(t, finalise())

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/ui"
 	"github.com/cashapp/hermit/util"
 )
@@ -24,9 +25,9 @@ type Cache struct {
 }
 
 // BasePath returns the subfolder in the cache path for the given file
-func BasePath(checksum, uri string) string {
-	hash := util.Hash(uri, checksum)
-	return filepath.Join(hash[:2], hash+"-"+filepath.Base(uri))
+func BasePath(checksum string, uri redact.URL) string {
+	hash := util.Hash(uri.Reveal(), checksum)
+	return filepath.Join(hash[:2], hash+"-"+filepath.Base(uri.Reveal()))
 }
 
 // Open or create a Cache at the given directory, using the given http client.
@@ -64,13 +65,13 @@ func (c *Cache) Root() string {
 }
 
 // Mkdir makes a directory for the given URI.
-func (c *Cache) Mkdir(uri string) (string, error) {
+func (c *Cache) Mkdir(uri redact.URL) (string, error) {
 	path := c.Path("", uri)
 	return path, os.MkdirAll(path, os.ModePerm) //nolint:gosec
 }
 
 // Create a new, empty, cache entry.
-func (c *Cache) Create(checksum, uri string) (*os.File, error) {
+func (c *Cache) Create(checksum string, uri redact.URL) (*os.File, error) {
 	path := c.Path(checksum, uri)
 	dir := filepath.Dir(path)
 	err := os.MkdirAll(dir, os.ModePerm) //nolint:gosec
@@ -81,7 +82,7 @@ func (c *Cache) Create(checksum, uri string) (*os.File, error) {
 }
 
 // OpenLocal opens a local cached copy of "uri", or errors.
-func (c *Cache) OpenLocal(checksum, uri string) (*os.File, error) {
+func (c *Cache) OpenLocal(checksum string, uri redact.URL) (*os.File, error) {
 	source, err := c.GetSource(c.httpClient, uri)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -92,7 +93,7 @@ func (c *Cache) OpenLocal(checksum, uri string) (*os.File, error) {
 // Open a local or remote artifact, transparently caching it. Subsequent accesses will use the cached copy.
 //
 // If checksum is present it must be the SHA256 hash of the downloaded artifact.
-func (c *Cache) Open(b *ui.Task, checksum, uri string, mirrors ...string) (*os.File, error) {
+func (c *Cache) Open(b *ui.Task, checksum string, uri redact.URL, mirrors ...redact.URL) (*os.File, error) {
 	cachePath := c.Path(checksum, uri)
 	_, err := os.Stat(cachePath)
 	if err == nil {
@@ -114,8 +115,8 @@ func (c *Cache) Open(b *ui.Task, checksum, uri string, mirrors ...string) (*os.F
 // Download a local or remote artifact, transparently caching it.
 //
 // If checksum is present it must be the SHA256 hash of the downloaded artifact.
-func (c *Cache) Download(b *ui.Task, checksum, uri string, mirrors ...string) (path string, etag string, actualChecksum string, err error) {
-	uris := append([]string{uri}, mirrors...)
+func (c *Cache) Download(b *ui.Task, checksum string, uri redact.URL, mirrors ...redact.URL) (path string, etag string, actualChecksum string, err error) {
+	uris := append([]redact.URL{uri}, mirrors...)
 	var lastError error
 	attempts := 3
 	for attempt := 1; attempt <= attempts; attempt++ {
@@ -133,9 +134,9 @@ func (c *Cache) Download(b *ui.Task, checksum, uri string, mirrors ...string) (p
 			b.Debugf("%s: %s", uri, err)
 		}
 		if lastError == nil {
-			return "", "", "", errors.Errorf("failed to download from any of %s", strings.Join(uris, ", "))
+			return "", "", "", errors.Errorf("failed to download from any of %s", joinURLs(uris))
 		}
-		msg := fmt.Sprintf("Failed to download any of %s on attempt %d/%d: %s", strings.Join(uris, ", "), attempt, attempts, lastError)
+		msg := fmt.Sprintf("Failed to download any of %s on attempt %d/%d: %s", joinURLs(uris), attempt, attempts, lastError)
 		if attempt < attempts {
 			msg = "Retrying. " + msg
 		}
@@ -152,8 +153,8 @@ func (c *Cache) Download(b *ui.Task, checksum, uri string, mirrors ...string) (p
 
 // ETag fetches the etag from given URI if available.
 // Otherwise an empty string is returned
-func (c *Cache) ETag(b *ui.Task, uri string, mirrors ...string) (etag string, err error) {
-	for _, uri := range append([]string{uri}, mirrors...) {
+func (c *Cache) ETag(b *ui.Task, uri redact.URL, mirrors ...redact.URL) (etag string, err error) {
+	for _, uri := range append([]redact.URL{uri}, mirrors...) {
 		source, err := c.GetSource(c.fastFailHTTPClient, uri)
 		if err != nil {
 			return "", errors.WithStack(err)
@@ -169,13 +170,13 @@ func (c *Cache) ETag(b *ui.Task, uri string, mirrors ...string) (etag string, er
 }
 
 // IsCached returns true if the URI is cached.
-func (c *Cache) IsCached(checksum, uri string) bool {
+func (c *Cache) IsCached(checksum string, uri redact.URL) bool {
 	_, err := os.Stat(c.Path(checksum, uri))
 	return err == nil
 }
 
 // Evict a file from the cache.
-func (c *Cache) Evict(b *ui.Task, checksum, uri string) error {
+func (c *Cache) Evict(b *ui.Task, checksum string, uri redact.URL) error {
 	b.SubTask("remove").Debugf("rm -rf %s", c.Path(checksum, uri))
 	err := os.RemoveAll(c.Path(checksum, uri))
 	if err != nil && !os.IsNotExist(err) {
@@ -190,20 +191,28 @@ func (c *Cache) Clean() error {
 }
 
 // Path to cached object.
-func (c *Cache) Path(checksum, uri string) string {
+func (c *Cache) Path(checksum string, uri redact.URL) string {
 	base := BasePath(checksum, uri)
 	return filepath.Join(c.root, base)
 }
 
+func joinURLs(uris []redact.URL) string {
+	display := make([]string, len(uris))
+	for i, uri := range uris {
+		display[i] = uri.String()
+	}
+	return strings.Join(display, ", ")
+}
+
 // UnavailableError returns 101 for the exit code.
 type UnavailableError struct {
-	URI string
+	URI redact.URL
 	Err error
 }
 
 // Error returns the error string for the unavailable error
 func (e *UnavailableError) Error() string {
-	msg := e.URI + " is unavailable"
+	msg := e.URI.String() + " is unavailable"
 	if e.Err != nil {
 		return fmt.Sprintf("%s: %v", msg, e.Err)
 	}

--- a/cache/cachew.go
+++ b/cache/cachew.go
@@ -3,13 +3,15 @@ package cache
 import (
 	"net/http"
 	"net/url"
+
+	"github.com/cashapp/hermit/redact"
 )
 
 // CachewSourceSelector wraps another PackageSourceSelector to redirect HTTP/HTTPS
 // downloads through a Cachew proxy server https://github.com/block/cachew.
 func CachewSourceSelector(getSource PackageSourceSelector, cachewURL string) PackageSourceSelector {
-	return func(client *http.Client, uri string) (PackageSource, error) {
-		u, err := url.Parse(uri)
+	return func(client *http.Client, uri redact.URL) (PackageSource, error) {
+		u, err := url.Parse(uri.Reveal())
 		if err != nil {
 			return getSource(client, uri)
 		}
@@ -25,6 +27,6 @@ func CachewSourceSelector(getSource PackageSourceSelector, cachewURL string) Pac
 			rewrittenURI += "?" + u.RawQuery
 		}
 
-		return HTTPSource(client, rewrittenURI), nil
+		return HTTPSource(client, redact.URL(rewrittenURI)), nil
 	}
 }

--- a/cache/cachew_test.go
+++ b/cache/cachew_test.go
@@ -3,11 +3,13 @@ package cache
 import (
 	"net/http"
 	"testing"
+
+	"github.com/cashapp/hermit/redact"
 )
 
 func TestCachewSourceSelector(t *testing.T) {
 	// Mock base selector that always returns a file source
-	baseSelector := func(client *http.Client, uri string) (PackageSource, error) {
+	baseSelector := func(client *http.Client, uri redact.URL) (PackageSource, error) {
 		return &fileSource{path: "/tmp/test"}, nil
 	}
 
@@ -54,7 +56,7 @@ func TestCachewSourceSelector(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			source, err := selector(nil, tt.inputURI)
+			source, err := selector(nil, redact.URL(tt.inputURI))
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -64,7 +66,7 @@ func TestCachewSourceSelector(t *testing.T) {
 				if !ok {
 					t.Fatalf("expected httpSource, got %T", source)
 				}
-				if httpSrc.url != tt.expectedURI {
+				if httpSrc.url != redact.URL(tt.expectedURI) {
 					t.Errorf("expected URL %s, got %s", tt.expectedURI, httpSrc.url)
 				}
 			} else {
@@ -82,14 +84,14 @@ func TestCachewSourceSelector(t *testing.T) {
 }
 
 func TestCachewSourceSelectorInvalidURL(t *testing.T) {
-	baseSelector := func(client *http.Client, uri string) (PackageSource, error) {
+	baseSelector := func(client *http.Client, uri redact.URL) (PackageSource, error) {
 		return &fileSource{path: "/tmp/fallback"}, nil
 	}
 
 	selector := CachewSourceSelector(baseSelector, "https://cachew.example.com")
 
 	// Test invalid URL - should fall back to base selector
-	source, err := selector(nil, "://invalid-url")
+	source, err := selector(nil, redact.URL("://invalid-url"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cache/git.go
+++ b/cache/git.go
@@ -6,12 +6,14 @@ import (
 	"strings"
 
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/ui"
 	"github.com/cashapp/hermit/util"
 )
 
 type gitSource struct {
-	URL string
+	URL    redact.URL
+	runner util.CommandRunner
 }
 
 func (s *gitSource) OpenLocal(c *Cache, checksum string) (*os.File, error) {
@@ -26,17 +28,17 @@ func (s *gitSource) Download(b *ui.Task, cache *Cache, checksum string) (string,
 	if err != nil {
 		return "", "", "", err
 	}
-	args := util.GitArgs("clone", "--depth=1")
+	args := redact.Args(util.GitArgs("clone", "--depth=1")...)
 	if tag != "" {
-		args = append(args, "--branch="+tag)
+		args = append(args, redact.Plain("--branch="+tag))
 	}
-	args = append(args, "--", repo, checkoutDir)
-	err = util.RunSystemInDir(b, cache.root, args...)
+	args = append(args, redact.Plain("--"), repo, redact.Plain(checkoutDir))
+	err = s.runner.RunInDir(b, cache.root, args...)
 	if err != nil {
 		return "", "", "", errors.WithStack(err)
 	}
 
-	bts, err := util.CaptureSystemInDir(b, checkoutDir, "git", "rev-parse", "HEAD")
+	bts, err := s.runner.CaptureInDir(b, checkoutDir, redact.Args("git", "rev-parse", "HEAD")...)
 	if err != nil {
 		return "", "", "", errors.WithStack(err)
 	}
@@ -46,16 +48,9 @@ func (s *gitSource) Download(b *ui.Task, cache *Cache, checksum string) (string,
 }
 
 func (s *gitSource) ETag(b *ui.Task) (etag string, err error) {
-	repo, tag, err := parseGitURL(s.URL)
+	bts, err := s.lsRemote(b)
 	if err != nil {
-		return "", err
-	}
-	if tag == "" {
-		tag = "HEAD"
-	}
-	bts, err := util.CaptureSystem(b, util.GitArgs("ls-remote", "--", repo, tag)...)
-	if err != nil {
-		return "", errors.Wrap(err, s.URL)
+		return "", errors.Wrap(err, s.URL.String())
 	}
 	str := string(bts)
 	parts := strings.Split(str, "\t")
@@ -67,28 +62,25 @@ func (s *gitSource) ETag(b *ui.Task) (etag string, err error) {
 }
 
 func (s *gitSource) Validate() error {
+	_, err := s.lsRemote(nil)
+	return errors.Wrap(err, "error getting remote HEAD")
+}
+
+func (s *gitSource) lsRemote(log ui.Logger) ([]byte, error) {
 	repo, tag, err := parseGitURL(s.URL)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if tag == "" {
 		tag = "HEAD"
 	}
-	args := util.GitArgs("ls-remote", "--", repo, tag)
-	cmd, err := util.SystemCommand(args...)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return errors.Wrapf(err, "error getting remote HEAD: %s", string(out))
-	}
-	return nil
+	args := append(redact.Args(util.GitArgs("ls-remote", "--")...), repo, redact.Plain(tag))
+	return s.runner.CaptureInDir(log, "", args...)
 }
 
-func parseGitURL(source string) (repo, tag string, err error) {
-	parts := strings.SplitN(source, "#", 2)
-	repo = parts[0]
+func parseGitURL(source redact.URL) (repo redact.URL, tag string, err error) {
+	parts := strings.SplitN(source.Reveal(), "#", 2)
+	repo = redact.URL(parts[0])
 
 	if err := util.ValidateGitURL(repo); err != nil {
 		return "", "", errors.WithStack(err)

--- a/cache/github.go
+++ b/cache/github.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cashapp/hermit/errors"
 	"github.com/cashapp/hermit/github"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/ui"
 )
 
@@ -18,8 +19,8 @@ var githubRe = regexp.MustCompile(`^https\://github\.com/([^/]+)/([^/]+)/release
 
 // GitHubSourceSelector can download private release assets from GitHub using an authenticated GitHub client.
 func GitHubSourceSelector(getSource PackageSourceSelector, ghclient *github.Client, match github.RepoMatcher) PackageSourceSelector {
-	return func(client *http.Client, uri string) (PackageSource, error) {
-		info, ok := getGitHubReleaseInfo(uri)
+	return func(client *http.Client, uri redact.URL) (PackageSource, error) {
+		info, ok := getGitHubReleaseInfo(uri.Reveal())
 		if !ok || match == nil || !match(info.owner, info.repo) {
 			return getSource(client, uri)
 		}
@@ -30,7 +31,7 @@ func GitHubSourceSelector(getSource PackageSourceSelector, ghclient *github.Clie
 type githubReleaseSource struct {
 	info     *githubReleaseInfo
 	ghclient *github.Client
-	url      string
+	url      redact.URL
 }
 
 func (g *githubReleaseSource) OpenLocal(c *Cache, checksum string) (*os.File, error) {

--- a/cache/http.go
+++ b/cache/http.go
@@ -11,16 +11,18 @@ import (
 	"path/filepath"
 
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/ui"
+	"github.com/cashapp/hermit/util"
 )
 
 type httpSource struct {
 	client *http.Client
-	url    string
+	url    redact.URL
 }
 
 // HTTPSource is a PackageSource for a HTTP URL.
-func HTTPSource(client *http.Client, url string) PackageSource {
+func HTTPSource(client *http.Client, url redact.URL) PackageSource {
 	return &httpSource{client, url}
 }
 
@@ -33,13 +35,13 @@ func (s *httpSource) Download(b *ui.Task, cache *Cache, checksum string) (path s
 	cachePath := cache.Path(checksum, s.url)
 	b.Tracef("cachePath %v checksum %v url %v \n", cachePath, checksum, s.url)
 	ctx := context.Background()
-	req, err := http.NewRequestWithContext(ctx, "GET", s.url, &bytes.Reader{})
+	req, err := http.NewRequestWithContext(ctx, "GET", s.url.Reveal(), &bytes.Reader{})
 	if err != nil {
-		return "", "", "", errors.Wrap(err, "could not fetch")
+		return "", "", "", errors.Wrap(util.StripURLError(err), "could not fetch")
 	}
 	response, err := s.client.Do(req)
 	if err != nil {
-		return "", "", "", errors.Wrap(err, "could not download to cache")
+		return "", "", "", errors.Wrapf(util.StripURLError(err), "could not download %s to cache", s.url)
 	}
 	defer response.Body.Close()
 	return downloadHTTP(b, response, checksum, s.url, cachePath)
@@ -47,13 +49,13 @@ func (s *httpSource) Download(b *ui.Task, cache *Cache, checksum string) (path s
 
 func (s *httpSource) ETag(b *ui.Task) (etag string, err error) {
 	uri := s.url
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodHead, uri, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodHead, uri.Reveal(), nil)
 	if err != nil {
-		return "", errors.Wrap(err, uri)
+		return "", errors.Wrap(util.StripURLError(err), uri.String())
 	}
 	resp, err := s.client.Do(req)
 	if err != nil {
-		return "", errors.Wrap(err, uri)
+		return "", errors.Wrap(util.StripURLError(err), uri.String())
 	}
 	defer resp.Body.Close()
 	// Normal HTTP error, log and try the next mirror.
@@ -65,13 +67,13 @@ func (s *httpSource) ETag(b *ui.Task) (etag string, err error) {
 }
 
 func (s *httpSource) Validate() error {
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodHead, s.url, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodHead, s.url.Reveal(), nil)
 	if err != nil {
-		return errors.Wrap(err, s.url)
+		return errors.Wrap(util.StripURLError(err), s.url.String())
 	}
 	resp, err := s.client.Do(req)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.Wrap(util.StripURLError(err), s.url.String())
 	}
 	defer resp.Body.Close()
 
@@ -82,7 +84,7 @@ func (s *httpSource) Validate() error {
 	return nil
 }
 
-func downloadHTTP(b *ui.Task, response *http.Response, checksum string, uri string, cachePath string) (path string, etag string, returnChecksum string, err error) {
+func downloadHTTP(b *ui.Task, response *http.Response, checksum string, uri redact.URL, cachePath string) (path string, etag string, returnChecksum string, err error) {
 	if response.StatusCode < 200 || response.StatusCode > 299 {
 		return "", "", "", errors.Errorf("download failed: %s (%d), source url: %s", response.Status, response.StatusCode, uri)
 	}

--- a/cache/source.go
+++ b/cache/source.go
@@ -9,13 +9,14 @@ import (
 	"github.com/cashapp/hermit/util"
 
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/ui"
 )
 
 // PackageSourceSelector selects a PackageSource for a URI.
 //
 // If not provided to the Cache, GetSource() will be used.
-type PackageSourceSelector func(client *http.Client, uri string) (PackageSource, error)
+type PackageSourceSelector func(client *http.Client, uri redact.URL) (PackageSource, error)
 
 // PackageSource for a specific version / system of a package
 type PackageSource interface {
@@ -27,14 +28,18 @@ type PackageSource interface {
 }
 
 // GetSource for the given uri, or an error if the uri can not be parsed as a source
-func GetSource(client *http.Client, uri string) (PackageSource, error) {
-	if strings.HasSuffix(uri, ".git") || strings.Contains(uri, ".git#") {
-		return &gitSource{URL: uri}, nil
+func GetSource(client *http.Client, uri redact.URL) (PackageSource, error) {
+	raw := uri.Reveal()
+	if strings.HasSuffix(raw, ".git") || strings.Contains(raw, ".git#") {
+		return &gitSource{URL: uri, runner: &util.RealCommandRunner{}}, nil
 	}
 
-	u, err := url.Parse(uri)
+	u, err := url.Parse(raw)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		if uerr, ok := err.(*url.Error); ok { //nolint:errorlint
+			return nil, errors.Errorf("invalid URI %q: %s", uri, uerr.Err)
+		}
+		return nil, errors.Errorf("invalid URI %q", uri)
 	}
 
 	switch u.Scheme {
@@ -42,7 +47,7 @@ func GetSource(client *http.Client, uri string) (PackageSource, error) {
 		return &fileSource{path: u.Path}, nil
 
 	case "http", "https":
-		return HTTPSource(client, uri), errors.WithStack(err)
+		return HTTPSource(client, uri), nil
 
 	default:
 		return nil, errors.Errorf("unsupported URI %s", uri)

--- a/cache/source_test.go
+++ b/cache/source_test.go
@@ -1,22 +1,27 @@
 package cache
 
 import (
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
+	"github.com/cashapp/hermit/redact"
+	"github.com/cashapp/hermit/ui"
+	"github.com/cashapp/hermit/util"
 )
 
 func TestGitParseRepo(t *testing.T) {
 	repo, tag, err := parseGitURL("org-49461806@github.com:squareup/orc.git")
 	assert.NoError(t, err)
-	assert.Equal(t, "org-49461806@github.com:squareup/orc.git", repo)
+	assert.Equal(t, redact.URL("org-49461806@github.com:squareup/orc.git"), repo)
 	assert.Equal(t, "", tag)
 	repo, tag, err = parseGitURL("org-49461806@github.com:squareup/orc.git#v1.2.3")
 	assert.NoError(t, err)
-	assert.Equal(t, "org-49461806@github.com:squareup/orc.git", repo)
+	assert.Equal(t, redact.URL("org-49461806@github.com:squareup/orc.git"), repo)
 	assert.Equal(t, "v1.2.3", tag)
 }
 
@@ -37,7 +42,7 @@ func TestParseGitURLArgumentInjection(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		_, _, err := parseGitURL(tt.url)
+		_, _, err := parseGitURL(redact.URL(tt.url))
 		if tt.expectError {
 			assert.Error(t, err, "Should reject: "+tt.url)
 		} else {
@@ -52,7 +57,7 @@ func TestGitSourcePreventRCE(t *testing.T) {
 	pwnedFile := filepath.Join(tmpDir, "pwned")
 	maliciousURL := "--upload-pack=sh -c 'echo OWNED > " + pwnedFile + "' #file://" + tmpDir + "/.git"
 
-	src := &gitSource{URL: maliciousURL}
+	src := &gitSource{URL: redact.URL(maliciousURL), runner: &util.RealCommandRunner{}}
 	err := src.Validate()
 	assert.Error(t, err)
 
@@ -81,7 +86,7 @@ func TestGitSourceRCEAttempt(t *testing.T) {
 	pwnedFile := filepath.Join(tmpDir, "pwned")
 	payload := "--upload-pack=sh -c 'echo OWNED > " + pwnedFile + "' #file://" + repoDir + "/.git"
 
-	src := &gitSource{URL: payload}
+	src := &gitSource{URL: redact.URL(payload), runner: &util.RealCommandRunner{}}
 	err := src.Validate()
 
 	assert.Error(t, err)
@@ -106,9 +111,85 @@ func TestGitURLParsing(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		repo, tag, err := parseGitURL(tt.url)
+		repo, tag, err := parseGitURL(redact.URL(tt.url))
 		assert.NoError(t, err)
-		assert.Equal(t, tt.repo, repo)
+		assert.Equal(t, redact.URL(tt.repo), repo)
 		assert.Equal(t, tt.tag, tag)
 	}
+}
+
+type capturingRunner struct {
+	commands [][]string
+	output   []byte
+}
+
+func (c *capturingRunner) RunInDir(_ *ui.Task, _ string, args ...redact.Value) error {
+	c.commands = append(c.commands, redact.Reveal(args))
+	return nil
+}
+
+func (c *capturingRunner) CaptureInDir(_ ui.Logger, _ string, args ...redact.Value) ([]byte, error) {
+	c.commands = append(c.commands, redact.Reveal(args))
+	return c.output, nil
+}
+
+func TestGitSourceUsesCredentialsButRedactsDisplay(t *testing.T) {
+	runner := &capturingRunner{output: []byte("abc123\n")}
+	src := &gitSource{URL: redact.URL("https://x-access-token:sekret@github.com/owner/repo.git#v1"), runner: runner}
+
+	u, buf := ui.NewForTesting()
+	task := u.Task("test")
+	_, etag, _, err := src.Download(task, &Cache{root: t.TempDir()}, "checksum")
+	assert.NoError(t, err)
+	assert.Equal(t, "abc123", etag)
+
+	clone := strings.Join(runner.commands[0], " ")
+	assert.Contains(t, clone, "https://x-access-token:sekret@github.com/owner/repo.git")
+	assert.Contains(t, clone, "--branch=v1")
+	assert.NotContains(t, buf.String(), "sekret")
+}
+
+func TestHTTPSourceDoesNotLeakURLCredentials(t *testing.T) {
+	u, buf := ui.NewForTesting()
+	task := u.Task("test")
+	source := HTTPSource(http.DefaultClient, "https://sekret-token@127.0.0.1:1/owner/file.tar.gz")
+
+	_, _, _, err := source.Download(task, &Cache{root: t.TempDir()}, "checksum")
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "sekret-token")
+	assert.Contains(t, err.Error(), "https://127.0.0.1:1/owner/file.tar.gz")
+
+	_, err = source.ETag(task)
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "sekret-token")
+
+	err = source.Validate()
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "sekret-token")
+
+	assert.NotContains(t, buf.String(), "sekret-token")
+}
+
+func TestGitSourceDoesNotLeakURLCredentials(t *testing.T) {
+	u, buf := ui.NewForTesting()
+	task := u.Task("test")
+	src := &gitSource{
+		URL:    redact.URL("https://x-access-token:sekret@127.0.0.1:1/owner/repo.git"),
+		runner: &util.RealCommandRunner{},
+	}
+
+	_, _, _, err := src.Download(task, &Cache{root: t.TempDir()}, "checksum")
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "sekret")
+
+	_, err = src.ETag(task)
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "sekret")
+	assert.Contains(t, err.Error(), "https://127.0.0.1:1/owner/repo.git")
+
+	err = src.Validate()
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "sekret")
+
+	assert.NotContains(t, buf.String(), "sekret")
 }

--- a/env.go
+++ b/env.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cashapp/hermit/internal/system"
 	"github.com/cashapp/hermit/manifest"
 	"github.com/cashapp/hermit/platform"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/shell"
 	"github.com/cashapp/hermit/sources"
 	"github.com/cashapp/hermit/state"
@@ -91,7 +92,7 @@ const (
 // Config for a Hermit environment.
 type Config struct {
 	Envars            envars.Envars `hcl:"env,optional" help:"Extra environment variables."`
-	Sources           []string      `hcl:"sources,optional" help:"Package manifest sources."`
+	Sources           []redact.URL  `hcl:"sources,optional" help:"Package manifest sources."`
 	ManageGit         bool          `hcl:"manage-git,optional" default:"true" help:"Whether Hermit should automatically 'git add' new packages."`
 	InheritParent     bool          `hcl:"inherit-parent,optional" default:"false" help:"Whether this environment inherits a potential parent environment from one of the parent directories"`
 	InstallOnActivate []string      `hcl:"install-on-activate,optional" help:"List of packages to eagerly download and unpack when the environment is activated."`
@@ -269,7 +270,7 @@ func FindEnvDir(binary string) (envDir string, err error) {
 	return
 }
 
-func getSources(l *ui.UI, envDir string, config *Config, state *state.State, defaultSources []string, sourceRewriters ...sources.URLRewriter) (*sources.Sources, error) {
+func getSources(l *ui.UI, envDir string, config *Config, state *state.State, defaultSources []redact.URL, sourceRewriters ...sources.URLRewriter) (*sources.Sources, error) {
 	configuredSources := config.Sources
 	if config.Sources == nil {
 		configuredSources = defaultSources

--- a/github/api.go
+++ b/github/api.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/redact"
 )
 
 const (
@@ -49,7 +50,7 @@ type Client struct {
 }
 
 // New creates a new GitHub API client.
-func New(client *http.Client, token string) *Client {
+func New(client *http.Client, token redact.Secret) *Client {
 	if client == nil {
 		client = http.DefaultClient
 	}

--- a/github/http.go
+++ b/github/http.go
@@ -2,6 +2,8 @@ package github
 
 import (
 	"net/http"
+
+	"github.com/cashapp/hermit/redact"
 )
 
 // TokenAuthenticatedTransport returns a HTTP transport that will inject a
@@ -9,7 +11,7 @@ import (
 //
 // Conceptually similar to
 // https://github.com/google/go-github/blob/d23570d44313ca73dbcaadec71fc43eca4d29f8b/github/github.go#L841-L875
-func TokenAuthenticatedTransport(transport http.RoundTripper, token string) http.RoundTripper {
+func TokenAuthenticatedTransport(transport http.RoundTripper, token redact.Secret) http.RoundTripper {
 	if transport == nil {
 		transport = http.DefaultTransport
 	}
@@ -17,14 +19,14 @@ func TokenAuthenticatedTransport(transport http.RoundTripper, token string) http
 }
 
 type githubAuthenticatedHTTPClient struct {
-	token string
+	token redact.Secret
 	rt    http.RoundTripper
 }
 
 func (g *githubAuthenticatedHTTPClient) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context()) // The stdlib docs recommend not mutating the request in place.
 	if (req.URL.Host == "github.com" || req.URL.Host == "api.github.com") && g.token != "" {
-		req.Header.Set("Authorization", "token "+g.token)
+		req.Header.Set("Authorization", "token "+g.token.Reveal())
 	}
 	return g.rt.RoundTrip(req)
 }

--- a/github/url.go
+++ b/github/url.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/redact"
 )
 
 // isGitHubHTTPSURL checks if a URL is a GitHub HTTPS URL and returns owner/repo if it is
@@ -27,16 +28,19 @@ func isGitHubSSHURL(uri string) bool {
 }
 
 // AuthenticatedURLRewriter rewrites GitHub URLs to include an auth token if they match the provided pattern
-func AuthenticatedURLRewriter(token string, matcher RepoMatcher) func(uri string) (string, error) {
-	return func(repo string) (string, error) {
+func AuthenticatedURLRewriter(token redact.Secret, matcher RepoMatcher) func(uri redact.URL) (redact.URL, error) {
+	return func(repo redact.URL) (redact.URL, error) {
 		// Pass through SSH URLs unchanged
-		if isGitHubSSHURL(repo) {
+		if isGitHubSSHURL(repo.Reveal()) {
 			return repo, nil
 		}
 
-		u, err := url.Parse(repo)
+		u, err := url.Parse(repo.Reveal())
 		if err != nil {
-			return "", errors.WithStack(err)
+			if uerr, ok := err.(*url.Error); ok { //nolint:errorlint
+				return "", errors.Errorf("invalid URL %q: %s", repo, uerr.Err)
+			}
+			return "", errors.Errorf("invalid URL %q", repo)
 		}
 
 		owner, repoName, ok := isGitHubHTTPSURL(u)
@@ -44,8 +48,8 @@ func AuthenticatedURLRewriter(token string, matcher RepoMatcher) func(uri string
 			return repo, nil
 		}
 		if matcher(owner, repoName) {
-			u.User = url.UserPassword("x-access-token", token)
-			return u.String(), nil
+			u.User = url.UserPassword("x-access-token", token.Reveal())
+			return redact.URL(u.String()), nil
 		}
 		return repo, nil
 	}

--- a/hermittest/envfixture.go
+++ b/hermittest/envfixture.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cashapp/hermit/cache"
 	"github.com/cashapp/hermit/envars"
 	"github.com/cashapp/hermit/internal/dao"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/sources"
 	"github.com/cashapp/hermit/state"
 	"github.com/cashapp/hermit/ui"
@@ -60,7 +61,7 @@ func NewEnvTestFixture(t *testing.T, handler http.Handler) *EnvTestFixture {
 	cache, err := cache.Open(stateDir, nil, client, client)
 	assert.NoError(t, err)
 	sta, err := state.Open(stateDir, state.Config{
-		Sources: []string{},
+		Sources: []redact.URL{},
 		Builtin: sources.NewBuiltInSource(vfs.InMemoryFS(nil)),
 	}, cache)
 	assert.NoError(t, err)

--- a/manifest/autoversion/git_tags.go
+++ b/manifest/autoversion/git_tags.go
@@ -30,7 +30,7 @@ func gitTagsAutoVersion(autoVersion *manifest.AutoVersionBlock) (string, error) 
 	// output format of refs is
 	// <oid> TAB <ref> LF
 	// source: https://git-scm.com/docs/git-ls-remote
-	args := util.GitArgs("ls-remote", "--tags", "--refs", "--", remoteURL)
+	args := util.GitArgs("ls-remote", "--tags", "--refs", "--", remoteURL.Reveal())
 	cmd, err := util.SystemCommand(args...)
 	if err != nil {
 		return "", errors.WithStack(err)

--- a/manifest/autoversion/git_tags_test.go
+++ b/manifest/autoversion/git_tags_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alecthomas/assert/v2"
 	"github.com/cashapp/hermit/errors"
 	"github.com/cashapp/hermit/manifest"
+	"github.com/cashapp/hermit/redact"
 )
 
 func Test_GitTagsAutoVersion(t *testing.T) {
@@ -39,7 +40,7 @@ func Test_GitTagsAutoVersion(t *testing.T) {
 	assert.NoError(t, err)
 
 	latest, err := gitTagsAutoVersion(&manifest.AutoVersionBlock{
-		GitTags:        tmpDir,
+		GitTags:        redact.URL(tmpDir),
 		VersionPattern: "v?(.*)",
 	})
 

--- a/manifest/config.go
+++ b/manifest/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cashapp/hermit/envars"
 	"github.com/cashapp/hermit/errors"
 	"github.com/cashapp/hermit/platform"
+	"github.com/cashapp/hermit/redact"
 )
 
 //go:generate stringer -linecomment -type PackageState
@@ -38,11 +39,11 @@ type Layer struct {
 	Test         *string           `hcl:"test,optional" help:"Command that will test the package is operational."`
 	Env          envars.Envars     `hcl:"env,optional" help:"Environment variables to export."`
 	Vars         map[string]string `hcl:"vars,optional" help:"Set local variables used during manifest evaluation."`
-	Source       string            `hcl:"source,optional" help:"URL for source package. Valid URLs are Git repositories (using .git[#<tag>] suffix), Local Files (using file:// prefix), and Remote Files (using http:// or https:// prefix)"`
+	Source       redact.URL        `hcl:"source,optional" help:"URL for source package. Valid URLs are Git repositories (using .git[#<tag>] suffix), Local Files (using file:// prefix), and Remote Files (using http:// or https:// prefix)"`
 	DontExtract  bool              `hcl:"dont-extract,optional" help:"Don't extract the package source, just copy it into the installation directory."`
-	Mirrors      []string          `hcl:"mirrors,optional" help:"Mirrors to use if the primary source is unavailable."`
+	Mirrors      []redact.URL      `hcl:"mirrors,optional" help:"Mirrors to use if the primary source is unavailable."`
 	SHA256       string            `hcl:"sha256,optional" help:"SHA256 of source package for verification. When in conflict with SHA256 in sha256sums, this value takes precedence."`
-	SHA256Source string            `hcl:"sha256-source,optional" help:"URL for SHA256 checksum file for source package."`
+	SHA256Source redact.URL        `hcl:"sha256-source,optional" help:"URL for SHA256 checksum file for source package."`
 	Darwin       []*Layer          `hcl:"darwin,block" help:"Darwin-specific configuration."`
 	Linux        []*Layer          `hcl:"linux,block" help:"Linux-specific configuration."`
 	Platform     []*PlatformBlock  `hcl:"platform,block" help:"Platform-specific configuration. <attr> is a set regexes that must all match against one of CPU, OS, etc.."`
@@ -92,7 +93,7 @@ type AutoVersionBlock struct {
 	GitHubRelease string                `hcl:"github-release,optional" help:"GitHub <user>/<repo> to retrieve and update versions from the releases API."`
 	HTML          *HTMLAutoVersionBlock `hcl:"html,block" help:"Extract version information from a HTML URL using XPath."`
 	JSON          *JSONAutoVersionBlock `hcl:"json,block" help:"Extract version information from a JSON URL using jq."`
-	GitTags       string                `hcl:"git-tags,optional" help:"Git remote URL to fetch git tags for version extraction."`
+	GitTags       redact.URL            `hcl:"git-tags,optional" help:"Git remote URL to fetch git tags for version extraction."`
 
 	VersionPattern        string `hcl:"version-pattern,optional" help:"Regex with one capture group to extract the version number from the origin." default:"v?(.*)"`
 	IgnoreInvalidVersions bool   `hcl:"ignore-invalid-versions,optional" help:"Ignore tags that don't match the versin-pattern instead of failing. Does not apply to versions extracted using HTML URL"`

--- a/manifest/config_test.go
+++ b/manifest/config_test.go
@@ -7,8 +7,11 @@ import (
 	"github.com/alecthomas/assert/v2"
 	"github.com/alecthomas/repr"
 
+	"github.com/alecthomas/hcl"
+
 	"github.com/cashapp/hermit/envars"
 	"github.com/cashapp/hermit/platform"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/sources"
 	"github.com/cashapp/hermit/ui"
 )
@@ -307,3 +310,21 @@ func TestManifest(t *testing.T) {
 // func TestHelp(t *testing.T) {
 // assert.Equal(t, ``, Help())
 // }
+
+func TestLayerSerialisesSourceURLsRaw(t *testing.T) {
+	layer := Layer{
+		Source:       redact.URL("https://user:sekret@example.com/pkg-${version}.tar.gz"),
+		Mirrors:      []redact.URL{"https://user:sekret@mirror.example.com/pkg-${version}.tar.gz"},
+		SHA256Source: redact.URL("https://user:sekret@example.com/pkg-${version}.sha256"),
+	}
+	data, err := hcl.Marshal(&layer)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), "https://user:sekret@example.com/pkg-${version}.tar.gz")
+	assert.Contains(t, string(data), "https://user:sekret@mirror.example.com/pkg-${version}.tar.gz")
+
+	var back Layer
+	assert.NoError(t, hcl.Unmarshal(data, &back))
+	assert.Equal(t, layer.Source, back.Source)
+	assert.Equal(t, layer.Mirrors, back.Mirrors)
+	assert.Equal(t, layer.SHA256Source, back.SHA256Source)
+}

--- a/manifest/digest/digest.go
+++ b/manifest/digest/digest.go
@@ -17,8 +17,10 @@ import (
 	"github.com/cashapp/hermit/errors"
 	"github.com/cashapp/hermit/manifest"
 	"github.com/cashapp/hermit/platform"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/state"
 	"github.com/cashapp/hermit/ui"
+	"github.com/cashapp/hermit/util"
 )
 
 // UpdateDigests for the manifest at the given path.
@@ -35,7 +37,7 @@ func UpdateDigests(l *ui.UI, client *http.Client, state *state.State, path strin
 		return errors.Wrap(err, "failed to load manifest")
 	}
 	// Dedupe by source, as channels often have the same source as normal packages.
-	pkgsBySource := map[string]pkgAndref{}
+	pkgsBySource := map[redact.URL]pkgAndref{}
 	for _, ref := range mani.References(name) {
 		for _, p := range slices.Concat(platform.Core, platform.Optional) {
 			config := manifest.Config{
@@ -57,7 +59,7 @@ func UpdateDigests(l *ui.UI, client *http.Client, state *state.State, path strin
 				continue
 			}
 			// Skip git repos
-			if strings.Contains(pkg.Source, ".git#") || strings.HasSuffix(pkg.Source, ".git") {
+			if strings.Contains(pkg.Source.Reveal(), ".git#") || strings.HasSuffix(pkg.Source.Reveal(), ".git") {
 				continue
 			}
 			// Skip checksums for channels.
@@ -154,7 +156,7 @@ func writeAST(path string, ast *hcl.AST, filename string) error {
 
 type pkgAndDigest struct {
 	ref    manifest.Reference
-	source string
+	source redact.URL
 	digest string
 }
 
@@ -182,11 +184,17 @@ var digestRe = regexp.MustCompile(`^([A-Z0-9a-z]{64})(?:\s+(.*))?`)
 var checksumCache sync.Map
 
 func tryGetSHA(task *ui.Task, client *http.Client, pkg *manifest.Package) string {
-	u := pkg.Source
+	u := pkg.Source.Reveal()
 	dir := u[:strings.LastIndex(u, "/")]
-	variants := []string{u + ".sha256.txt", u + ".sha256", dir + "/checksums.txt", dir + "/sha256.txt", dir + "/SHA256SUMS"}
+	variants := []redact.URL{
+		redact.URL(u + ".sha256.txt"),
+		redact.URL(u + ".sha256"),
+		redact.URL(dir + "/checksums.txt"),
+		redact.URL(dir + "/sha256.txt"),
+		redact.URL(dir + "/SHA256SUMS"),
+	}
 	if pkg.SHA256Source != "" {
-		variants = []string{pkg.SHA256Source}
+		variants = []redact.URL{pkg.SHA256Source}
 	}
 	filename, err := url.PathUnescape(path.Base(u))
 	if err != nil {
@@ -196,13 +204,13 @@ func tryGetSHA(task *ui.Task, client *http.Client, pkg *manifest.Package) string
 		content, ok := checksumCache.Load(variant)
 		if !ok {
 			task.Tracef("Trying %s", variant)
-			req, err := http.NewRequest(http.MethodGet, variant, &strings.Reader{}) //nolint: noctx
+			req, err := http.NewRequest(http.MethodGet, variant.Reveal(), &strings.Reader{}) //nolint: noctx
 			if err != nil {
 				return ""
 			}
 			resp, err := client.Do(req)
 			if err != nil {
-				task.Tracef("Failed to fetch %s: %v", variant, err)
+				task.Tracef("Failed to fetch %s: %v", variant, util.StripURLError(err))
 				return ""
 			}
 			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -245,8 +253,9 @@ func updateHCLSHA256Sums(ast *hcl.AST, updated []pkgAndDigest) error {
 	}
 
 	for _, pkg := range updated {
+		source := pkg.source.Reveal()
 		sha256Sums.Map = append(sha256Sums.Map, &hcl.MapEntry{
-			Key:   &hcl.Value{Str: &pkg.source},
+			Key:   &hcl.Value{Str: &source},
 			Value: &hcl.Value{Str: &pkg.digest},
 		})
 	}

--- a/manifest/digest/digest_test.go
+++ b/manifest/digest/digest_test.go
@@ -1,0 +1,26 @@
+package digest
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/cashapp/hermit/manifest"
+	"github.com/cashapp/hermit/redact"
+	"github.com/cashapp/hermit/ui"
+)
+
+func TestTryGetSHADoesNotLeakURLCredentials(t *testing.T) {
+	u, buf := ui.NewForTesting()
+	task := u.Task("test")
+	pkg := &manifest.Package{
+		Source:       redact.URL("https://sekret-token@127.0.0.1:1/owner/file.tar.gz"),
+		SHA256Source: redact.URL("https://sekret-token@127.0.0.1:1/owner/file.sha256"),
+	}
+
+	digest := tryGetSHA(task, http.DefaultClient, pkg)
+
+	assert.Equal(t, "", digest)
+	assert.NotContains(t, buf.String(), "sekret-token")
+	assert.Contains(t, buf.String(), "https://127.0.0.1:1/owner/file.sha256")
+}

--- a/manifest/infer.go
+++ b/manifest/infer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cashapp/hermit/errors"
 	"github.com/cashapp/hermit/github"
 	"github.com/cashapp/hermit/platform"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/ui"
 )
 
@@ -73,7 +74,7 @@ func InferFromArtefact(p *ui.UI, packageSource cache.PackageSourceSelector, http
 		platforms = append(platforms, &PlatformBlock{
 			Attrs: []string{plat.OS, plat.Arch},
 			Layer: Layer{
-				Source: platSource,
+				Source: redact.URL(platSource),
 			},
 		})
 	}
@@ -120,7 +121,7 @@ func validateSourcesByPlatform(p *ui.UI, packageSource cache.PackageSourceSelect
 nextPlatform:
 	for plat, url := range sourcesByPlatform {
 		p.Debugf("  %s - %s", plat, url)
-		if err := ValidatePackageSource(packageSource, httpClient, url); err != nil {
+		if err := ValidatePackageSource(packageSource, httpClient, redact.URL(url)); err != nil {
 			// Try different extensions as packages sometimes use .zip for Windows, .tar.gz for Linux, etc.
 			candidate := url
 			// Strip the existing suffix.
@@ -130,7 +131,7 @@ nextPlatform:
 			// Try alternative suffixAlternatives.
 			for _, suffix := range suffixAlternatives {
 				url = candidate + suffix
-				if err := ValidatePackageSource(packageSource, httpClient, url); err == nil {
+				if err := ValidatePackageSource(packageSource, httpClient, redact.URL(url)); err == nil {
 					sourcesByPlatform[plat] = url
 					continue nextPlatform
 				}

--- a/manifest/infer_test.go
+++ b/manifest/infer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alecthomas/assert/v2"
 	"github.com/cashapp/hermit/cache"
 	"github.com/cashapp/hermit/github"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/ui"
 )
 
@@ -40,9 +41,9 @@ func TestInfer(t *testing.T) {
 		Layer: Layer{
 			Binaries: []string{},
 			Platform: []*PlatformBlock{
-				{Attrs: []string{"darwin", "amd64"}, Layer: Layer{Source: srv.URL + "/releases/download/${version}/pkg-${version}-${os}-${arch}.zip"}},
-				{Attrs: []string{"darwin", "arm64"}, Layer: Layer{Source: srv.URL + "/releases/download/${version}/pkg-${version}-${os}-amd64.zip"}},
-				{Attrs: []string{"linux", "amd64"}, Layer: Layer{Source: srv.URL + "/releases/download/${version}/pkg-${version}-${os}-${arch}.tgz"}},
+				{Attrs: []string{"darwin", "amd64"}, Layer: Layer{Source: redact.URL(srv.URL + "/releases/download/${version}/pkg-${version}-${os}-${arch}.zip")}},
+				{Attrs: []string{"darwin", "arm64"}, Layer: Layer{Source: redact.URL(srv.URL + "/releases/download/${version}/pkg-${version}-${os}-amd64.zip")}},
+				{Attrs: []string{"linux", "amd64"}, Layer: Layer{Source: redact.URL(srv.URL + "/releases/download/${version}/pkg-${version}-${os}-${arch}.tgz")}},
 			},
 		},
 		Versions: []VersionBlock{{

--- a/manifest/manifesttest/pkgbuilder.go
+++ b/manifest/manifesttest/pkgbuilder.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cashapp/hermit/envars"
 	"github.com/cashapp/hermit/manifest"
 	"github.com/cashapp/hermit/platform"
+	"github.com/cashapp/hermit/redact"
 )
 
 // PkgBuilder is a builder pattern implementation for manifest.Package objects
@@ -70,7 +71,7 @@ func (b PkgBuilder) WithBinaries(bins ...string) PkgBuilder {
 
 // WithSource sets the source of the package
 func (b PkgBuilder) WithSource(src string) PkgBuilder {
-	b.result.Source = src
+	b.result.Source = redact.URL(src)
 	return b
 }
 

--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cashapp/hermit/errors"
 	"github.com/cashapp/hermit/internal/system"
 	"github.com/cashapp/hermit/platform"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/sources"
 	"github.com/cashapp/hermit/ui"
 )
@@ -79,10 +80,10 @@ type Package struct {
 	RuntimeDeps          []Reference
 	Provides             []string
 	Env                  envars.Ops
-	Source               string
-	SHA256Source         string
+	Source               redact.URL
+	SHA256Source         redact.URL
 	DontExtract          bool // Don't extract the package, just download it.
-	Mirrors              []string
+	Mirrors              []redact.URL
 	Root                 string
 	SHA256               string
 	Mutable              bool
@@ -614,17 +615,17 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 	for i, provides := range p.Provides {
 		p.Provides[i] = envars.Expand(provides, mapping)
 	}
-	p.Source = envars.Expand(p.Source, mapping)
-	p.SHA256Source = envars.Expand(p.SHA256Source, mapping)
+	p.Source = redact.URL(envars.Expand(p.Source.Reveal(), mapping))
+	p.SHA256Source = redact.URL(envars.Expand(p.SHA256Source.Reveal(), mapping))
 	for i, mirror := range p.Mirrors {
-		p.Mirrors[i] = envars.Expand(mirror, mapping)
+		p.Mirrors[i] = redact.URL(envars.Expand(mirror.Reveal(), mapping))
 	}
 	// Get sha256 checksum after variable expansion for source, taking care of
 	// autoversion
 	for _, layer := range layers {
 		if layer.SHA256 != "" {
 			p.SHA256 = layer.SHA256
-		} else if sum, ok := manifest.SHA256Sums[p.Source]; ok {
+		} else if sum, ok := manifest.SHA256Sums[p.Source.Reveal()]; ok {
 			p.SHA256 = sum
 		}
 	}
@@ -726,11 +727,12 @@ func inferPackageRepository(p *Package, manifest *Manifest) {
 		}
 	}
 
-	if !strings.HasPrefix(p.Source, githubComPrefix) || strings.HasPrefix(p.Source, "https://github.com/cashapp/hermit-build") {
+	source := p.Source.Reveal()
+	if !strings.HasPrefix(source, githubComPrefix) || strings.HasPrefix(source, "https://github.com/cashapp/hermit-build") {
 		return
 	}
 
-	rest := strings.TrimPrefix(p.Source, githubComPrefix)
+	rest := strings.TrimPrefix(source, githubComPrefix)
 
 	restSplit := strings.Split(rest, "/")
 

--- a/manifest/validate.go
+++ b/manifest/validate.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/cashapp/hermit/cache"
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/redact"
 )
 
 // ValidatePackageSource checks that a package source is accessible.
-func ValidatePackageSource(packageSource cache.PackageSourceSelector, httpClient *http.Client, url string) error {
+func ValidatePackageSource(packageSource cache.PackageSourceSelector, httpClient *http.Client, url redact.URL) error {
 	source, err := packageSource(httpClient, url)
 	if err != nil {
-		return errors.Wrap(err, url)
+		return errors.Wrap(err, url.String())
 	}
 	return errors.Wrapf(source.Validate(), "invalid source")
 }

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -1,0 +1,80 @@
+// Package redact provides types for sensitive values that display in redacted
+// form by default, and are only revealed at the point of deliberate use.
+package redact
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var urlCredentialsRe = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.-]*://)[^/?#\s]+@`)
+
+// Value is a possibly-sensitive value that displays in redacted form.
+type Value interface {
+	fmt.Stringer
+	Reveal() string
+}
+
+// Plain is a non-sensitive value that displays as-is. It exists so that
+// non-sensitive values can be mixed with sensitive ones, eg. in command arguments.
+type Plain string
+
+func (p Plain) String() string { return string(p) }
+func (p Plain) Reveal() string { return string(p) }
+
+// Secret is an opaque sensitive value, such as an access token, that displays
+// as "[redacted]".
+type Secret string
+
+func (s Secret) String() string {
+	if s == "" {
+		return ""
+	}
+	return "[redacted]"
+}
+func (s Secret) GoString() string { return s.String() }
+func (s Secret) Reveal() string   { return string(s) }
+
+// URL is a URL that may embed credentials in its userinfo section. It displays
+// with the credentials removed, but serialises in full for config round-tripping.
+type URL string
+
+func (u URL) String() string                { return urlCredentialsRe.ReplaceAllString(string(u), "$1") }
+func (u URL) GoString() string              { return u.String() }
+func (u URL) Reveal() string                { return string(u) }
+func (u URL) MarshalText() ([]byte, error)  { return []byte(u), nil }
+func (u *URL) UnmarshalText(b []byte) error { *u = URL(b); return nil }
+
+// Args wraps non-sensitive command arguments as a list of Values.
+func Args(args ...string) []Value {
+	out := make([]Value, len(args))
+	for i, arg := range args {
+		out[i] = Plain(arg)
+	}
+	return out
+}
+
+// Reveal returns the raw form of each value.
+func Reveal(values []Value) []string {
+	out := make([]string, len(values))
+	for i, value := range values {
+		out[i] = value.Reveal()
+	}
+	return out
+}
+
+// Scrubber returns a Replacer substituting each sensitive value's raw form with
+// its redacted form, for untyped text such as subprocess output. Nil if none.
+func Scrubber(values []Value) *strings.Replacer {
+	var pairs []string
+	for _, value := range values {
+		if value.Reveal() != value.String() {
+			pairs = append(pairs, value.Reveal(), value.String())
+		}
+	}
+	if pairs == nil {
+		return nil
+	}
+	return strings.NewReplacer(pairs...)
+}

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -1,0 +1,76 @@
+package redact_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/cashapp/hermit/redact"
+)
+
+func TestURLDisplaysWithoutCredentials(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"UserAndPassword", "https://x-access-token:sekret@github.com/owner/repo.git", "https://github.com/owner/repo.git"},
+		{"UserOnly", "https://sekret@github.com/owner/repo.git", "https://github.com/owner/repo.git"},
+		{"LiteralAtInPassword", "https://user:p@ss@github.com/owner/repo.git", "https://github.com/owner/repo.git"},
+		{"NoCredentials", "https://github.com/owner/repo.git", "https://github.com/owner/repo.git"},
+		{"AtInPath", "https://github.com/owner/repo@v1.0", "https://github.com/owner/repo@v1.0"},
+		{"AtInQuery", "https://example.com?user=@foo", "https://example.com?user=@foo"},
+		{"SCPLike", "git@github.com:owner/repo.git", "git@github.com:owner/repo.git"},
+		{"EnvScheme", "env:///bin/packages", "env:///bin/packages"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			url := redact.URL(test.in)
+			assert.Equal(t, test.want, url.String())
+			assert.Equal(t, test.in, url.Reveal())
+		})
+	}
+}
+
+func TestURLFormattingRedacts(t *testing.T) {
+	url := redact.URL("https://x-access-token:sekret@github.com/owner/repo.git")
+	assert.Equal(t, "https://github.com/owner/repo.git", fmt.Sprintf("%v", url))
+	assert.Equal(t, "https://github.com/owner/repo.git", fmt.Sprintf("%#v", url))
+	assert.Equal(t, `"https://github.com/owner/repo.git"`, fmt.Sprintf("%q", url))
+}
+
+func TestURLSerialisesRaw(t *testing.T) {
+	url := redact.URL("https://user:sekret@example.com/repo.git")
+	data, err := json.Marshal(url)
+	assert.NoError(t, err)
+	assert.Equal(t, `"https://user:sekret@example.com/repo.git"`, string(data))
+	var back redact.URL
+	assert.NoError(t, json.Unmarshal(data, &back))
+	assert.Equal(t, url, back)
+}
+
+func TestSecret(t *testing.T) {
+	secret := redact.Secret("sekret")
+	assert.Equal(t, "[redacted]", secret.String())
+	assert.Equal(t, "[redacted]", fmt.Sprintf("%v", secret))
+	assert.Equal(t, "[redacted]", fmt.Sprintf("%#v", secret))
+	assert.Equal(t, "sekret", secret.Reveal())
+	assert.Equal(t, "", redact.Secret("").String())
+}
+
+func TestArgsRoundTrip(t *testing.T) {
+	args := append(redact.Args("git", "clone"), redact.URL("https://user:sekret@example.com/repo.git"))
+	assert.Equal(t, []string{"git", "clone", "https://user:sekret@example.com/repo.git"}, redact.Reveal(args))
+	assert.Equal(t, "git", args[0].String())
+}
+
+func TestScrubber(t *testing.T) {
+	assert.Zero(t, redact.Scrubber(redact.Args("git", "clone")))
+
+	args := append(redact.Args("git", "clone"), redact.URL("https://user:sekret@example.com/repo.git"))
+	scrubber := redact.Scrubber(args)
+	assert.Equal(t,
+		"fatal: unable to access 'https://example.com/repo.git/'",
+		scrubber.Replace("fatal: unable to access 'https://user:sekret@example.com/repo.git/'"))
+}

--- a/sources/git.go
+++ b/sources/git.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/ui"
 	"github.com/cashapp/hermit/util"
 )
@@ -14,19 +15,26 @@ import (
 // GitSource is a new Source based on a git repo
 type GitSource struct {
 	fs        *uriFS
+	remote    redact.URL
 	sourceDir string
 	path      string
 	runner    util.CommandRunner
 }
 
 // NewGitSource returns a new GitSource
-func NewGitSource(uri, sourceDir string, runner util.CommandRunner) *GitSource {
-	key := util.Hash(uri)
+func NewGitSource(uri redact.URL, sourceDir string, runner util.CommandRunner) *GitSource {
+	key := util.Hash(uri.Reveal())
 	path := filepath.Join(sourceDir, key)
-	return &GitSource{&uriFS{
-		uri: uri,
-		FS:  os.DirFS(path),
-	}, sourceDir, path, runner}
+	return &GitSource{
+		fs: &uriFS{
+			uri: uri.String(),
+			FS:  os.DirFS(path),
+		},
+		remote:    uri,
+		sourceDir: sourceDir,
+		path:      path,
+		runner:    runner,
+	}
 }
 
 func (s *GitSource) Sync(p *ui.UI, force bool) (bool, error) {
@@ -38,7 +46,7 @@ func (s *GitSource) Sync(p *ui.UI, force bool) (bool, error) {
 			return false, errors.WithStack(err)
 		}
 
-		err = syncGit(task, s.sourceDir, s.fs.uri, s.path, s.runner)
+		err = syncGit(task, s.sourceDir, s.remote, s.path, s.runner)
 		// If the sync failed while the repo had already been cloned, log a warning
 		// If the repo has not yet been cloned, fail.
 		if err != nil {
@@ -70,7 +78,7 @@ func (s *GitSource) ensureSourcesDirExists() error {
 }
 
 // Atomically clone git repo.
-func syncGit(b *ui.Task, dir, source, finalDest string, runner util.CommandRunner) (err error) {
+func syncGit(b *ui.Task, dir string, source redact.URL, finalDest string, runner util.CommandRunner) (err error) {
 	task := b.SubProgress("sync", 1)
 	defer func() {
 		task.Done()
@@ -82,7 +90,7 @@ func syncGit(b *ui.Task, dir, source, finalDest string, runner util.CommandRunne
 	// First, if a git repo exists, just pull.
 	info, _ := os.Stat(filepath.Join(finalDest, ".git"))
 	if info != nil {
-		err = runner.RunInDir(b, finalDest, util.GitArgs("pull")...)
+		err = runner.RunInDir(b, finalDest, redact.Args(util.GitArgs("pull")...)...)
 		if err == nil {
 			return nil
 		}
@@ -94,7 +102,8 @@ func syncGit(b *ui.Task, dir, source, finalDest string, runner util.CommandRunne
 		return errors.WithStack(err)
 	}
 	defer os.RemoveAll(dest)
-	if err = runner.RunInDir(b, dest, util.GitArgs("clone", "--depth=1", "--", source, dest)...); err != nil {
+	cloneArgs := append(redact.Args(util.GitArgs("clone", "--depth=1", "--")...), source, redact.Plain(dest))
+	if err = runner.RunInDir(b, dest, cloneArgs...); err != nil {
 		return errors.WithStack(err)
 	}
 	_ = os.RemoveAll(finalDest)

--- a/sources/git_test.go
+++ b/sources/git_test.go
@@ -2,26 +2,47 @@ package sources_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/sources"
 	"github.com/cashapp/hermit/ui"
+	"github.com/cashapp/hermit/util"
 )
 
 type FailingGit struct {
 	err error
 }
 
-func (f *FailingGit) RunInDir(_ *ui.Task, _ string, _ ...string) error {
+func (f *FailingGit) RunInDir(_ *ui.Task, _ string, _ ...redact.Value) error {
 	return f.err
+}
+
+func (f *FailingGit) CaptureInDir(_ ui.Logger, _ string, _ ...redact.Value) ([]byte, error) {
+	return nil, f.err
+}
+
+type CapturingGit struct {
+	commands [][]string
+}
+
+func (c *CapturingGit) RunInDir(_ *ui.Task, _ string, args ...redact.Value) error {
+	c.commands = append(c.commands, redact.Reveal(args))
+	return nil
+}
+
+func (c *CapturingGit) CaptureInDir(_ ui.Logger, _ string, args ...redact.Value) ([]byte, error) {
+	c.commands = append(c.commands, redact.Reveal(args))
+	return nil, nil
 }
 
 func TestGitDoesNotRemoveSourceAfterSyncFailure(t *testing.T) {
 	git := &FailingGit{}
 	sourceDir := t.TempDir()
-	source := sources.NewGitSource("git://test", sourceDir, git)
+	source := sources.NewGitSource(redact.URL("git://test"), sourceDir, git)
 
 	// Create the initial directory for sources by successfully syncing
 	u, _ := ui.NewForTesting()
@@ -45,4 +66,29 @@ func TestGitDoesNotRemoveSourceAfterSyncFailure(t *testing.T) {
 	assert.Equal(t, len(files), 1)
 	assert.Equal(t, gitDir, files[0].Name())
 
+}
+
+func TestGitSyncUsesCredentialsButDisplaysRedactedURI(t *testing.T) {
+	git := &CapturingGit{}
+	source := sources.NewGitSource(redact.URL("https://x-access-token:sekret@github.com/owner/repo.git"), t.TempDir(), git)
+	assert.Equal(t, "https://github.com/owner/repo.git", source.URI())
+
+	u, buf := ui.NewForTesting()
+	_, err := source.Sync(u, true)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(git.commands))
+	assert.Contains(t, strings.Join(git.commands[0], " "), "https://x-access-token:sekret@github.com/owner/repo.git")
+	assert.NotContains(t, buf.String(), "sekret")
+}
+
+func TestGitSyncDoesNotLeakURLCredentials(t *testing.T) {
+	u, buf := ui.NewForTesting()
+	source := sources.NewGitSource(redact.URL("https://x-access-token:sekret@127.0.0.1:1/owner/repo.git"), t.TempDir(), &util.RealCommandRunner{})
+
+	_, err := source.Sync(u, true)
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "sekret")
+	assert.Contains(t, err.Error(), "https://127.0.0.1:1/owner/repo.git")
+	assert.NotContains(t, buf.String(), "sekret")
 }

--- a/sources/sources.go
+++ b/sources/sources.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cashapp/hermit/util"
 
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/ui"
 )
 
@@ -86,10 +87,10 @@ func (s *Sources) Sync(p *ui.UI, force bool) error {
 }
 
 // URLRewriter is a function that can transform a source URI
-type URLRewriter func(uri string) (string, error)
+type URLRewriter func(uri redact.URL) (redact.URL, error)
 
 // ForURIs returns Source instances for given uri strings
-func ForURIs(b *ui.UI, dir, env string, uris []string, rewriters ...URLRewriter) (*Sources, error) {
+func ForURIs(b *ui.UI, dir, env string, uris []redact.URL, rewriters ...URLRewriter) (*Sources, error) {
 	sources := make([]Source, 0, len(uris))
 	for _, uri := range uris {
 		// Apply each rewriter in sequence
@@ -116,20 +117,23 @@ func ForURIs(b *ui.UI, dir, env string, uris []string, rewriters ...URLRewriter)
 	}, nil
 }
 
-func getSource(b *ui.UI, source, dir, env string) (Source, error) {
-	task := b.Task(source)
+func getSource(b *ui.UI, source redact.URL, dir, env string) (Source, error) {
+	task := b.Task(source.String())
 	defer task.Done()
 
-	if strings.HasSuffix(source, ".git") {
+	if strings.HasSuffix(source.Reveal(), ".git") {
 		if err := util.ValidateGitURL(source); err != nil {
 			return nil, errors.WithStack(err)
 		}
 		return NewGitSource(source, dir, &util.RealCommandRunner{}), nil
 	}
 
-	uri, err := url.Parse(source)
+	uri, err := url.Parse(source.Reveal())
 	if err != nil {
-		return nil, errors.Wrap(err, "invalid source")
+		if uerr, ok := err.(*url.Error); ok { //nolint:errorlint
+			return nil, errors.Errorf("invalid source %q: %s", source, uerr.Err)
+		}
+		return nil, errors.Errorf("invalid source %q", source)
 	}
 	var (
 		// Directory of source, if any, to check for existence.
@@ -161,7 +165,7 @@ func getSource(b *ui.UI, source, dir, env string) (Source, error) {
 		return nil, errors.Errorf("unsupported source %q", source)
 	}
 	if info, err := os.Stat(checkDir); err == nil {
-		return NewLocalSource(source, candidate), nil
+		return NewLocalSource(source.String(), candidate), nil
 	} else if info != nil && !info.IsDir() {
 		task.Warnf("source %q should be a directory but is not", source)
 	} else {

--- a/sources/sources_test.go
+++ b/sources/sources_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alecthomas/assert/v2"
 	"github.com/cashapp/hermit/errors"
 	"github.com/cashapp/hermit/github"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/ui"
 )
 
@@ -18,13 +19,13 @@ func TestEnvSourceRejectsPathTraversal(t *testing.T) {
 	assert.NoError(t, os.MkdirAll(env, 0750))
 	assert.NoError(t, os.MkdirAll(outside, 0750))
 
-	for _, uri := range []string{
+	for _, uri := range []redact.URL{
 		"env:///../outside",
 		"env:///%2e%2e/outside",
 	} {
-		t.Run(uri, func(t *testing.T) {
+		t.Run(uri.String(), func(t *testing.T) {
 			ui, _ := ui.NewForTesting()
-			_, err := ForURIs(ui, filepath.Join(root, "state"), env, []string{uri})
+			_, err := ForURIs(ui, filepath.Join(root, "state"), env, []redact.URL{uri})
 			assert.Error(t, err)
 		})
 	}
@@ -80,11 +81,12 @@ func TestGitHubTokenRewriter(t *testing.T) {
 			matcher, err := github.GlobRepoMatcher([]string{tt.pattern})
 			assert.NoError(t, err)
 
-			rewriter := github.AuthenticatedURLRewriter(tt.token, matcher)
-			result, err := rewriter(tt.uri)
+			rewriter := github.AuthenticatedURLRewriter(redact.Secret(tt.token), matcher)
+			result, err := rewriter(redact.URL(tt.uri))
 
 			assert.NoError(t, err)
-			assert.Equal(t, tt.want, result)
+			assert.Equal(t, tt.want, result.Reveal())
+			assert.Equal(t, tt.uri, result.String())
 		})
 	}
 }
@@ -96,9 +98,9 @@ func TestForURIsIntegration(t *testing.T) {
 	t.Run("successful rewriting", func(t *testing.T) {
 		matcher, err := github.GlobRepoMatcher([]string{"owner/*"})
 		assert.NoError(t, err)
-		rewriter := github.AuthenticatedURLRewriter("test-token", matcher)
+		rewriter := github.AuthenticatedURLRewriter(redact.Secret("test-token"), matcher)
 
-		uris := []string{
+		uris := []redact.URL{
 			"https://github.com/owner/repo1.git",
 			"https://github.com/other/repo2.git",
 			"git@github.com:owner/repo3.git",
@@ -108,19 +110,20 @@ func TestForURIsIntegration(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, len(uris), len(sources.sources))
 
-		// Verify the sources were created with appropriate URIs
-		// First URI should be rewritten with token, others should remain unchanged
-		assert.Contains(t, sources.sources[0].URI(), "x-access-token:test-token@github.com")
-		assert.Equal(t, uris[1], sources.sources[1].URI())
-		assert.Equal(t, uris[2], sources.sources[2].URI())
+		gitSource, ok := sources.sources[0].(*GitSource)
+		assert.True(t, ok)
+		assert.Equal(t, "https://x-access-token:test-token@github.com/owner/repo1.git", gitSource.remote.Reveal())
+		assert.Equal(t, "https://github.com/owner/repo1.git", sources.sources[0].URI())
+		assert.Equal(t, uris[1].Reveal(), sources.sources[1].URI())
+		assert.Equal(t, uris[2].Reveal(), sources.sources[2].URI())
 	})
 
 	t.Run("rewriter error", func(t *testing.T) {
-		errorRewriter := func(uri string) (string, error) {
+		errorRewriter := func(uri redact.URL) (redact.URL, error) {
 			return "", errors.New("rewriter error")
 		}
 
-		uris := []string{"https://github.com/owner/repo.git"}
+		uris := []redact.URL{"https://github.com/owner/repo.git"}
 		_, err := ForURIs(l, "testdir", "testenv", uris, errorRewriter)
 
 		assert.Error(t, err)
@@ -128,18 +131,18 @@ func TestForURIsIntegration(t *testing.T) {
 	})
 
 	t.Run("git remote helper uri", func(t *testing.T) {
-		_, err := ForURIs(l, "testdir", "testenv", []string{"zzq::x.git"})
+		_, err := ForURIs(l, "testdir", "testenv", []redact.URL{"zzq::x.git"})
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "remote helpers are not supported")
 	})
 
 	t.Run("invalid rewritten uri", func(t *testing.T) {
-		invalidRewriter := func(uri string) (string, error) {
+		invalidRewriter := func(uri redact.URL) (redact.URL, error) {
 			return "invalid://not-a-valid-source", nil
 		}
 
-		uris := []string{"https://github.com/owner/repo.git"}
+		uris := []redact.URL{"https://github.com/owner/repo.git"}
 		_, err := ForURIs(l, "testdir", "testenv", uris, invalidRewriter)
 
 		assert.Error(t, err)

--- a/state/state.go
+++ b/state/state.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cashapp/hermit/internal/dao"
 	"github.com/cashapp/hermit/manifest"
 	"github.com/cashapp/hermit/platform"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/sources"
 	"github.com/cashapp/hermit/ui"
 	"github.com/cashapp/hermit/util"
@@ -24,7 +25,7 @@ import (
 )
 
 // DefaultSources if no others are defined.
-var DefaultSources = []string{"https://github.com/cashapp/hermit-packages.git"}
+var DefaultSources = []redact.URL{"https://github.com/cashapp/hermit-packages.git"}
 
 type precompiledAutoMirror struct {
 	re     *regexp.Regexp
@@ -43,7 +44,7 @@ type AutoMirror struct {
 // Config for Hermit's global state.
 type Config struct {
 	// List of sources to sync packages from.
-	Sources []string
+	Sources []redact.URL
 	// Auto-generated mirrors.
 	AutoMirrors []AutoMirror
 	// Builtin sources.
@@ -327,7 +328,7 @@ func (s *State) CacheAndUnpack(b *ui.Task, p *manifest.Package) error {
 	// This is safe because cache paths are content-addressed and the cache layer
 	// uses temp files + atomic os.Rename (see cache/http.go downloadHTTP()).
 	if !s.isCached(p) {
-		mirrors := make([]string, len(p.Mirrors))
+		mirrors := make([]redact.URL, len(p.Mirrors))
 		copy(mirrors, p.Mirrors)
 		mirrors = append(mirrors, s.generateMirrors(p.Source)...)
 		_, etag, _, err := s.cache.Download(b, p.SHA256, p.Source, mirrors...)
@@ -366,7 +367,7 @@ func (s *State) CacheAndDigest(b *ui.Task, p *manifest.Package) (string, error) 
 	var actualDigest string
 	var err error
 	if !s.isCached(p) {
-		mirrors := make([]string, len(p.Mirrors))
+		mirrors := make([]redact.URL, len(p.Mirrors))
 		copy(mirrors, p.Mirrors)
 		mirrors = append(mirrors, s.generateMirrors(p.Source)...)
 		_, _, actualDigest, err = s.cache.Download(b, p.SHA256, p.Source, mirrors...)
@@ -426,7 +427,7 @@ func (s *State) extract(b *ui.Task, p *manifest.Package) error {
 	)
 
 	if !s.isCached(p) {
-		mirrors := make([]string, len(p.Mirrors))
+		mirrors := make([]redact.URL, len(p.Mirrors))
 		copy(mirrors, p.Mirrors)
 		mirrors = append(mirrors, s.generateMirrors(p.Source)...)
 		path, etag, _, err = s.cache.Download(b, p.SHA256, p.Source, mirrors...)
@@ -562,7 +563,7 @@ func (s *State) UpgradeChannel(b *ui.Task, pkg *manifest.Package) error {
 	}
 
 	name := pkg.Reference.String()
-	mirrors := make([]string, len(pkg.Mirrors))
+	mirrors := make([]redact.URL, len(pkg.Mirrors))
 	copy(mirrors, pkg.Mirrors)
 	mirrors = append(mirrors, s.generateMirrors(pkg.Source)...)
 
@@ -626,16 +627,16 @@ func (s *State) evictPackage(b *ui.Task, pkg *manifest.Package) error {
 }
 
 // Return the generated mirrors that match URL.
-func (s *State) generateMirrors(url string) (mirrors []string) {
+func (s *State) generateMirrors(url redact.URL) (mirrors []redact.URL) {
 	for _, pam := range s.autoMirrors {
-		matches := pam.re.FindStringSubmatch(url)
+		matches := pam.re.FindStringSubmatch(url.Reveal())
 		if matches == nil {
 			continue
 		}
 		mirror := os.Expand(pam.mirror, func(key string) string {
 			return matches[pam.groups[key]]
 		})
-		mirrors = append(mirrors, mirror)
+		mirrors = append(mirrors, redact.URL(mirror))
 	}
 	return
 }

--- a/util/git.go
+++ b/util/git.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/redact"
 )
 
 var (
@@ -26,12 +27,13 @@ func GitArgs(args ...string) []string {
 
 // ValidateGitURL rejects URLs selecting a transport Hermit does not support, and
 // URLs that git would interpret as an option.
-func ValidateGitURL(url string) error {
-	if strings.HasPrefix(url, "-") {
+func ValidateGitURL(url redact.URL) error {
+	raw := url.Reveal()
+	if strings.HasPrefix(raw, "-") {
 		return errors.Errorf("invalid git URL %q: cannot start with '-'", url)
 	}
-	scheme := gitURLSchemeRe.FindString(url)
-	switch rest := url[len(scheme):]; {
+	scheme := gitURLSchemeRe.FindString(raw)
+	switch rest := raw[len(scheme):]; {
 	case strings.HasPrefix(rest, "://"):
 		if !slices.Contains(allowedGitSchemes, strings.ToLower(scheme)) {
 			return errors.Errorf("invalid git URL %q: scheme must be one of %s", url, strings.Join(allowedGitSchemes, ", "))

--- a/util/git_test.go
+++ b/util/git_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/util"
 )
 
@@ -31,7 +32,7 @@ func TestValidateGitURL(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := util.ValidateGitURL(test.url)
+			err := util.ValidateGitURL(redact.URL(test.url))
 			if test.fails {
 				assert.Error(t, err)
 			} else {
@@ -39,6 +40,13 @@ func TestValidateGitURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateGitURLRedactsCredentialsInErrors(t *testing.T) {
+	err := util.ValidateGitURL(redact.URL("zzq://x-access-token:sekret@example.com/repo.git"))
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "sekret")
+	assert.Contains(t, err.Error(), "zzq://example.com/repo.git")
 }
 
 func TestGitArgsPinsTransportPolicy(t *testing.T) {

--- a/util/run.go
+++ b/util/run.go
@@ -12,20 +12,28 @@ import (
 
 	"github.com/cashapp/hermit/envars"
 	"github.com/cashapp/hermit/errors"
+	"github.com/cashapp/hermit/redact"
 	"github.com/cashapp/hermit/ui"
 )
 
 // CommandRunner abstracts how we run command in a given directory
 type CommandRunner interface {
 	// RunInDir runs a command in the given directory.
-	RunInDir(log *ui.Task, dir string, args ...string) error
+	RunInDir(log *ui.Task, dir string, args ...redact.Value) error
+	// CaptureInDir runs a command in the given directory and returns its
+	// combined output. A nil log discards debug and output logging.
+	CaptureInDir(log ui.Logger, dir string, args ...redact.Value) ([]byte, error)
 }
 
 // RealCommandRunner actually calls command
 type RealCommandRunner struct{}
 
-func (g *RealCommandRunner) RunInDir(task *ui.Task, dir string, commands ...string) error {
-	return errors.WithStack(RunSystemInDir(task, dir, commands...))
+func (g *RealCommandRunner) RunInDir(task *ui.Task, dir string, commands ...redact.Value) error {
+	return errors.WithStack(runSystemInDir(task, dir, commands))
+}
+
+func (g *RealCommandRunner) CaptureInDir(log ui.Logger, dir string, commands ...redact.Value) ([]byte, error) {
+	return captureSystemInDir(log, dir, commands)
 }
 
 // SystemCommand constructs a command for an external tool used internally by
@@ -84,6 +92,43 @@ func systemEnviron() (envars.Envars, error) {
 	return environ, nil
 }
 
+func displayJoin(args []redact.Value) string {
+	display := make([]string, len(args))
+	for i, arg := range args {
+		display[i] = arg.String()
+	}
+	return shellquote.Join(display...)
+}
+
+// scrubbingWriter replaces sensitive values in subprocess output before it
+// reaches the log, buffering by line so a value cannot straddle two writes.
+type scrubbingWriter struct {
+	w    io.Writer
+	repl *strings.Replacer
+	buf  bytes.Buffer
+}
+
+func (s *scrubbingWriter) Write(b []byte) (int, error) {
+	s.buf.Write(b)
+	for {
+		i := bytes.IndexByte(s.buf.Bytes(), '\n')
+		if i < 0 {
+			return len(b), nil
+		}
+		line := string(s.buf.Next(i + 1))
+		if _, err := io.WriteString(s.w, s.repl.Replace(line)); err != nil {
+			return len(b), err
+		}
+	}
+}
+
+func (s *scrubbingWriter) flush() {
+	if s.buf.Len() > 0 {
+		_, _ = io.WriteString(s.w, s.repl.Replace(s.buf.String()))
+		s.buf.Reset()
+	}
+}
+
 // Run a command, outputting to stdout and stderr.
 func Run(log *ui.Task, args ...string) error {
 	return RunInDir(log, "", args...)
@@ -109,13 +154,29 @@ func CaptureSystem(log ui.Logger, args ...string) ([]byte, error) {
 // CaptureSystemInDir runs an external tool used internally by Hermit in the given dir
 // and returns its output.
 func CaptureSystemInDir(log ui.Logger, dir string, args ...string) ([]byte, error) {
-	log.Debugf("%s", shellquote.Join(args...))
-	cmd, err := SystemCommand(args...)
+	return captureSystemInDir(log, dir, redact.Args(args...))
+}
+
+func captureSystemInDir(log ui.Logger, dir string, args []redact.Value) ([]byte, error) {
+	if log != nil {
+		log.Debugf("%s", displayJoin(args))
+	}
+	cmd, err := SystemCommand(redact.Reveal(args)...)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	cmd.Dir = dir
-	return captureOutput(log, cmd)
+	out, err := cmd.CombinedOutput()
+	if scrubber := redact.Scrubber(args); scrubber != nil {
+		out = []byte(scrubber.Replace(string(out)))
+	}
+	if err != nil {
+		return out, errors.Wrapf(err, "%s: %s", displayJoin(args), strings.TrimSpace(string(out)))
+	}
+	if log != nil {
+		_, _ = log.Write(out)
+	}
+	return out, nil
 }
 
 // CaptureInDir runs a command in the given dir, returning combined stdout and stderr.
@@ -152,11 +213,22 @@ func RunInDir(log *ui.Task, dir string, args ...string) error {
 
 // RunSystemInDir runs an external tool used internally by Hermit in the given dir.
 func RunSystemInDir(log *ui.Task, dir string, args ...string) error {
+	return runSystemInDir(log, dir, redact.Args(args...))
+}
+
+func runSystemInDir(log *ui.Task, dir string, args []redact.Value) error {
 	log = log.SubTask("exec")
-	log.Debugf("%s", shellquote.Join(args...))
+	log.Debugf("%s", displayJoin(args))
 	b := &bytes.Buffer{}
-	w := io.MultiWriter(b, log)
-	cmd, err := SystemCommand(args...)
+	var relay io.Writer = log
+	scrubber := redact.Scrubber(args)
+	if scrubber != nil {
+		sw := &scrubbingWriter{w: log, repl: scrubber}
+		defer sw.flush()
+		relay = sw
+	}
+	w := io.MultiWriter(b, relay)
+	cmd, err := SystemCommand(redact.Reveal(args)...)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -165,9 +237,13 @@ func RunSystemInDir(log *ui.Task, dir string, args ...string) error {
 	cmd.Stderr = w
 	if err = cmd.Run(); err != nil {
 		if !log.WillLog(ui.LevelDebug) {
-			log.Errorf("%s", b.String())
+			out := b.String()
+			if scrubber != nil {
+				out = scrubber.Replace(out)
+			}
+			log.Errorf("%s", out)
 		}
-		return errors.Wrapf(err, "%s failed", shellquote.Join(args...))
+		return errors.Wrapf(err, "%s failed", displayJoin(args))
 	}
 	return nil
 }

--- a/util/run_test.go
+++ b/util/run_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/alecthomas/assert/v2"
 	"github.com/cashapp/hermit/envars"
+	"github.com/cashapp/hermit/redact"
+	"github.com/cashapp/hermit/ui"
 	"github.com/cashapp/hermit/util"
 )
 
@@ -51,4 +53,42 @@ func TestSystemCommandRejectsPaths(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "git")
 	_, err := util.SystemCommand(path)
 	assert.EqualError(t, err, `system command must be a bare name: "`+path+`"`)
+}
+
+func TestCommandRunnerRedactsSensitiveArgsInErrors(t *testing.T) {
+	p, _ := ui.NewForTesting()
+	runner := &util.RealCommandRunner{}
+	err := runner.RunInDir(p.Task("test"), t.TempDir(),
+		redact.Plain("ls"), redact.URL("https://x-access-token:sekret@example.com/repo.git"))
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "sekret")
+	assert.Contains(t, err.Error(), "https://example.com/repo.git")
+}
+
+func TestCommandRunnerScrubsSensitiveArgsFromRelayedOutput(t *testing.T) {
+	p, buf := ui.NewForTesting()
+	runner := &util.RealCommandRunner{}
+	err := runner.RunInDir(p.Task("test"), t.TempDir(),
+		redact.Plain("echo"), redact.URL("https://x-access-token:sekret@example.com/repo.git"))
+	assert.NoError(t, err)
+	assert.NotContains(t, buf.String(), "sekret")
+	assert.Contains(t, buf.String(), "https://example.com/repo.git")
+}
+
+func TestCommandRunnerCaptureScrubsSensitiveArgs(t *testing.T) {
+	p, buf := ui.NewForTesting()
+	runner := &util.RealCommandRunner{}
+	url := redact.URL("https://x-access-token:sekret@example.com/repo.git")
+
+	out, err := runner.CaptureInDir(p, t.TempDir(),
+		redact.Plain("sh"), redact.Plain("-c"), redact.Plain(`echo "$0"`), url)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://example.com/repo.git\n", string(out))
+	assert.NotContains(t, buf.String(), "sekret")
+
+	_, err = runner.CaptureInDir(nil, t.TempDir(),
+		redact.Plain("sh"), redact.Plain("-c"), redact.Plain(`echo "$0"; exit 1`), url)
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "sekret")
+	assert.Contains(t, err.Error(), "https://example.com/repo.git")
 }

--- a/util/url.go
+++ b/util/url.go
@@ -1,0 +1,12 @@
+package util
+
+import "net/url"
+
+// StripURLError unwraps *url.Error so stdlib messages cannot leak credentials
+// embedded in the URL; callers reattach the redacted URL.
+func StripURLError(err error) error {
+	if uerr, ok := err.(*url.Error); ok { //nolint:errorlint
+		return uerr.Err
+	}
+	return err
+}


### PR DESCRIPTION
With github-token-auth configured, the GitHub token was embedded in
rewritten source URLs and leaked in cleartext through task labels,
hermit status, command-line error messages and relayed git output.
Credentials embedded in manifest source URLs leaked the same way.

Wrap sensitive values in redacting types (redact.Secret, redact.URL)
at application boundaries - environment variables, HCL fields and CLI
flags - and carry them through typed APIs, revealing the raw value
only at exec argv, HTTP requests and cache hashing. Subprocess output
is scrubbed by exact match since git echoes tokenised URLs, and
stdlib *url.Error is stripped to its cause so its message cannot
reintroduce the raw URL. Serialisation stays raw so config files and
sha256sums round-trip verbatim, and cache paths still hash the raw
URL so existing caches remain valid.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
