### PR TITLE
fix: override binaries and apps in nested manifest blocks

### DIFF
--- a/docs/docs/packaging/reference.md
+++ b/docs/docs/packaging/reference.md
@@ -55,6 +55,14 @@ channel nightly {
 Package source can refer to a remote archive file by using `http://` or `https://` prefixes, to a local file by using `file://` prefix, or to a Git repository by using `.git` suffix. 
 If the source points to an archive file, it is extracted at installation. Git repositories are cloned from the default branch and used as is.
 
+Configuration in a `version`, `channel`, `darwin`, `linux` or `platform` block
+is layered over the manifest's top level, with the most specific block that
+sets an attribute winning. That applies to `binaries` and `apps` as well: a
+nested block that declares them replaces the outer list wholesale rather than
+adding to it, so a platform block can narrow `binaries = ["bin/*"]` down to
+the exact paths that exist on that platform. A nested block that does not
+declare them inherits the outer list.
+
 ## Sources
 
 A manifest source is a location where a set of manifests are stored. Hermit

--- a/manifest/resolver.go
+++ b/manifest/resolver.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -493,11 +494,17 @@ func newPackage(manifest *AnnotatedManifest, config Config, selector Selector) (
 		if layer.Dest != "" {
 			p.Dest = layer.Dest
 		}
+		// Binaries and Apps are overridden wholesale by the most specific layer
+		// that declares them, matching the scalar attributes above. Appending
+		// instead would place the outer block's globs alongside the inner
+		// block's, which for the common "inner block narrows the path" case
+		// (eg. podman: top-level "podman" vs darwin "usr/bin/podman") leaves
+		// the outer glob matching nothing and makes the package unresolvable.
 		if len(layer.Apps) != 0 {
-			p.Apps = append(p.Apps, layer.Apps...)
+			p.Apps = slices.Clone(layer.Apps)
 		}
 		if len(layer.Binaries) != 0 {
-			p.Binaries = append(p.Binaries, layer.Binaries...)
+			p.Binaries = slices.Clone(layer.Binaries)
 		}
 		if len(layer.Requires) != 0 {
 			p.Requires = append(p.Requires, layer.Requires...)

--- a/manifest/resolver_test.go
+++ b/manifest/resolver_test.go
@@ -392,6 +392,205 @@ func TestResolver_Resolve(t *testing.T) {
 	}
 }
 
+func TestResolveBinariesOverride(t *testing.T) {
+	config := Config{
+		Env:   "/home/user/project",
+		State: "/home/user/.cache/hermit",
+		Platform: platform.Platform{
+			OS:   platform.Linux,
+			Arch: platform.Amd64,
+		},
+	}
+	files := map[string]string{
+		"test.hcl": `
+            description = ""
+            binaries = ["a", "b"]
+            version "0.1.0" {
+              source = "www.example-1.com"
+              binaries = ["a"]
+            }
+            version "0.2.0" {
+              source = "www.example-2.com"
+            }
+        `,
+	}
+	logger := ui.New(ui.LevelInfo, os.Stdout, os.Stderr, true, true)
+	ss := []sources.Source{}
+	for name, content := range files {
+		ss = append(ss, sources.NewMemSource(name, content))
+	}
+	l, err := New(sources.New("", ss), config)
+	assert.NoError(t, err)
+
+	// A version block declaring its own binaries overrides the top-level set
+	// wholesale rather than adding to it.
+	pkg, err := l.Resolve(logger, PrefixSelector(ParseReference("test-0.1.0")))
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"a"}, pkg.Binaries)
+
+	// A version block declaring none still inherits the top-level set.
+	pkg, err = l.Resolve(logger, PrefixSelector(ParseReference("test-0.2.0")))
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, pkg.Binaries)
+}
+
+func TestResolveAppsOverride(t *testing.T) {
+	config := Config{
+		Env:   "/home/user/project",
+		State: "/home/user/.cache/hermit",
+		Platform: platform.Platform{
+			OS:   platform.Linux,
+			Arch: platform.Amd64,
+		},
+	}
+	files := map[string]string{
+		"test.hcl": `
+            description = ""
+            apps = ["Top.app"]
+            version "0.1.0" {
+              source = "www.example-1.com"
+              apps = ["Nested.app"]
+            }
+        `,
+	}
+	logger := ui.New(ui.LevelInfo, os.Stdout, os.Stderr, true, true)
+	ss := []sources.Source{}
+	for name, content := range files {
+		ss = append(ss, sources.NewMemSource(name, content))
+	}
+	l, err := New(sources.New("", ss), config)
+	assert.NoError(t, err)
+
+	pkg, err := l.Resolve(logger, PrefixSelector(ParseReference("test-0.1.0")))
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"Nested.app"}, pkg.Apps)
+}
+
+// TestResolveBinariesPlatformOverride pins the shape reported in #249: a
+// top-level binaries list narrowed by a matching platform block, with the
+// top-level list still applying on platforms the block does not match.
+func TestResolveBinariesPlatformOverride(t *testing.T) {
+	files := map[string]string{
+		"podman.hcl": `
+            description = ""
+            source = "https://example.com/podman-${version}.tar.gz"
+            binaries = ["podman"]
+            platform "darwin" {
+              strip = 1
+              binaries = ["usr/bin/podman"]
+            }
+            version "1.0.0" {
+            }
+        `,
+	}
+	for _, tt := range []struct {
+		platform platform.Platform
+		want     []string
+	}{
+		{platform.Platform{OS: platform.Darwin, Arch: platform.Amd64}, []string{"usr/bin/podman"}},
+		{platform.Platform{OS: platform.Linux, Arch: platform.Amd64}, []string{"podman"}},
+	} {
+		config := Config{
+			Env:      "/home/user/project",
+			State:    "/home/user/.cache/hermit",
+			Platform: tt.platform,
+		}
+		logger := ui.New(ui.LevelInfo, os.Stdout, os.Stderr, true, true)
+		ss := []sources.Source{}
+		for name, content := range files {
+			ss = append(ss, sources.NewMemSource(name, content))
+		}
+		l, err := New(sources.New("", ss), config)
+		assert.NoError(t, err)
+		pkg, err := l.Resolve(logger, PrefixSelector(ParseReference("podman-1.0.0")))
+		assert.NoError(t, err)
+		assert.Equal(t, tt.want, pkg.Binaries)
+	}
+}
+
+// TestResolveBinariesAndAppsIndependent checks that overriding one of the two
+// list attributes does not disturb the other.
+func TestResolveBinariesAndAppsIndependent(t *testing.T) {
+	config := Config{
+		Env:   "/home/user/project",
+		State: "/home/user/.cache/hermit",
+		Platform: platform.Platform{
+			OS:   platform.Linux,
+			Arch: platform.Amd64,
+		},
+	}
+	files := map[string]string{
+		"test.hcl": `
+            description = ""
+            source = "https://example.com/test-${version}.tar.gz"
+            binaries = ["a"]
+            apps = ["Top.app"]
+            version "1.0.0" {
+              binaries = ["b"]
+            }
+        `,
+	}
+	logger := ui.New(ui.LevelInfo, os.Stdout, os.Stderr, true, true)
+	ss := []sources.Source{}
+	for name, content := range files {
+		ss = append(ss, sources.NewMemSource(name, content))
+	}
+	l, err := New(sources.New("", ss), config)
+	assert.NoError(t, err)
+
+	pkg, err := l.Resolve(logger, PrefixSelector(ParseReference("test-1.0.0")))
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"b"}, pkg.Binaries)
+	assert.Equal(t, []string{"Top.app"}, pkg.Apps, "overriding binaries must not clear apps")
+}
+
+// TestResolveBinariesChannelOverride covers the channel path, where the
+// referenced version's layers act as the ancestor of the channel's own layers.
+func TestResolveBinariesChannelOverride(t *testing.T) {
+	config := Config{
+		Env:   "/home/user/project",
+		State: "/home/user/.cache/hermit",
+		Platform: platform.Platform{
+			OS:   platform.Linux,
+			Arch: platform.Amd64,
+		},
+	}
+	files := map[string]string{
+		"test.hcl": `
+            description = ""
+            source = "https://example.com/test-${version}.tar.gz"
+            binaries = ["root"]
+            version "1.0.0" {
+              binaries = ["version"]
+            }
+            channel "stable" {
+              version = "1.0.0"
+              update = "24h"
+              binaries = ["channel"]
+            }
+            channel "plain" {
+              version = "1.0.0"
+              update = "24h"
+            }
+        `,
+	}
+	logger := ui.New(ui.LevelInfo, os.Stdout, os.Stderr, true, true)
+	ss := []sources.Source{}
+	for name, content := range files {
+		ss = append(ss, sources.NewMemSource(name, content))
+	}
+	l, err := New(sources.New("", ss), config)
+	assert.NoError(t, err)
+
+	pkg, err := l.Resolve(logger, PrefixSelector(ParseReference("test@stable")))
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"channel"}, pkg.Binaries)
+
+	pkg, err = l.Resolve(logger, PrefixSelector(ParseReference("test@plain")))
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"version"}, pkg.Binaries)
+}
+
 func TestSearchVersionsAndChannelsCoexist(t *testing.T) {
 	files := map[string]string{
 		"test.hcl": `


### PR DESCRIPTION
A `version`, `channel`, `darwin`, `linux` or `platform` block that declared its own `binaries` or `apps` had them appended to the outer block's list instead of replacing it. Both outer and inner globs were resolved, so when the inner block narrowed the path the outer glob could match nothing and make the package fail to resolve.

`podman` is the live example from #249: the top level declares `binaries = ["podman"]` for Linux while the darwin block declares `["usr/bin/podman"]` for the stripped archive. `kotlin` relies on the same override behavior, as reported in #254.

The fix replaces both lists wholesale with the most specific layer that sets them. An unset attribute still inherits the outer value. This matches the existing scalar layering behavior for `source`, `strip`, `root`, and `dest`.

The HCL parser rejects duplicate fields inside one block, so only ancestor/descendant layers can collide; same-block accumulation is not representable. An exhaustive layer-aware scan of 632 `cashapp/hermit-packages` manifests found exactly two genuine nested binaries cases: podman and kotlin. Other repeated declarations are mutually exclusive sibling blocks. `rustup.hcl`, which a naive scan can flag, has sibling version blocks (1.25.1 versus 1.25.2+) and no root-level binaries; running the resolver confirms rust-analyzer remains present only from 1.25.2 onward.

Tests cover nested binaries and apps override, inheritance, the #249 platform shape, binaries/apps independence, and the channel path where a channel pins a version but overrides its binaries. The new tests fail against the unfixed append behavior and pass with the fix.

`go test ./...` passes across 17 packages and `golangci-lint run` is clean. The packaging reference now documents that nested `binaries` and `apps` replace the outer list, while blocks that omit them inherit it.

Fixes #249
Fixes #254
