### PR TITLE
fix: keep the zsh prompt prefix after terminal prompt marks

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -856,6 +856,43 @@ EOF
 			`,
 		},
 		{
+			// Terminal shell integrations (eg. Ghostty, kitty) prepend an OSC 133
+			// prompt mark to PS1 and require it to stay at column 0. Ghostty's
+			// mark carries "cl=line" ("the prompt starts here, clear the line"),
+			// so a prefix inserted ahead of it makes the terminal clear the line
+			// partway through the prompt and lose the input start column.
+			name:         "ZshPromptPrefixGoesAfterTerminalPromptMarks",
+			preparations: prep{fixture("testenv1")},
+			script: `
+				cat > "$HERMIT_USER_CONFIG" <<EOF
+prompt = "short"
+EOF
+				if [ -n "${ZSH_VERSION-}" ]; then
+					PS1=$'%{\e]133;A;cl=line\a%}%~ '
+					. bin/activate-hermit
+					for f in $precmd_functions; do "$f"; done
+					assert test "${PS1}" = $'%{\e]133;A;cl=line\a%}🐚 %~ '
+				fi
+			`,
+		},
+		{
+			// Only leading zero-width escape groups are skipped; a prompt that
+			// starts with ordinary text keeps the prefix at the very front.
+			name:         "ZshPromptPrefixStaysLeadingWithoutTerminalPromptMarks",
+			preparations: prep{fixture("testenv1")},
+			script: `
+				cat > "$HERMIT_USER_CONFIG" <<EOF
+prompt = "short"
+EOF
+				if [ -n "${ZSH_VERSION-}" ]; then
+					PS1='%~ '
+					. bin/activate-hermit
+					for f in $precmd_functions; do "$f"; done
+					assert test "${PS1}" = '🐚 %~ '
+				fi
+			`,
+		},
+		{
 			name:         "CleanPackagesDoesNotChmodSymlinkTargets",
 			preparations: prep{fixture("testenv1"), activate(".")},
 			script: `

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -856,11 +856,7 @@ EOF
 			`,
 		},
 		{
-			// Terminal shell integrations (eg. Ghostty, kitty) prepend an OSC 133
-			// prompt mark to PS1 and require it to stay at column 0. Ghostty's
-			// mark carries "cl=line" ("the prompt starts here, clear the line"),
-			// so a prefix inserted ahead of it makes the terminal clear the line
-			// partway through the prompt and lose the input start column.
+			// Terminal prompt marks must remain at column 0 before the Hermit prefix.
 			name:         "ZshPromptPrefixGoesAfterTerminalPromptMarks",
 			preparations: prep{fixture("testenv1")},
 			script: `
@@ -876,8 +872,7 @@ EOF
 			`,
 		},
 		{
-			// Only leading zero-width escape groups are skipped; a prompt that
-			// starts with ordinary text keeps the prefix at the very front.
+			// Without terminal prompt marks, the Hermit prefix stays at the front.
 			name:         "ZshPromptPrefixStaysLeadingWithoutTerminalPromptMarks",
 			preparations: prep{fixture("testenv1")},
 			script: `

--- a/shell/files/activate.tmpl.sh
+++ b/shell/files/activate.tmpl.sh
@@ -68,30 +68,18 @@ if test -n "${PS1+_}"; then
   update_hermit_ps1 () {
     if [[ ! -v _HERMIT_OLD_PS1 ]]; then
       typeset -g +x _HERMIT_OLD_PS1="${PS1}"
-      # Terminal shell integrations (eg. Ghostty, kitty) prepend an OSC 133
-      # prompt mark to PS1, wrapped in %{...%} so zsh treats it as zero width,
-      # and rely on it remaining at column 0. Some marks carry directives:
-      # Ghostty's is "OSC 133;A;cl=line", meaning "the prompt starts here, clear
-      # the line". Inserting our prefix ahead of such a mark makes the terminal
-      # clear the line partway through drawing the prompt and lose track of where
-      # input begins, so skip past any leading zero-width escape groups first.
-      # The delimiters are held in variables because a literal "%}" inside a
-      # parameter expansion pattern is a zsh parse error ("bad substitution").
+      # Keep leading zero-width terminal prompt marks at column 0 by inserting the Hermit prefix after them.
+      # Variables avoid zsh treating a literal "%}" in a parameter expansion pattern as a bad substitution.
       local _hermit_ps1_open='%{' _hermit_ps1_close='%}'
       local _hermit_ps1_head='' _hermit_ps1_rest="${PS1}" _hermit_ps1_group=''
       while [[ "${_hermit_ps1_rest}" == ${_hermit_ps1_open}* ]]; do
         _hermit_ps1_group="${_hermit_ps1_rest%%$_hermit_ps1_close*}"
-        # Stop unless the group is closed and holds an escape sequence. Comparing
-        # against the remainder detects a missing "%}", which also guarantees the
-        # remainder shrinks every iteration and the loop terminates.
+        # Reject unclosed or non-escape groups so the remainder shrinks on every iteration.
         [[ "${_hermit_ps1_group}" != "${_hermit_ps1_rest}" && "${_hermit_ps1_group}" == *$'\e'* ]] || break
         _hermit_ps1_head+="${_hermit_ps1_group}${_hermit_ps1_close}"
         _hermit_ps1_rest="${_hermit_ps1_rest#*$_hermit_ps1_close}"
       done
-      # Assigned in two steps so the environment name stays adjacent to the
-      # opening PS1=" -- TestActivationScriptNeutralisesMaliciousEnvBasename
-      # reads the text between them to check the name is free of shell
-      # metacharacters (VULN-78225). Do not collapse these into one assignment.
+      # Keep this two-step assignment for TestActivationScriptNeutralisesMaliciousEnvBasename (VULN-78225).
       PS1="{{if eq .Prompt "env"}}{{ .EnvName }}{{end}}🐚 ${_hermit_ps1_rest}"
       PS1="${_hermit_ps1_head}${PS1}"
     fi

--- a/shell/files/activate.tmpl.sh
+++ b/shell/files/activate.tmpl.sh
@@ -68,7 +68,32 @@ if test -n "${PS1+_}"; then
   update_hermit_ps1 () {
     if [[ ! -v _HERMIT_OLD_PS1 ]]; then
       typeset -g +x _HERMIT_OLD_PS1="${PS1}"
-      PS1="{{if eq .Prompt "env"}}{{ .EnvName }}{{end}}🐚 ${PS1}"
+      # Terminal shell integrations (eg. Ghostty, kitty) prepend an OSC 133
+      # prompt mark to PS1, wrapped in %{...%} so zsh treats it as zero width,
+      # and rely on it remaining at column 0. Some marks carry directives:
+      # Ghostty's is "OSC 133;A;cl=line", meaning "the prompt starts here, clear
+      # the line". Inserting our prefix ahead of such a mark makes the terminal
+      # clear the line partway through drawing the prompt and lose track of where
+      # input begins, so skip past any leading zero-width escape groups first.
+      # The delimiters are held in variables because a literal "%}" inside a
+      # parameter expansion pattern is a zsh parse error ("bad substitution").
+      local _hermit_ps1_open='%{' _hermit_ps1_close='%}'
+      local _hermit_ps1_head='' _hermit_ps1_rest="${PS1}" _hermit_ps1_group=''
+      while [[ "${_hermit_ps1_rest}" == ${_hermit_ps1_open}* ]]; do
+        _hermit_ps1_group="${_hermit_ps1_rest%%$_hermit_ps1_close*}"
+        # Stop unless the group is closed and holds an escape sequence. Comparing
+        # against the remainder detects a missing "%}", which also guarantees the
+        # remainder shrinks every iteration and the loop terminates.
+        [[ "${_hermit_ps1_group}" != "${_hermit_ps1_rest}" && "${_hermit_ps1_group}" == *$'\e'* ]] || break
+        _hermit_ps1_head+="${_hermit_ps1_group}${_hermit_ps1_close}"
+        _hermit_ps1_rest="${_hermit_ps1_rest#*$_hermit_ps1_close}"
+      done
+      # Assigned in two steps so the environment name stays adjacent to the
+      # opening PS1=" -- TestActivationScriptNeutralisesMaliciousEnvBasename
+      # reads the text between them to check the name is free of shell
+      # metacharacters (VULN-78225). Do not collapse these into one assignment.
+      PS1="{{if eq .Prompt "env"}}{{ .EnvName }}{{end}}🐚 ${_hermit_ps1_rest}"
+      PS1="${_hermit_ps1_head}${PS1}"
     fi
   }
   {{- end}}


### PR DESCRIPTION
## Problem

Inside an activated Hermit environment, in a terminal whose shell integration uses OSC 133 prompt marks, the zsh prompt corrupts as soon as the cursor gets near the right margin:

- typing past the wrap blanks the entire line, prompt included
- the erase survives backspacing back up to the first line
- the input start column drifts a few columns forward
- resizing the window redraws with a duplicated prefix

Reproduced with Ghostty 1.3.1 and zsh 5.9 on macOS. Terminals that ignore OSC 133, such as macOS Terminal.app, are unaffected, which is what makes this look terminal-specific rather than shell-specific.

## Cause

Ghostty's zsh integration injects `%{\e]133;A;cl=line\a%}` at the front of `PS1`. The `cl=line` parameter means *"the prompt starts here, clear the line"*, and the `%{...%}` wrapper tells zsh the mark occupies no columns.

`update_hermit_ps1` prepends the Hermit prefix to whatever `PS1` already holds, so the prefix lands **ahead** of that mark. On the next prompt the integration sees `PS1` changed, stops restoring it, and marks it again — nesting the marks around the prefix:

```
\e]133;A;cl=line\a  🐚   \e]133;A;cl=line\a  ~/path  branch *  \e]133;B\a \e]133;B\a
                         ^^^^^^^^^^^^^^^^^^ second clear-line, 3 columns in
```

The terminal clears the line, draws `🐚 `, then hits the second clear-line directive at column 3 and wipes the line again, resetting its idea of where the prompt begins. zsh's own column arithmetic never moves, because both marks are declared zero width — so the two disagree permanently.

Without the prefix the two marks end up adjacent and the second clear-line is harmless, because nothing has been drawn between them. Hermit's three columns are the only thing that ever lands in that gap.

## Fix

Insert the prefix after any leading zero-width escape groups, so the terminal's mark stays at column 0.

Groups with no closing `%}`, or with no escape sequence inside, are left alone. That guard doubles as the loop's termination proof: when it does not fire, the matched group is strictly shorter than the remainder, so the remainder shrinks every iteration.

Prompts that begin with ordinary text are unchanged — the prefix still goes at the very front — so there is no behaviour change for anyone whose terminal does not inject prompt marks.

## Notes for review

- The `%{` / `%}` delimiters are held in variables because a literal `%}` inside a parameter-expansion pattern is a zsh parse error (`bad substitution`).
- The `PS1` assignment is deliberately split across two statements so the environment name stays adjacent to the opening `PS1="`. That is the text `TestActivationScriptNeutralisesMaliciousEnvBasename` reads to verify the name carries no shell metacharacters (VULN-78225). I added a comment so it is not collapsed into one assignment later.
- Only leading groups containing a **literal** escape byte are skipped. A prompt starting with `%{$fg[red]%}` holds no literal escape at that point, so it is untouched; one starting with `%{$'\e[31m'%}` is skipped, which means the prefix inherits that colour. That seemed preferable to splitting a terminal mark, but say the word if you would rather narrow the test to OSC introducers specifically.
- **bash is not addressed here.** It has the same latent issue (`PS1="…🐚 ${PS1}"` at activation time, with `\[…\]` rather than `%{…%}` wrappers), but it is not deferred to a `precmd` hook so it needs separate reasoning, and I could not verify it as rigorously as the zsh path. Happy to follow up in a second PR if you want it covered.

## Testing

Two integration tests added alongside the existing zsh `precmd` tests, asserting against Ghostty's real mark string:

- `ZshPromptPrefixGoesAfterTerminalPromptMarks` — the prefix goes after the mark
- `ZshPromptPrefixStaysLeadingWithoutTerminalPromptMarks` — the prefix stays leading when there is no mark

Both pin `prompt = "short"` so the expected prefix is deterministic.

`go test ./...`, `golangci-lint run` and `./bin/lint-shell-scripts` all pass. The full integration suite passes except `TestFishActivationEscapesTrailingBackslash`, which fails identically on clean `master` in my environment because `fish` is not installed.
